### PR TITLE
Fix app label for memcached resources

### DIFF
--- a/pkg/memcached/service.go
+++ b/pkg/memcached/service.go
@@ -1,6 +1,8 @@
 package memcached
 
 import (
+	"fmt"
+
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	labels "github.com/openstack-k8s-operators/lib-common/modules/common/labels"
 	service "github.com/openstack-k8s-operators/lib-common/modules/common/service"
@@ -12,14 +14,14 @@ func HeadlessService(m *memcachedv1.Memcached) *corev1.Service {
 	labels := labels.GetLabels(m, "memcached", map[string]string{
 		"owner": "infra-operator",
 		"cr":    m.GetName(),
-		"app":   "memcached",
+		"app":   fmt.Sprintf("memcached-%s", m.GetName()),
 	})
 	details := &service.GenericServiceDetails{
 		Name:      m.GetName(),
 		Namespace: m.GetNamespace(),
 		Labels:    labels,
 		Selector: map[string]string{
-			"app": "memcached",
+			"app": fmt.Sprintf("memcached-%s", m.GetName()),
 		},
 		Port: service.GenericServicePort{
 			Name:     "memcached",

--- a/pkg/memcached/statefulset.go
+++ b/pkg/memcached/statefulset.go
@@ -14,8 +14,8 @@ import (
 // StatefulSet returns a Stateful resource for the Memcached CR
 func StatefulSet(m *memcachedv1.Memcached) *appsv1.StatefulSet {
 	matchls := map[string]string{
-		"app":   "memcached",
-		"cr":    fmt.Sprintf("memcached-%s", m.Name),
+		"app":   fmt.Sprintf("memcached-%s", m.Name),
+		"cr":    m.Name,
 		"owner": "infra-operator",
 	}
 	ls := labels.GetLabels(m, "memcached", matchls)


### PR DESCRIPTION
We have to use different labels for different CR instance because we deploy one service resource per CR instance.