### PR TITLE
Memcached: Present number of pods in status

### DIFF
--- a/apis/bases/memcached.openstack.org_memcacheds.yaml
+++ b/apis/bases/memcached.openstack.org_memcacheds.yaml
@@ -102,6 +102,10 @@ spec:
                   - type
                   type: object
                 type: array
+              readyCount:
+                description: ReadyCount of Memcached instances
+                format: int32
+                type: integer
             type: object
         type: object
     served: true

--- a/apis/memcached/v1beta1/memcached_types.go
+++ b/apis/memcached/v1beta1/memcached_types.go
@@ -43,6 +43,9 @@ type MemcachedSpec struct {
 
 // MemcachedStatus defines the observed state of Memcached
 type MemcachedStatus struct {
+	// ReadyCount of Memcached instances
+	ReadyCount int32 `json:"readyCount,omitempty"`
+
 	// Conditions
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`
 }

--- a/config/crd/bases/memcached.openstack.org_memcacheds.yaml
+++ b/config/crd/bases/memcached.openstack.org_memcacheds.yaml
@@ -102,6 +102,10 @@ spec:
                   - type
                   type: object
                 type: array
+              readyCount:
+                description: ReadyCount of Memcached instances
+                format: int32
+                type: integer
             type: object
         type: object
     served: true

--- a/controllers/memcached/memcached_controller.go
+++ b/controllers/memcached/memcached_controller.go
@@ -203,13 +203,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 	if sferr != nil {
 		return sfres, sferr
 	}
-	statefulset := commonstatefulset.GetStatefulSet()
 
 	//
-	// Reconstruct the state of the galera resource based on the replicaset and its pods
+	// Reconstruct the state of the memcached resource based on the statefulset and its pods
 	//
-
-	if statefulset.Status.ReadyReplicas > 0 {
+	instance.Status.ReadyCount = commonstatefulset.GetStatefulSet().Status.ReadyReplicas
+	if instance.Status.ReadyCount > 0 {
 		instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
 	}
 


### PR DESCRIPTION
This adds ReadyCount field in status, so that users can understand number of pods properly deployed. This field is supported by most of CRs and adding this to Memcached CR makes the interface more consistent across all CRs.