### PR TITLE
Watch RBAC resources to trigger reconcile

### DIFF
--- a/controllers/client/openstackclient_controller.go
+++ b/controllers/client/openstackclient_controller.go
@@ -266,5 +266,8 @@ func (r *OpenStackClientReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&clientv1beta1.OpenStackClient{}).
 		Owns(&corev1.Pod{}).
+		Owns(&corev1.ServiceAccount{}).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
 		Complete(r)
 }

--- a/controllers/memcached/memcached_controller.go
+++ b/controllers/memcached/memcached_controller.go
@@ -272,6 +272,9 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&memcachedv1.Memcached{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.Service{}).
+		Owns(&corev1.ServiceAccount{}).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
 		Complete(r)
 }
 

--- a/controllers/network/dnsmasq_controller.go
+++ b/controllers/network/dnsmasq_controller.go
@@ -259,6 +259,9 @@ func (r *DNSMasqReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.ConfigMap{}).
+		Owns(&corev1.ServiceAccount{}).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
 		Watches(&source.Kind{Type: &corev1.ConfigMap{}},
 			dnsmasqFN,
 			builder.WithPredicates(p)).

--- a/controllers/redis/redis_controller.go
+++ b/controllers/redis/redis_controller.go
@@ -207,5 +207,8 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&redisv1beta1.Redis{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
+		Owns(&corev1.ServiceAccount{}).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
 		Complete(r)
 }


### PR DESCRIPTION
This ensures the controller watches service account, role, and role bindings to reconcile these resources in case any change is made.