### PR TITLE
Remove openstack from workflow name

### DIFF
--- a/.github/workflows/build-infra-operator.yaml
+++ b/.github/workflows/build-infra-operator.yaml
@@ -1,4 +1,4 @@
-name: OpenStack Infra image builder
+name: Infra Operator image builder
 
 on:
   push:


### PR DESCRIPTION
The image name/repo name for infra operator doesn't have openstack in its name. Removing openstack name so that we can sort github status list correctly [1].

[1] https://github.com/gibizer/openstack-k8s-status/tree/main