### PR TITLE
Fix wrong image names

### DIFF
--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -12,8 +12,8 @@ spec:
       - name: manager
         env:
         - name: INFRA_CLIENT_IMAGE_URL_DEFAULT
-          value: quay.io/podified-antelopecentos9/openstack-openstackclient:current-podified
+          value: quay.io/podified-antelope-centos9/openstack-openstackclient:current-podified
         - name: INFRA_MEMCACHED_IMAGE_URL_DEFAULT
-          value: quay.io/podified-antelopecentos9/openstack-memcached:current-podified
+          value: quay.io/podified-antelope-centos9/openstack-memcached:current-podified
         - name: INFRA_REDIS_IMAGE_URL_DEFAULT
           value: registry.redhat.io/rhel9/redis-6:latest

--- a/config/samples/client_v1beta1_openstackclient.yaml
+++ b/config/samples/client_v1beta1_openstackclient.yaml
@@ -3,6 +3,6 @@ kind: OpenStackClient
 metadata:
   name: test
 spec:
-  containerImage: quay.io/podified-antelopecentos9/openstack-openstackclient:current-podified
+  containerImage: quay.io/podified-antelope-centos9/openstack-openstackclient:current-podified
   openStackConfigMap: openstack-config
   openStackConfigSecret: openstack-config-secret


### PR DESCRIPTION
This fixes a typo (missing -) in the default image names, which were introduced by a733e908da2d1415ba7de9ac19ab39d883f83c03.