### PR TITLE
[IPAM] extend IPSet and NetConfig validation and adds Immutable feature

### DIFF
--- a/apis/bases/network.openstack.org_ipsets.yaml
+++ b/apis/bases/network.openstack.org_ipsets.yaml
@@ -58,7 +58,7 @@ spec:
                         can only be one default route defined per IPSet.
                       type: boolean
                     fixedIP:
-                      description: 'Fixed Ip TODO: add validation to webhook'
+                      description: Fixed Ip
                       type: string
                     name:
                       description: Network Name

--- a/apis/bases/network.openstack.org_ipsets.yaml
+++ b/apis/bases/network.openstack.org_ipsets.yaml
@@ -48,6 +48,9 @@ spec:
           spec:
             description: IPSetSpec defines the desired state of IPSet
             properties:
+              immutable:
+                default: false
+                type: boolean
               networks:
                 description: Networks used to request IPs for
                 items:

--- a/apis/bases/network.openstack.org_netconfigs.yaml
+++ b/apis/bases/network.openstack.org_netconfigs.yaml
@@ -18,16 +18,7 @@ spec:
     singular: netconfig
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Ready
-      jsonPath: .status.conditions[0].status
-      name: Ready
-      type: string
-    - description: Message
-      jsonPath: .status.conditions[0].message
-      name: Message
-      type: string
-    name: v1beta1
+  - name: v1beta1
     schema:
       openAPIV3Schema:
         description: NetConfig is the Schema for the netconfigs API
@@ -77,12 +68,10 @@ spec:
                               description: AllocationRange definition
                               properties:
                                 end:
-                                  description: End a set of IPs that are reserved
-                                    and will not be assigned
+                                  description: End IP for the AllocationRange
                                   type: string
                                 start:
