### PR TITLE
CSV: Set operator-type: non-standalone

### DIFF
--- a/config/manifests/bases/infra-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/infra-operator.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    operators.operatorframework.io/operator-type: non-standalone
   name: infra-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
This should hide the infra operator package/bundle in the OpenShift console as we only want the main OpenStack operator to show up there.