### PR TITLE
Replace TripleO images by TCIB images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,8 +332,8 @@ SKIP_CERT ?=false
 .PHONY: run-with-webhook
 run-with-webhook: export METRICS_PORT?=8080
 run-with-webhook: export HEALTH_PORT?=8081
-run-with-webhook: export INFRA_CLIENT_IMAGE_URL_DEFAULT=quay.io/tripleozedcentos9/openstack-tripleoclient:current-tripleo
-run-with-webhook: export INFRA_MEMCACHED_IMAGE_URL_DEFAULT=quay.io/tripleozedcentos9/openstack-memcached:current-tripleo
+run-with-webhook: export INFRA_CLIENT_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-openstackclient:current-podified
+run-with-webhook: export INFRA_MEMCACHED_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-memcached:current-podified
 run-with-webhook: export INFRA_REDIS_IMAGE_URL_DEFAULT=registry.redhat.io/rhel9/redis-6:latest
 run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/configure_local_webhook.sh

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -12,8 +12,8 @@ spec:
       - name: manager
         env:
         - name: INFRA_CLIENT_IMAGE_URL_DEFAULT
-          value: quay.io/tripleozedcentos9/openstack-tripleoclient:current-tripleo
+          value: quay.io/podified-antelopecentos9/openstack-openstackclient:current-podified
         - name: INFRA_MEMCACHED_IMAGE_URL_DEFAULT
-          value: quay.io/tripleozedcentos9/openstack-memcached:current-tripleo
+          value: quay.io/podified-antelopecentos9/openstack-memcached:current-podified
         - name: INFRA_REDIS_IMAGE_URL_DEFAULT
           value: registry.redhat.io/rhel9/redis-6:latest

--- a/config/samples/client_v1beta1_openstackclient.yaml
+++ b/config/samples/client_v1beta1_openstackclient.yaml
@@ -3,6 +3,6 @@ kind: OpenStackClient
 metadata:
   name: test
 spec:
-  containerImage: quay.io/tripleozedcentos9/openstack-tripleoclient:current-tripleo
+  containerImage: quay.io/podified-antelopecentos9/openstack-openstackclient:current-podified
   openStackConfigMap: openstack-config
   openStackConfigSecret: openstack-config-secret


### PR DESCRIPTION
We imported container build tools from TripleO as TCIB[1]. Now we are retiring TripleO and should complete the migration.

[1] https://github.com/openstack-k8s-operators/tcib