### PR TITLE
Add more kuttl tests coverage

### DIFF
--- a/config/samples/rabbitmq_v1beta1_transporturl.yaml
+++ b/config/samples/rabbitmq_v1beta1_transporturl.yaml
@@ -2,6 +2,6 @@ apiVersion: rabbitmq.openstack.org/v1beta1
 kind: TransportURL
 metadata:
   # the name of this resource is used in the transport URL and to name the k8s secret
-  name: cinder
+  name: transporturl
 spec:
   rabbitmqClusterName: rabbitmq

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -18,7 +18,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 reportFormat: JSON
 reportName: kuttl-test-infra
-namespace: openstack
+namespace: infra-kuttl-tests
 timeout: 180
 parallel: 1
 suppress:

--- a/tests/kuttl/tests/memcached/01-assert.yaml
+++ b/tests/kuttl/tests/memcached/01-assert.yaml
@@ -1,0 +1,19 @@
+#
+# Check for:
+#
+# - 1 Memcached CR
+#
+
+apiVersion: memcached.openstack.org/v1beta1
+kind: Memcached
+metadata:
+  name: memcached
+spec:
+  containerImage: quay.io/podified-antelope-centos9/openstack-memcached:current-podified
+  replicas: 1
+status:
+  readyCount: 1
+  serverList:
+  - 'memcached-0.memcached:11211'
+  serverListWithInet:
+  - 'inet:[memcached-0.memcached]:11211'

--- a/tests/kuttl/tests/memcached/01-deploy-memcached.yaml
+++ b/tests/kuttl/tests/memcached/01-deploy-memcached.yaml
@@ -1,0 +1,1 @@
+../../../../config/samples/memcached_v1beta1_memcached.yaml

--- a/tests/kuttl/tests/memcached/05-cleanup-memcached.yaml
+++ b/tests/kuttl/tests/memcached/05-cleanup-memcached.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: memcached.openstack.org/v1beta1
+  kind: Memcached
+  name: memcached

--- a/tests/kuttl/tests/memcached/05-errors.yaml
+++ b/tests/kuttl/tests/memcached/05-errors.yaml
@@ -1,0 +1,10 @@
+#
+# Check for:
+#
+# - No Memcached CR
+#
+
+apiVersion: memcached.openstack.org/v1beta1
+kind: Memcached
+metadata:
+  name: memcached

--- a/tests/kuttl/tests/rabbitmq/01-assert.yaml
+++ b/tests/kuttl/tests/rabbitmq/01-assert.yaml
@@ -1,0 +1,22 @@
+#
+# Check for:
+#
+# - 1 TransportURL CR
+# - 1 Secret for TransporURL CR
+#
+
+apiVersion: rabbitmq.openstack.org/v1beta1
+kind: TransportURL
+metadata:
+  name: cinder
+spec:
+  rabbitmqClusterName: rabbitmq
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rabbitmq-transport-url-cinder
+  ownerReferences:
+  - apiVersion: rabbitmq.openstack.org/v1beta1
+    kind: TransportURL
+    name: cinder

--- a/tests/kuttl/tests/rabbitmq/01-assert.yaml
+++ b/tests/kuttl/tests/rabbitmq/01-assert.yaml
@@ -8,15 +8,15 @@
 apiVersion: rabbitmq.openstack.org/v1beta1
 kind: TransportURL
 metadata:
-  name: cinder
+  name: transporturl
 spec:
   rabbitmqClusterName: rabbitmq
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: rabbitmq-transport-url-cinder
+  name: rabbitmq-transport-url-transporturl
   ownerReferences:
   - apiVersion: rabbitmq.openstack.org/v1beta1
     kind: TransportURL
-    name: cinder
+    name: transporturl

--- a/tests/kuttl/tests/rabbitmq/01-deploy-transporturl.yaml
+++ b/tests/kuttl/tests/rabbitmq/01-deploy-transporturl.yaml
@@ -1,0 +1,1 @@
+../../../../config/samples/rabbitmq_v1beta1_transporturl.yaml

--- a/tests/kuttl/tests/rabbitmq/05-cleanup-transporturl.yaml
+++ b/tests/kuttl/tests/rabbitmq/05-cleanup-transporturl.yaml
@@ -3,4 +3,4 @@ kind: TestStep
 delete:
 - apiVersion: rabbitmq.openstack.org/v1beta1
   kind: TransportURL
-  name: cinder
+  name: transporturl

--- a/tests/kuttl/tests/rabbitmq/05-cleanup-transporturl.yaml
+++ b/tests/kuttl/tests/rabbitmq/05-cleanup-transporturl.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: rabbitmq.openstack.org/v1beta1
+  kind: TransportURL
+  name: cinder

--- a/tests/kuttl/tests/rabbitmq/05-errors.yaml
+++ b/tests/kuttl/tests/rabbitmq/05-errors.yaml
@@ -8,9 +8,9 @@
 apiVersion: rabbitmq.openstack.org/v1beta1
 kind: TransportURL
 metadata:
-  name: cinder
+  name: transporturl
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: rabbitmq-transport-url-cinder
+  name: rabbitmq-transport-url-transporturl

--- a/tests/kuttl/tests/rabbitmq/05-errors.yaml
+++ b/tests/kuttl/tests/rabbitmq/05-errors.yaml
@@ -1,0 +1,16 @@
+#
+# Check for:
+#
+# - No TransportURL CR
+# - No Secret for TransporURL CR
+#
+
+apiVersion: rabbitmq.openstack.org/v1beta1
+kind: TransportURL
+metadata:
+  name: cinder
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rabbitmq-transport-url-cinder


### PR DESCRIPTION
This updates the kuttl tests so that we can test `Memcached` CR and `TransportURL` CR.