### PR TITLE
Fix hostname in server list fields

### DIFF
--- a/controllers/memcached/memcached_controller.go
+++ b/controllers/memcached/memcached_controller.go
@@ -289,7 +289,7 @@ func (r *Reconciler) GetServerLists(
 	}
 
 	for i := int32(0); i < instance.Spec.Replicas; i++ {
-		server := fmt.Sprintf("%s-memcached-%d.memcached", instance.Name, i)
+		server := fmt.Sprintf("memcached-%s-%d.%s", instance.Name, i, instance.Name)
 		serverList = append(serverList, fmt.Sprintf("%s:%d", server, memcached.MemcachedPort))
 
 		// python-memcached requires inet(6) prefix according to the IP version

--- a/controllers/memcached/memcached_controller.go
+++ b/controllers/memcached/memcached_controller.go
@@ -247,7 +247,7 @@ func (r *Reconciler) generateConfigMaps(
 	cms := []util.Template{
 		// ConfigMap
 		{
-			Name:          fmt.Sprintf("%s-memcached-config-data", instance.Name),
+			Name:          fmt.Sprintf("%s-config-data", instance.Name),
 			Namespace:     instance.Namespace,
 			Type:          util.TemplateTypeConfig,
 			InstanceType:  instance.Kind,
@@ -289,7 +289,7 @@ func (r *Reconciler) GetServerLists(
 	}
 
 	for i := int32(0); i < instance.Spec.Replicas; i++ {
-		server := fmt.Sprintf("memcached-%s-%d.%s", instance.Name, i, instance.Name)
+		server := fmt.Sprintf("%s-%d.%s", instance.Name, i, instance.Name)
 		serverList = append(serverList, fmt.Sprintf("%s:%d", server, memcached.MemcachedPort))
 
 		// python-memcached requires inet(6) prefix according to the IP version

--- a/pkg/memcached/service.go
+++ b/pkg/memcached/service.go
@@ -1,8 +1,6 @@
 package memcached
 
 import (
-	"fmt"
-
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	labels "github.com/openstack-k8s-operators/lib-common/modules/common/labels"
 	service "github.com/openstack-k8s-operators/lib-common/modules/common/service"
@@ -14,14 +12,14 @@ func HeadlessService(m *memcachedv1.Memcached) *corev1.Service {
 	labels := labels.GetLabels(m, "memcached", map[string]string{
 		"owner": "infra-operator",
 		"cr":    m.GetName(),
-		"app":   fmt.Sprintf("memcached-%s", m.GetName()),
+		"app":   m.GetName(),
 	})
 	details := &service.GenericServiceDetails{
 		Name:      m.GetName(),
 		Namespace: m.GetNamespace(),
 		Labels:    labels,
 		Selector: map[string]string{
-			"app": fmt.Sprintf("memcached-%s", m.GetName()),
+			"app": m.GetName(),
 		},
 		Port: service.GenericServicePort{
 			Name:     "memcached",

--- a/pkg/memcached/statefulset.go
+++ b/pkg/memcached/statefulset.go
@@ -14,7 +14,7 @@ import (
 // StatefulSet returns a Stateful resource for the Memcached CR
 func StatefulSet(m *memcachedv1.Memcached) *appsv1.StatefulSet {
 	matchls := map[string]string{
-		"app":   fmt.Sprintf("memcached-%s", m.Name),
+		"app":   m.Name,
 		"cr":    m.Name,
 		"owner": "infra-operator",
 	}
@@ -45,7 +45,7 @@ func StatefulSet(m *memcachedv1.Memcached) *appsv1.StatefulSet {
 
 	sfs := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("memcached-%s", m.Name),
+			Name:      m.Name,
 			Namespace: m.Namespace,
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -93,7 +93,7 @@ func StatefulSet(m *memcachedv1.Memcached) *appsv1.StatefulSet {
 							VolumeSource: corev1.VolumeSource{
 								ConfigMap: &corev1.ConfigMapVolumeSource{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: fmt.Sprintf("%s-memcached-config-data", m.Name),
+										Name: fmt.Sprintf("%s-config-data", m.Name),
 									},
 									Items: []corev1.KeyToPath{
 										{
@@ -109,7 +109,7 @@ func StatefulSet(m *memcachedv1.Memcached) *appsv1.StatefulSet {
 							VolumeSource: corev1.VolumeSource{
 								ConfigMap: &corev1.ConfigMapVolumeSource{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: fmt.Sprintf("%s-memcached-config-data", m.Name),
+										Name: fmt.Sprintf("%s-config-data", m.Name),
 									},
 									Items: []corev1.KeyToPath{
 										{


### PR DESCRIPTION
Pod DNS is supposed to look like `<stateful set name>-<index>.<service name>`

This fixes the wrong hostname format used to generate server list status fields.

This also removes redundant `memcached` from resource names. Now individual operators are supposed add it as CR name suffix, thus adding it again in memcached controller causes redundant names.