### PR TITLE
Change name of memcached configmap

### DIFF
--- a/controllers/memcached/memcached_controller.go
+++ b/controllers/memcached/memcached_controller.go
@@ -194,7 +194,7 @@ func (r *Reconciler) generateConfigMaps(
 	cms := []util.Template{
 		// ConfigMap
 		{
-			Name:          fmt.Sprintf("%s-config-data", instance.Name),
+			Name:          fmt.Sprintf("%s-memcached-config-data", instance.Name),
 			Namespace:     instance.Namespace,
 			Type:          util.TemplateTypeConfig,
 			InstanceType:  instance.Kind,

--- a/pkg/memcached/statefulset.go
+++ b/pkg/memcached/statefulset.go
@@ -91,7 +91,7 @@ func StatefulSet(m *memcachedv1.Memcached) *appsv1.StatefulSet {
 							VolumeSource: corev1.VolumeSource{
 								ConfigMap: &corev1.ConfigMapVolumeSource{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: m.Name + "-config-data",
+										Name: m.Name + "-memcached-config-data",
 									},
 									Items: []corev1.KeyToPath{
 										{
@@ -107,7 +107,7 @@ func StatefulSet(m *memcachedv1.Memcached) *appsv1.StatefulSet {
 							VolumeSource: corev1.VolumeSource{
 								ConfigMap: &corev1.ConfigMapVolumeSource{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: m.Name + "-config-data",
+										Name: m.Name + "-memcached-config-data",
 									},
 									Items: []corev1.KeyToPath{
 										{


### PR DESCRIPTION
When we create a Memcached CR instance for individual services, then we should ideally append -memcached to the name of the configmap to avoid conflicing with the service configmaps. This change appends the -memcached to the configmap name accordingly.