### PR TITLE
Add edpm jobs to infra-operator

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,0 +1,36 @@
+---
+- job:
+    name: infra-operator-content-provider
+    parent: content-provider-base
+    vars:
+      cifmw_operator_build_org: openstack-k8s-operators
+      cifmw_operator_build_operators:
+        - name: "openstack-operator"
+          src: "~/src/github.com/{{ cifmw_operator_build_org }}/openstack-operator"
+          image_base: infra
+    irrelevant-files: &irrev
+      - tests/kuttl
+      - docs
+      - containers/ci
+      - .github/workflows
+      - .ci-operator.yaml
+      - .dockerignore
+      - .gitignore
+      - .golangci.yaml
+      - .pre-commit-config.yaml
+      - LICENSE
+      - OWNERS*
+      - PROJECT
+      - .*/*.md
+      - kuttl-test.yaml
+      - renovate.json
+
+- job:
+    name: infra-operator-crc-podified-edpm-deployment
+    parent: cifmw-crc-podified-edpm-deployment
+    irrelevant-files: *irrev
+
+- job:
+    name: infra-operator-crc-podified-edpm-baremetal
+    parent: cifmw-crc-podified-edpm-baremetal
+    irrelevant-files: *irrev

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,0 +1,10 @@
+---
+- project:
+    name: openstack-k8s-operators/infra-operator
+    github-check:
+      jobs:
+        - infra-operator-content-provider
+        - infra-operator-crc-podified-edpm-baremetal: &content_provider
+            dependencies:
+              - infra-operator-content-provider
+        - infra-operator-crc-podified-edpm-deployment: *content_provider


### PR DESCRIPTION
Now dataplane uses infra-operator for IPAM stuff. Let's avoid breaking the EDPM deployment with changes here.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/328