### PR TITLE
[EnvTest]Disable metrics in to allow parallel test run

### DIFF
--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -113,6 +113,10 @@ var _ = BeforeSuite(func() {
 	// Start the controller-manager if goroutine
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
+		// NOTE(gibi): disable metrics reporting in test to allow
+		// parallel test execution. Otherwise each instance would like to
+		// bind to the same port
+		MetricsBindAddress: "0",
 	})
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Without this change make test might fails on a machine with many cores as parallel test execution tries to bind the metrics service to the same port causing:
```
  [FAILED] in [BeforeSuite] - /home/gibi/upstream/git/openstack-k8s-operators/infra-operator/test/functional/suite_test.go:116 @ 05/22/23 13:52:59.878
  << Timeline

  [FAILED] Unexpected error:
      <*fmt.wrapError | 0xc000a289e0>:
      error listening on :8080: listen tcp :8080: bind: address already in use
      {
          msg: "error listening on :8080: listen tcp :8080: bind: address already in use",
          err: <*net.OpError | 0xc0007269b0>{
              Op: "listen",
              Net: "tcp",
              Source: nil,
              Addr: <*net.TCPAddr | 0xc00081d8f0>{IP: nil, Port: 8080, Zone: ""},
              Err: <*os.SyscallError | 0xc000a289c0>{
                  Syscall: "bind",
                  Err: <syscall.Errno>0x62,
              },
          },
      }
  occurred
  In [BeforeSuite] at: /home/gibi/upstream/git/openstack-k8s-operators/infra-operator/test/functional/suite_test.go:116 @ 05/22/23 13:52:59.878

  Full Stack Trace
    github.com/openstack-k8s-operators/infra-operator/test/functional_test.glob..func4()
    	/home/gibi/upstream/git/openstack-k8s-operators/infra-operator/test/functional/suite_test.go:116 +0x8c3
```