### PR TITLE
Fix omitempty + default value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,5 +307,5 @@ gowork: ## Generate go.work file to support our multi module repository
 
 .PHONY: operator-lint
 operator-lint: gowork ## Runs operator-lint
-	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@v0.1.0
+	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@v0.3.0
 	go vet -vettool=$(LOCALBIN)/operator-lint ./... ./apis/...

--- a/apis/memcached/v1beta1/memcached_types.go
+++ b/apis/memcached/v1beta1/memcached_types.go
@@ -26,7 +26,7 @@ type MemcachedSpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="quay.io/tripleozedcentos9/openstack-memcached:current-tripleo"
 	// Name of the memcached container image to run
-	ContainerImage string `json:"containerImage,omitempty"`
+	ContainerImage string `json:"containerImage"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=1


### PR DESCRIPTION
Having a CRD field with omitempty tag with a kubebuilder default value defined can cause unexpected behavior. See
https://github.com/gibizer/operator-lint/blob/main/linters/crd/C003 for details.

So this patch remove the problematic definitions and bumps the operator-lint version to 0.3.0 that has a check to cover this.