-                                  description: Start a set of IPs that are reserved
-                                    and will not be assigned
+                                  description: Start IP for the AllocationRange
                                   type: string
                               required:
                               - end

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.9.2
 	github.com/onsi/gomega v1.27.6
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230606033311-3b01713e4d45
+	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53
 	k8s.io/api v0.26.3
 	k8s.io/apimachinery v0.26.3
 	k8s.io/client-go v0.26.3

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -330,6 +330,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53 h1:5llv2sWeaMSnA3w2kS57ouQQ4pudlXrR0dCgw51QK9o=
+golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/apis/network/v1beta1/common_webhook.go
+++ b/apis/network/v1beta1/common_webhook.go
@@ -1,0 +1,80 @@
+package v1beta1
+
+// Because webhooks *MUST* exist within the api/<version> package, we need to place common
+// functions here that might be used across different Kinds' webhooks
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	goClient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Client needed for API calls (manager's client, set by first SetupWebhookWithManager() call
+// to any particular webhook)
+var webhookClient goClient.Client
+
+const (
+	errNotIPAddr              = "not an IP address"
+	errInvalidCidr            = "IP address prefix (CIDR) %s"
+	errNotInCidr              = "address not in IP address prefix (CIDR) %s"
+	errMixedAddressFamily     = "cannot mix IPv4 and IPv6"
+	errInvalidRange           = "Start address: %s > End address %s"
+	errDupeNetworkName        = "network name %s already in use at %s, must be uniq"
+	errDupeCIDR               = "CIDR %s already in use at %s"
+	errInvalidDNSDomain       = "DNSDoman name %s is not valid"
+	errDupeDNSDomain          = "DNSDoman name %s already in use at %s, must be uniq"
+	errNetworkNotFound        = "network %s not in NetConfig"
+	errSubnetNotInNetwork     = "subnet %s not in network %s of the NetConfig"
+	errNetworkChanged         = "network %s removed"
+	errSubnetChanged          = "subnet within a network must not change (%s/%s)"
+	errSubnetParameterChanged = "%s of a subnet must not change - %v"
+	errFixedIPChanged         = "fixedIP must not change"
+	errDefaultRouteChanged    = "defaultRoute must not change"
+	errMultiDefaultRoute      = "%s defaultRoute can only be requested on a singe network"
+)
+
+func getNetConfig(
+	c client.Client,
+	obj metav1.Object,
+) (*NetConfig, error) {
+	// check if NetConfig is available
+	opts := &client.ListOptions{
+		Namespace: obj.GetNamespace(),
+	}
+
+	netcfgs := &NetConfigList{}
+	err := webhookClient.List(context.TODO(), netcfgs, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(netcfgs.Items) == 0 {
+		return nil, nil
+	} else if len(netcfgs.Items) > 1 {
+		return nil, fmt.Errorf("more then one NetConfig found in namespace %s, there must be only one", obj.GetNamespace())
+	}
+
+	return &netcfgs.Items[0], nil
+}
+
+func getIPSets(
+	c client.Client,
+	obj metav1.Object,
+) (*IPSetList, error) {
+	// check if IPSet is available
+	opts := &client.ListOptions{
+		Namespace: obj.GetNamespace(),
+	}
+
+	ipsets := &IPSetList{}
+	err := webhookClient.List(context.TODO(), ipsets, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return ipsets, nil
+}

--- a/apis/network/v1beta1/ipset_types.go
+++ b/apis/network/v1beta1/ipset_types.go
@@ -34,7 +34,6 @@ type IPSetNetwork struct {
 
 	// +kubebuilder:validation:Optional
 	// Fixed Ip
-	// TODO: add validation to webhook
 	FixedIP *string `json:"fixedIP,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/apis/network/v1beta1/ipset_types.go
+++ b/apis/network/v1beta1/ipset_types.go
@@ -43,6 +43,10 @@ type IPSetNetwork struct {
 
 // IPSetSpec defines the desired state of IPSet
 type IPSetSpec struct {
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	Immutable bool `json:"immutable"`
+
 	// Networks used to request IPs for
 	Networks []IPSetNetwork `json:"networks"`
 }

--- a/apis/network/v1beta1/ipset_webhook.go
+++ b/apis/network/v1beta1/ipset_webhook.go
@@ -17,7 +17,15 @@ limitations under the License.
 package v1beta1
 
 import (
+	"fmt"
+	"net"
+
+	"golang.org/x/exp/slices"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	k8snet "k8s.io/utils/net"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -28,12 +36,14 @@ var ipsetlog = logf.Log.WithName("ipset-resource")
 
 // SetupWebhookWithManager sets up the webhook with the Manager
 func (r *IPSet) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if webhookClient == nil {
+		webhookClient = mgr.GetClient()
+	}
+
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
 		Complete()
 }
-
-// TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
 //+kubebuilder:webhook:path=/mutate-network-openstack-org-v1beta1-ipset,mutating=true,failurePolicy=fail,sideEffects=None,groups=network.openstack.org,resources=ipsets,verbs=create;update,versions=v1beta1,name=mipset.kb.io,admissionReviewVersions=v1
 
@@ -55,16 +65,66 @@ var _ webhook.Validator = &IPSet{}
 func (r *IPSet) ValidateCreate() error {
 	ipsetlog.Info("validate create", "name", r.Name)
 
-	// TODO(user): fill in your validation logic upon object creation.
-	return nil
+	// check if there is already a NetConfig in the namespace.
+	netcfg, err := getNetConfig(webhookClient, r)
+	if err != nil {
+		return err
+	}
+	// stop if there is no NetConfig in the namespace.
+	if netcfg == nil {
+		return fmt.Errorf(fmt.Sprintf("no NetConfig found in namespace %s. Please create one.", r.GetNamespace()))
+	}
+
+	allErrs := field.ErrorList{}
+	basePath := field.NewPath("spec")
+
+	// validate requested networks exist in netcfg
+	allErrs = append(allErrs, valiateIPSetNetwork(r.Spec.Networks, basePath, &netcfg.Spec)...)
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+
+	return apierrors.NewInvalid(GroupVersion.WithKind("IPSet").GroupKind(), r.Name, allErrs)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *IPSet) ValidateUpdate(old runtime.Object) error {
 	ipsetlog.Info("validate update", "name", r.Name)
 
-	// TODO(user): fill in your validation logic upon object update.
-	return nil
+	oldIPSet, ok := old.(*IPSet)
+	if !ok || oldIPSet == nil {
+		return apierrors.NewInternalError(fmt.Errorf("unable to convert existing object"))
+	}
+
+	allErrs := field.ErrorList{}
+	// only run the validations on update if the object won't get updated
+	// to be deleted (remove finalizer).
+	if r.DeletionTimestamp.IsZero() {
+		// check if there is already a NetConfig in the namespace.
+		netcfg, err := getNetConfig(webhookClient, r)
+		if err != nil {
+			return err
+		}
+		// stop if there is no NetConfig in the namespace.
+		if netcfg == nil {
+			return fmt.Errorf(fmt.Sprintf("no NetConfig found in namespace %s. Please create one.", r.GetNamespace()))
+		}
+
+		basePath := field.NewPath("spec")
+
+		// validate requested networks exist in
+		allErrs = append(allErrs, valiateIPSetNetwork(r.Spec.Networks, basePath, &netcfg.Spec)...)
+
+		// validate against the previous object only
+		allErrs = append(allErrs, valiateIPSetChanged(r.Spec.Networks, oldIPSet.Spec.Networks, basePath)...)
+	}
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+
+	return apierrors.NewInvalid(GroupVersion.WithKind("IPSet").GroupKind(), r.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
@@ -73,4 +133,135 @@ func (r *IPSet) ValidateDelete() error {
 
 	// TODO(user): fill in your validation logic upon object deletion.
 	return nil
+}
+
+// valiateIPSetNetwork
+// - networks are uniq in the list
+// - networks and subnets exist in netcfg
+// - FixedIP is a valid IP address
+// - FixedIP has correct IP version of subnet
+// - FixedIP is in the subnet cidr
+// - Route is only specified on a single network per IPFamily
+func valiateIPSetNetwork(
+	networks []IPSetNetwork,
+	path *field.Path,
+	netCfgSpec *NetConfigSpec,
+) field.ErrorList {
+	allErrs := field.ErrorList{}
+	netNames := map[string]field.Path{}
+	defaultRouteCount := map[k8snet.IPFamily]int{
+		k8snet.IPv4:            0,
+		k8snet.IPv6:            0,
+		k8snet.IPFamilyUnknown: 0, // should not be required since the cidr gets validated on the NetConfig
+	}
+
+	for _netIdx, _net := range networks {
+		path := path.Child("networks").Index(_netIdx)
+
+		// validate uniqe networks in request
+		allErrs = append(allErrs, valiateUniqElement(netNames, string(_net.Name), path, "name", errDupeNetworkName)...)
+
+		// validate if requested network is in NetConfig
+		f := func(n Network) bool {
+			return n.Name == _net.Name
+		}
+		netIdx := slices.IndexFunc(netCfgSpec.Networks, f)
+
+		if netIdx >= 0 {
+			// validate if requested subnet is in NetConfig
+			f := func(n Subnet) bool {
+				return n.Name == _net.SubnetName
+			}
+			subNetIdx := slices.IndexFunc(netCfgSpec.Networks[netIdx].Subnets, f)
+
+			if subNetIdx >= 0 {
+				// net and subnet are valid
+
+				if _net.FixedIP != nil || _net.DefaultRoute != nil {
+					cidr := netCfgSpec.Networks[netIdx].Subnets[subNetIdx].Cidr
+					_, ipPrefix, ipPrefixErr := net.ParseCIDR(cidr)
+					if ipPrefixErr != nil {
+						// this should never happen as the subnet CIDR was already validated
+						// via the netcfg webhook
+						allErrs = append(allErrs, field.Invalid(path.Child("cidr"), cidr, errInvalidCidr))
+						return allErrs
+					}
+					ipFam := k8snet.IPFamilyOfCIDR(ipPrefix)
+
+					// validate the requested FixedIP
+					if _net.FixedIP != nil {
+						path := path.Child("fixedIP")
+						if err := valiateAddress(*_net.FixedIP, ipPrefix, path); err != nil {
+							allErrs = append(allErrs, err...)
+						}
+					}
+
+					// check that there are not multiple have the defaultRoute flag
+					if _net.DefaultRoute != nil && *_net.DefaultRoute {
+						defaultRouteCount[ipFam]++
+
+						for fam, count := range defaultRouteCount {
+							if count > 1 {
+								allErrs = append(allErrs, field.Invalid(path.Child("defaultRoute"), _net.Name, fmt.Sprintf(errMultiDefaultRoute, string(fam))))
+							}
+						}
+					}
+				}
+
+				continue
+			}
+
+			// the requested subnet was not found in the network
+			allErrs = append(allErrs, field.Invalid(path.Child("subnetName"), _net.SubnetName, fmt.Sprintf(errSubnetNotInNetwork, _net.SubnetName, _net.Name)))
+			continue
+		}
+
+		// the requested net was not found in the NetConfig
+		allErrs = append(allErrs, field.Invalid(path.Child("name"), _net.Name, fmt.Sprintf(errNetworkNotFound, _net.Name)))
+	}
+
+	return allErrs
+}
+
+// valiateIPSetChanged
+// - if a previous requested network is still in the list
+// - if subnet changed within a network
+// - if fixedIP changed
+// - if defaultRoute changed
+func valiateIPSetChanged(
+	networks []IPSetNetwork,
+	oldNetworks []IPSetNetwork,
+	path *field.Path,
+) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	for _netIdx, _net := range oldNetworks {
+		path := path.Child("networks").Index(_netIdx)
+
+		// validate if a previous requested network is still in the CR
+		f := func(n IPSetNetwork) bool {
+			return equality.Semantic.DeepEqual(n.Name, _net.Name)
+		}
+		netIdx := slices.IndexFunc(networks, f)
+		if netIdx < 0 {
+			// the network was removed
+			allErrs = append(allErrs, field.Invalid(path.Child("name"), _net.Name, fmt.Sprintf(errNetworkChanged, _net.Name)))
+			return allErrs
+		}
+
+		// validate if subnet changed within a network
+		if !equality.Semantic.DeepEqual(_net.SubnetName, networks[netIdx].SubnetName) {
+			allErrs = append(allErrs, field.Invalid(path.Child("subnetName"), _net.Name, fmt.Sprintf(errSubnetChanged, oldNetworks[_netIdx].SubnetName, networks[_netIdx].SubnetName)))
+		}
+		// validate if fixedIP changed
+		if !equality.Semantic.DeepEqual(_net.FixedIP, networks[netIdx].FixedIP) {
+			allErrs = append(allErrs, field.Invalid(path.Child("fixedIP"), _net.Name, errFixedIPChanged))
+		}
+		// validate if defaultRoute changed
+		if !equality.Semantic.DeepEqual(_net.DefaultRoute, networks[netIdx].DefaultRoute) {
+			allErrs = append(allErrs, field.Invalid(path.Child("defaultRoute"), _net.Name, errDefaultRouteChanged))
+		}
+	}
+
+	return allErrs
 }

--- a/apis/network/v1beta1/ipset_webhook_test.go
+++ b/apis/network/v1beta1/ipset_webhook_test.go
@@ -1,0 +1,479 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/pointer"
+)
+
+func TestIPSetValiateIPSetNetwork(t *testing.T) {
+	tests := []struct {
+		name      string
+		expectErr bool
+		c         *IPSet
+		n         NetConfigSpec
+	}{
+		{
+			name:      "should succeed with good values",
+			expectErr: false,
+			c: &IPSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "netcfg",
+					Namespace: "foo",
+				},
+				Spec: IPSetSpec{
+					Networks: []IPSetNetwork{
+						{
+							Name:       "net1",
+							SubnetName: "subnet1",
+							FixedIP:    pointer.String("172.17.0.10"),
+						},
+					},
+				},
+			},
+			n: getDefaultIPv4NetConfigSpec(),
+		},
+		{
+			name:      "should fail with network not in NetConfig",
+			expectErr: true,
+			c: &IPSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "netcfg",
+					Namespace: "foo",
+				},
+				Spec: IPSetSpec{
+					Networks: []IPSetNetwork{
+						{
+							Name:       "foo",
+							SubnetName: "subnet1",
+						},
+					},
+				},
+			},
+			n: getDefaultIPv4NetConfigSpec(),
+		},
+		{
+			name:      "should fail with subnet not in network of the NetConfig",
+			expectErr: true,
+			c: &IPSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "netcfg",
+					Namespace: "foo",
+				},
+				Spec: IPSetSpec{
+					Networks: []IPSetNetwork{
+						{
+							Name:       "net1",
+							SubnetName: "foo",
+						},
+					},
+				},
+			},
+			n: getDefaultIPv4NetConfigSpec(),
+		},
+		{
+			name:      "[IPv4] should fail with bad FixedIP",
+			expectErr: true,
+			c: &IPSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "netcfg",
+					Namespace: "foo",
+				},
+				Spec: IPSetSpec{
+					Networks: []IPSetNetwork{
+						{
+							Name:       "net1",
+							SubnetName: "subnet1",
+							FixedIP:    pointer.String("172.17.0.0.10"),
+						},
+					},
+				},
+			},
+			n: getDefaultIPv4NetConfigSpec(),
+		},
+		{
+			name:      "[IPv6] should fail with bad FixedIP",
+			expectErr: true,
+			c: &IPSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "netcfg",
+					Namespace: "foo",
+				},
+				Spec: IPSetSpec{
+					Networks: []IPSetNetwork{
+						{
+							Name:       "net1",
+							SubnetName: "subnet1",
+							FixedIP:    pointer.String("fd00:fd00:fd00:20000::10"),
+						},
+					},
+				},
+			},
+			n: getDefaultIPv6NetConfigSpec(),
+		},
+		{
+			name:      "[IPv4] should fail with subnet IPv4 and FixedIP IPv6",
+			expectErr: true,
+			c: &IPSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "netcfg",
+					Namespace: "foo",
+				},
+				Spec: IPSetSpec{
+					Networks: []IPSetNetwork{
+						{
+							Name:       "net1",
+							SubnetName: "subnet1",
+							FixedIP:    pointer.String("fd00:fd00:fd00:2000::10"),
+						},
+					},
+				},
+			},
+			n: getDefaultIPv4NetConfigSpec(),
+		},
+		{
+			name:      "[IPv6] should fail with subnet IPv6 and FixedIP IPv4",
+			expectErr: true,
+			c: &IPSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "netcfg",
+					Namespace: "foo",
+				},
+				Spec: IPSetSpec{
+					Networks: []IPSetNetwork{
+						{
+							Name:       "net1",
+							SubnetName: "subnet1",
+							FixedIP:    pointer.String("172.17.0.10"),
+						},
+					},
+				},
+			},
+			n: getDefaultIPv6NetConfigSpec(),
+		},
+		{
+			name:      "[IPv4] should fail when the FixedIP is ouside the CIDR",
+			expectErr: true,
+			c: &IPSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "netcfg",
+					Namespace: "foo",
+				},
+				Spec: IPSetSpec{
+					Networks: []IPSetNetwork{
+						{
+							Name:       "net1",
+							SubnetName: "subnet1",
+							FixedIP:    pointer.String("172.17.1.10"),
+						},
+					},
+				},
+			},
+			n: getDefaultIPv4NetConfigSpec(),
+		},
+		{
+			name:      "[IPv6] should fail when the FixedIP is ouside the CIDR",
+			expectErr: true,
+			c: &IPSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "netcfg",
+					Namespace: "foo",
+				},
+				Spec: IPSetSpec{
+					Networks: []IPSetNetwork{
+						{
+							Name:       "net1",
+							SubnetName: "subnet1",
+							FixedIP:    pointer.String("fd00:fd00:fd00:2001::10"),
+						},
+					},
+				},
+			},
+			n: getDefaultIPv6NetConfigSpec(),
+		},
+		{
+			name:      "should fail with multiple networks with same IP family have DefaultRoute flag",
+			expectErr: true,
+			c: &IPSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "netcfg",
+					Namespace: "foo",
+				},
+				Spec: IPSetSpec{
+					Networks: []IPSetNetwork{
+						{
+							Name:         "net1",
+							SubnetName:   "subnet1",
+							DefaultRoute: pointer.Bool(true),
+						},
+						{
+							Name:         "net2",
+							SubnetName:   "subnet3",
+							DefaultRoute: pointer.Bool(true),
+						},
+					},
+				},
+			},
+			n: getDefaultIPv4NetConfigSpec(),
+		},
+		{
+			name:      "should succeed with multiple networks with different IP family have DefaultRoute flag",
+			expectErr: false,
+			c: &IPSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "netcfg",
+					Namespace: "foo",
+				},
+				Spec: IPSetSpec{
+					Networks: []IPSetNetwork{
+						{
+							Name:         "net1",
+							SubnetName:   "subnet1",
+							DefaultRoute: pointer.Bool(true),
+						},
+						{
+							Name:         "net2",
+							SubnetName:   "subnet1",
+							DefaultRoute: pointer.Bool(true),
+						},
+					},
+				},
+			},
+			n: getDefaultIPv4IPv6NetConfigSpec(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			basePath := field.NewPath("spec")
+
+			var err error
+			allErrs := valiateIPSetNetwork(tt.c.Spec.Networks, basePath, &tt.n)
+			if len(allErrs) > 0 {
+				err = apierrors.NewInvalid(GroupVersion.WithKind("NetConfig").GroupKind(), tt.c.Name, allErrs)
+			}
+
+			if tt.expectErr {
+				g.Expect(err).NotTo(Succeed())
+
+			} else {
+				g.Expect(err).To(Succeed())
+			}
+		})
+	}
+}
+
+func TestIPSetUpdateValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		expectErr bool
+		newSpec   *IPSetSpec
+		oldSpec   *IPSetSpec
+		n         NetConfigSpec
+	}{
+		{
+			name:      "should succeed when values and templates correct",
+			expectErr: false,
+			newSpec: &IPSetSpec{
+				Networks: []IPSetNetwork{
+					{
+						Name:         "net1",
+						SubnetName:   "subnet1",
+						FixedIP:      pointer.String("172.17.0.10"),
+						DefaultRoute: pointer.Bool(true),
+					},
+					{
+						Name:       "net2",
+						SubnetName: "subnet3",
+						FixedIP:    pointer.String("172.18.0.10"),
+					},
+				},
+			},
+			oldSpec: &IPSetSpec{
+				Networks: []IPSetNetwork{
+					{
+						Name:         "net1",
+						SubnetName:   "subnet1",
+						FixedIP:      pointer.String("172.17.0.10"),
+						DefaultRoute: pointer.Bool(true),
+					},
+					{
+						Name:       "net2",
+						SubnetName: "subnet3",
+						FixedIP:    pointer.String("172.18.0.10"),
+					},
+				},
+			},
+			n: getDefaultIPv4NetConfigSpec(),
+		},
+		{
+			name:      "should fail if network was removed",
+			expectErr: true,
+			newSpec: &IPSetSpec{
+				Networks: []IPSetNetwork{
+					{
+						Name:         "net1",
+						SubnetName:   "subnet1",
+						FixedIP:      pointer.String("172.17.0.10"),
+						DefaultRoute: pointer.Bool(true),
+					},
+				},
+			},
+			oldSpec: &IPSetSpec{
+				Networks: []IPSetNetwork{
+					{
+						Name:         "net1",
+						SubnetName:   "subnet1",
+						FixedIP:      pointer.String("172.17.0.10"),
+						DefaultRoute: pointer.Bool(true),
+					},
+					{
+						Name:       "net2",
+						SubnetName: "subnet3",
+						FixedIP:    pointer.String("172.18.0.10"),
+					},
+				},
+			},
+			n: getDefaultIPv4NetConfigSpec(),
+		},
+		{
+			name:      "should fail if a subnet in a network changed",
+			expectErr: true,
+			newSpec: &IPSetSpec{
+				Networks: []IPSetNetwork{
+					{
+						Name:         "net1",
+						SubnetName:   "subnet1",
+						FixedIP:      pointer.String("172.17.0.10"),
+						DefaultRoute: pointer.Bool(true),
+					},
+					{
+						Name:       "net2",
+						SubnetName: "subnet3",
+						FixedIP:    pointer.String("172.18.0.10"),
+					},
+				},
+			},
+			oldSpec: &IPSetSpec{
+				Networks: []IPSetNetwork{
+					{
+						Name:         "net1",
+						SubnetName:   "subnet2",
+						FixedIP:      pointer.String("172.17.1.10"),
+						DefaultRoute: pointer.Bool(true),
+					},
+					{
+						Name:       "net2",
+						SubnetName: "subnet3",
+						FixedIP:    pointer.String("172.18.0.10"),
+					},
+				},
+			},
+			n: getDefaultIPv4NetConfigSpec(),
+		},
+		{
+			name:      "should fail when fixedIP changes",
+			expectErr: true,
+			newSpec: &IPSetSpec{
+				Networks: []IPSetNetwork{
+					{
+						Name:         "net1",
+						SubnetName:   "subnet1",
+						FixedIP:      pointer.String("172.17.0.11"),
+						DefaultRoute: pointer.Bool(true),
+					},
+				},
+			},
+			oldSpec: &IPSetSpec{
+				Networks: []IPSetNetwork{
+					{
+						Name:         "net1",
+						SubnetName:   "subnet1",
+						FixedIP:      pointer.String("172.17.0.10"),
+						DefaultRoute: pointer.Bool(true),
+					},
+				},
+			},
+			n: getDefaultIPv4NetConfigSpec(),
+		},
+		{
+			name:      "should fail when defaultRoute changes",
+			expectErr: true,
+			newSpec: &IPSetSpec{
+				Networks: []IPSetNetwork{
+					{
+						Name:         "net1",
+						SubnetName:   "subnet1",
+						FixedIP:      pointer.String("172.17.0.10"),
+						DefaultRoute: pointer.Bool(true),
+					},
+				},
+			},
+			oldSpec: &IPSetSpec{
+				Networks: []IPSetNetwork{
+					{
+						Name:       "net1",
+						SubnetName: "subnet1",
+						FixedIP:    pointer.String("172.17.0.10"),
+					},
+				},
+			},
+			n: getDefaultIPv4NetConfigSpec(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			basePath := field.NewPath("spec")
+
+			new := &IPSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: *tt.newSpec,
+			}
+
+			var err error
+
+			allErrs := valiateIPSetNetwork(tt.newSpec.Networks, basePath, &tt.n)
+			if len(allErrs) > 0 {
+				err = apierrors.NewInvalid(GroupVersion.WithKind("IPSet").GroupKind(), new.Name, allErrs)
+			}
+
+			allErrs = valiateIPSetChanged(tt.newSpec.Networks, tt.oldSpec.Networks, basePath)
+			if len(allErrs) > 0 {
+				err = apierrors.NewInvalid(GroupVersion.WithKind("IPSet").GroupKind(), new.Name, allErrs)
+			}
+
+			if tt.expectErr {
+				g.Expect(err).NotTo(Succeed())
+
+			} else {
+				g.Expect(err).To(Succeed())
+			}
+
+		})
+	}
+}

--- a/apis/network/v1beta1/netconfig_types.go
+++ b/apis/network/v1beta1/netconfig_types.go
@@ -88,11 +88,11 @@ type Subnet struct {
 // AllocationRange definition
 type AllocationRange struct {
 	// +kubebuilder:validation:Required
-	// Start a set of IPs that are reserved and will not be assigned
+	// Start IP for the AllocationRange
 	Start string `json:"start"`
 
 	// +kubebuilder:validation:Required
-	// End a set of IPs that are reserved and will not be assigned
+	// End IP for the AllocationRange
 	End string `json:"end"`
 }
 
@@ -121,8 +121,6 @@ type NetConfigStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:shortName=netcfg;netscfg
-//+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[0].status",description="Ready"
-//+kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[0].message",description="Message"
 
 // NetConfig is the Schema for the netconfigs API
 type NetConfig struct {

--- a/config/crd/bases/network.openstack.org_ipsets.yaml
+++ b/config/crd/bases/network.openstack.org_ipsets.yaml
@@ -58,7 +58,7 @@ spec:
                         can only be one default route defined per IPSet.
                       type: boolean
                     fixedIP:
-                      description: 'Fixed Ip TODO: add validation to webhook'
+                      description: Fixed Ip
                       type: string
                     name:
                       description: Network Name

--- a/config/crd/bases/network.openstack.org_ipsets.yaml
+++ b/config/crd/bases/network.openstack.org_ipsets.yaml
@@ -48,6 +48,9 @@ spec:
           spec:
             description: IPSetSpec defines the desired state of IPSet
             properties:
+              immutable:
+                default: false
+                type: boolean
               networks:
                 description: Networks used to request IPs for
                 items:

--- a/config/crd/bases/network.openstack.org_netconfigs.yaml
+++ b/config/crd/bases/network.openstack.org_netconfigs.yaml
@@ -18,16 +18,7 @@ spec:
     singular: netconfig
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Ready
-      jsonPath: .status.conditions[0].status
-      name: Ready
-      type: string
-    - description: Message
-      jsonPath: .status.conditions[0].message
-      name: Message
-      type: string
-    name: v1beta1
+  - name: v1beta1
     schema:
       openAPIV3Schema:
         description: NetConfig is the Schema for the netconfigs API
@@ -77,12 +68,10 @@ spec:
                               description: AllocationRange definition
                               properties:
                                 end:
-                                  description: End a set of IPs that are reserved
-                                    and will not be assigned
+                                  description: End IP for the AllocationRange
                                   type: string
                                 start:
-                                  description: Start a set of IPs that are reserved
-                                    and will not be assigned
+                                  description: Start IP for the AllocationRange
                                   type: string
                               required:
                               - end

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -249,6 +249,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - netconfigs
   sideEffects: None

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -330,18 +330,19 @@ func CreateIPSet(namespace string, spec map[string]interface{}) client.Object {
 	return th.CreateUnstructured(raw)
 }
 
-func GetIPSetSpec(nets ...networkv1.IPSetNetwork) map[string]interface{} {
+func GetIPSetSpec(immutable bool, nets ...networkv1.IPSetNetwork) map[string]interface{} {
 	spec := make(map[string]interface{})
 
 	networks := []networkv1.IPSetNetwork{}
 	networks = append(networks, nets...)
+	spec["immutable"] = immutable
 	spec["networks"] = interface{}(networks)
 
 	return spec
 }
 
 func GetDefaultIPSetSpec() map[string]interface{} {
-	return GetIPSetSpec(GetIPSetNet1())
+	return GetIPSetSpec(false, GetIPSetNet1())
 }
 
 func GetIPSetNet1() networkv1.IPSetNetwork {

--- a/test/functional/ipset_controller_test.go
+++ b/test/functional/ipset_controller_test.go
@@ -20,8 +20,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/openstack-k8s-operators/lib-common/modules/test/helpers"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 
@@ -31,81 +33,38 @@ import (
 
 var _ = Describe("IPSet controller", func() {
 	var ipSetName types.NamespacedName
+	var netCfgName types.NamespacedName
 
 	When("an IPSet gets created with no NetConfig available", func() {
-		BeforeEach(func() {
-			// create IPSet
-			ipset := CreateIPSet(namespace, GetDefaultIPSetSpec())
-			ipSetName = types.NamespacedName{
-				Name:      ipset.GetName(),
-				Namespace: namespace,
+		It("it gets blocked by the webhook and fail", func() {
+
+			raw := map[string]interface{}{
+				"apiVersion": "network.openstack.org/v1beta1",
+				"kind":       "IPSet",
+				"metadata": map[string]interface{}{
+					"name":      "foo",
+					"namespace": namespace,
+				},
+				"spec": GetDefaultIPSetSpec(),
 			}
 
-			DeferCleanup(th.DeleteInstance, ipset)
-		})
-
-		It("is not Ready", func() {
-			th.ExpectCondition(
-				ipSetName,
-				ConditionGetterFunc(IPSetConditionGetter),
-				condition.InputReadyCondition,
-				corev1.ConditionFalse,
-			)
-
-			th.ExpectCondition(
-				ipSetName,
-				ConditionGetterFunc(IPSetConditionGetter),
-				networkv1.ReservationReadyCondition,
-				corev1.ConditionUnknown,
-			)
-
-			th.ExpectCondition(
-				ipSetName,
-				ConditionGetterFunc(IPSetConditionGetter),
-				condition.ReadyCondition,
-				corev1.ConditionFalse,
-			)
-		})
-
-		When("the NetConfig is created with all the expected fields", func() {
-			BeforeEach(func() {
-				netCfg := CreateNetConfig(namespace, GetDefaultNetConfigSpec())
-
-				DeferCleanup(th.DeleteInstance, netCfg)
-			})
-
-			It("reports that input is ready", func() {
-				th.ExpectCondition(
-					ipSetName,
-					ConditionGetterFunc(IPSetConditionGetter),
-					condition.InputReadyCondition,
-					corev1.ConditionTrue,
-				)
-			})
-
-			It("reports the reservation is ready", func() {
-				th.ExpectCondition(
-					ipSetName,
-					ConditionGetterFunc(IPSetConditionGetter),
-					networkv1.ReservationReadyCondition,
-					corev1.ConditionTrue,
-				)
-			})
-
-			It("reports the overall state is ready", func() {
-				th.ExpectCondition(
-					ipSetName,
-					ConditionGetterFunc(IPSetConditionGetter),
-					condition.ReadyCondition,
-					corev1.ConditionTrue,
-				)
-			})
+			unstructuredObj := &unstructured.Unstructured{Object: raw}
+			_, err := controllerutil.CreateOrPatch(
+				th.Ctx, th.K8sClient, unstructuredObj, func() error { return nil })
+			Expect(err).To(HaveOccurred())
 		})
 	})
 
 	When("a GetDefaultIPSetSpec IPSet gets created", func() {
 		BeforeEach(func() {
 			netCfg := CreateNetConfig(namespace, GetDefaultNetConfigSpec())
+			netCfgName.Name = netCfg.GetName()
+			netCfgName.Namespace = netCfg.GetNamespace()
+
+			Eventually(func(g Gomega) {
+				res := GetNetConfig(netCfgName)
+				g.Expect(res).ToNot(BeNil())
+			}, timeout, interval).Should(Succeed())
 			ipset := CreateIPSet(namespace, GetDefaultIPSetSpec())
 
 			ipSetName = types.NamespacedName{
@@ -113,8 +72,10 @@ var _ = Describe("IPSet controller", func() {
 				Namespace: namespace,
 			}
 
-			DeferCleanup(th.DeleteInstance, ipset)
-			DeferCleanup(th.DeleteInstance, netCfg)
+			DeferCleanup(func(ctx SpecContext) {
+				th.DeleteInstance(ipset)
+				th.DeleteInstance(netCfg)
+			}, NodeTimeout(timeout))
 		})
 
 		It("should have created an IPSet", func() {
@@ -138,14 +99,24 @@ var _ = Describe("IPSet controller", func() {
 	When("an IPSet with FixedIP inside AllocationRange gets created", func() {
 		BeforeEach(func() {
 			netCfg := CreateNetConfig(namespace, GetDefaultNetConfigSpec())
+			netCfgName.Name = netCfg.GetName()
+			netCfgName.Namespace = netCfg.GetNamespace()
+
+			Eventually(func(g Gomega) {
+				res := GetNetConfig(netCfgName)
+				g.Expect(res).ToNot(BeNil())
+			}, timeout, interval).Should(Succeed())
+
 			ipset := CreateIPSet(namespace, GetIPSetSpec(GetIPSetNet1WithFixedIP("172.17.0.150")))
 			ipSetName = types.NamespacedName{
 				Name:      ipset.GetName(),
 				Namespace: namespace,
 			}
 
-			DeferCleanup(th.DeleteInstance, ipset)
-			DeferCleanup(th.DeleteInstance, netCfg)
+			DeferCleanup(func(ctx SpecContext) {
+				th.DeleteInstance(ipset)
+				th.DeleteInstance(netCfg)
+			}, NodeTimeout(timeout))
 		})
 
 		It("should have created an IPSet with IP 172.17.0.150 on net-1", func() {
@@ -168,14 +139,24 @@ var _ = Describe("IPSet controller", func() {
 	When("an IPSet with FixedIP outside AllocationRange gets created", func() {
 		BeforeEach(func() {
 			netCfg := CreateNetConfig(namespace, GetDefaultNetConfigSpec())
+			netCfgName.Name = netCfg.GetName()
+			netCfgName.Namespace = netCfg.GetNamespace()
+
+			Eventually(func(g Gomega) {
+				res := GetNetConfig(netCfgName)
+				g.Expect(res).ToNot(BeNil())
+			}, timeout, interval).Should(Succeed())
+
 			ipset := CreateIPSet(namespace, GetIPSetSpec(GetIPSetNet1WithFixedIP("172.17.0.220")))
 			ipSetName = types.NamespacedName{
 				Name:      ipset.GetName(),
 				Namespace: namespace,
 			}
 
-			DeferCleanup(th.DeleteInstance, ipset)
-			DeferCleanup(th.DeleteInstance, netCfg)
+			DeferCleanup(func(ctx SpecContext) {
+				th.DeleteInstance(ipset)
+				th.DeleteInstance(netCfg)
+			}, NodeTimeout(timeout))
 		})
 
 		It("should have created an IPSet with IP 172.17.0.220 on net-1", func() {
@@ -198,14 +179,24 @@ var _ = Describe("IPSet controller", func() {
 	When("an IPSet with FixedIP requests IP listed in ExcludeAddresses", func() {
 		BeforeEach(func() {
 			netCfg := CreateNetConfig(namespace, GetDefaultNetConfigSpec())
+			netCfgName.Name = netCfg.GetName()
+			netCfgName.Namespace = netCfg.GetNamespace()
+
+			Eventually(func(g Gomega) {
+				res := GetNetConfig(netCfgName)
+				g.Expect(res).ToNot(BeNil())
+			}, timeout, interval).Should(Succeed())
+
 			ipset := CreateIPSet(namespace, GetIPSetSpec(GetIPSetNet1WithFixedIP("172.17.0.201")))
 			ipSetName = types.NamespacedName{
 				Name:      ipset.GetName(),
 				Namespace: namespace,
 			}
 
-			DeferCleanup(th.DeleteInstance, ipset)
-			DeferCleanup(th.DeleteInstance, netCfg)
+			DeferCleanup(func(ctx SpecContext) {
+				th.DeleteInstance(ipset)
+				th.DeleteInstance(netCfg)
+			}, NodeTimeout(timeout))
 		})
 
 		It("should have created an IPSet with IP 172.17.0.201 on net-1", func() {
@@ -255,8 +246,10 @@ var _ = Describe("IPSet controller", func() {
 				Namespace: namespace,
 			}
 
-			DeferCleanup(th.DeleteInstance, ipset)
-			DeferCleanup(th.DeleteInstance, netCfg)
+			DeferCleanup(func(ctx SpecContext) {
+				th.DeleteInstance(ipset)
+				th.DeleteInstance(netCfg)
+			}, NodeTimeout(timeout))
 		})
 
 		It("should have created an IPSet with DNSDomain from subnet", func() {

--- a/test/functional/netconfig_webhook_test.go
+++ b/test/functional/netconfig_webhook_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package functional_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
+	networkv1 "github.com/openstack-k8s-operators/infra-operator/apis/network/v1beta1"
+)
+
+var _ = Describe("NetConfig webhook", func() {
+	var netConfigName, ipSetName types.NamespacedName
+
+	When("a GetDefaultNetConfigSpec NetConfig gets created", func() {
+		BeforeEach(func() {
+			netCfg := CreateNetConfig(namespace, GetDefaultNetConfigSpec())
+			netConfigName.Name = netCfg.GetName()
+			netConfigName.Namespace = netCfg.GetNamespace()
+			DeferCleanup(th.DeleteInstance, netCfg)
+		})
+
+		It("should have created a NetConfig", func() {
+			Eventually(func(g Gomega) {
+				GetNetConfig(netConfigName)
+			}, timeout, interval).Should(Succeed())
+		})
+
+		When("a second NetConfig gets created in the same namespace", func() {
+			It("gets blocked by the webhook and fail", func() {
+
+				raw := map[string]interface{}{
+					"apiVersion": "network.openstack.org/v1beta1",
+					"kind":       "NetConfig",
+					"metadata": map[string]interface{}{
+						"name":      "foo",
+						"namespace": namespace,
+					},
+					"spec": GetDefaultNetConfigSpec(),
+				}
+
+				unstructuredObj := &unstructured.Unstructured{Object: raw}
+				_, err := controllerutil.CreateOrPatch(
+					th.Ctx, th.K8sClient, unstructuredObj, func() error { return nil })
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		When("a there is at least one IPSet", func() {
+			BeforeEach(func() {
+				ipset := CreateIPSet(netConfigName.Namespace, GetIPSetSpec(GetIPSetNet1WithFixedIP("172.17.0.201")))
+				ipSetName = types.NamespacedName{
+					Name:      ipset.GetName(),
+					Namespace: namespace,
+				}
+
+				DeferCleanup(th.DeleteInstance, ipset)
+			})
+
+			It("should have created an IPSet with IP 172.17.0.201 on net-1", func() {
+				Eventually(func(g Gomega) {
+					res := GetReservationFromNet(ipSetName, "net-1")
+					g.Expect(res).To(Equal(networkv1.IPSetReservation{}))
+				}, timeout, interval).Should(Succeed())
+			})
+
+			It("should not be possible to delete the NetConfig", func() {
+				netcfg := &networkv1.NetConfig{}
+				Eventually(func(g Gomega) {
+					netcfg = GetNetConfig(netConfigName)
+				}, timeout, interval).Should(Succeed())
+
+				Expect(k8sClient.Delete(ctx, netcfg)).To(HaveOccurred())
+			})
+		})
+	})
+})

--- a/test/functional/netconfig_webhook_test.go
+++ b/test/functional/netconfig_webhook_test.go
@@ -66,7 +66,7 @@ var _ = Describe("NetConfig webhook", func() {
 
 		When("a there is at least one IPSet", func() {
 			BeforeEach(func() {
-				ipset := CreateIPSet(netConfigName.Namespace, GetIPSetSpec(GetIPSetNet1WithFixedIP("172.17.0.201")))
+				ipset := CreateIPSet(netConfigName.Namespace, GetIPSetSpec(false, GetIPSetNet1WithFixedIP("172.17.0.201")))
 				ipSetName = types.NamespacedName{
 					Name:      ipset.GetName(),
 					Namespace: namespace,


### PR DESCRIPTION
**A)** Adds further validations for IPSet and NetConfig.
NetConfig:

IPSet:
* Create
  - Validates that there is a NetConfig in the namespace

* Create and Update
  - networks are uniq in the list
  - networks and subnets exist in netcfg
  - FixedIP is a valid IP address
  - FixedIP has correct IP version of subnet
  - FixedIP is in the subnet cidr
  - Route is only specified on a single network

* Update
  - if a previous requested network is still in the list
  - if subnet changed within a network
  - if fixedIP changed
  - if defaultRoute changed

NetConfig:
* Create
  - validates if there is already a NetConfig in the namespace

* Update
   **Note**: those checks will be skipped if there are no IPSets in the namespace. in that case it is save to customize the NetConfig as needed.
  - validate if a network was removed
  - subnet is still there
  - cidr changed
  - Vlan changed
  - gateway changed
 
* Delete
  - validates that there is no IPSet in the namespace

**B)** Adds immutable parameter to IPSet

When Spec.Immutable == true on the existing object spec, the IPSet validation webhook on Update denies the spec change. Changes to the status and metadata are still possible as it is required for the operator to work properly.

Jira: [OSP-19996](https://issues.redhat.com//browse/OSP-19996)