### PR TITLE
Add revive to golanci

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,6 +4,7 @@ linters:
   enable:
     - errorlint
     - revive
+    - ginkgolinter
     - gofmt
     - govet
 linters-settings:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,11 +23,7 @@ repos:
 - repo: https://github.com/dnephin/pre-commit-golang
   rev: v0.5.1
   hooks:
-    - id: go-fmt
-      exclude: ^vendor
-    - id: go-vet
     - id: go-mod-tidy
-    - id: go-lint
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.3.0
@@ -51,3 +47,9 @@ repos:
     - id: no-commit-to-branch
     - id: trailing-whitespace
       exclude: ^vendor
+
+- repo: https://github.com/golangci/golangci-lint
+  rev: v1.52.2
+  hooks:
+    - id: golangci-lint
+      args: ["-v"]

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,11 @@ vet: gowork ## Run go vet against code.
 	go vet ./...
 	go vet ./apis/...
 
+.PHONY: tidy
+tidy: ## Run go mod tidy on every mod file in the repo
+	go mod tidy
+	cd ./apis && go mod tidy
+
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out


### PR DESCRIPTION
This PR replace deprecated go-linter using
revive (https://golangci-lint.run/usage/linters/#revive).

This patch also Remove fmt dependency from make tidy as per [1]

The fmt dependency cannot be run if the go.mod file needs an update:

```
 $ make tidy
 go fmt ./...
 go: updates to go.mod needed; to update it:
        go mod tidy
 make: *** [Makefile:103: fmt] Error 1
``
I have also made some changes as per the comment given here [2]

[1]: https://github.com/openstack-k8s-operators/placement-operator/pull/153
[2]: https://github.com/openstack-k8s-operators/cinder-operator/pull/147#discussion_r1158504341