### PR TITLE
Revert "[Makefile] Fix cp -a permission issue in make manifests"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: gowork controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases && \
-	rm -rf apis/bases && cp -a config/crd/bases apis/
+	rm -f apis/bases/* && cp -a config/crd/bases apis/
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.


### PR DESCRIPTION
This reverts commit 75a00cd30a5238afbe9171aa1bbc2e654e1bb482.

Reason for revert:
https://github.com/openshift/release/pull/41180 was merged which resolves the permission problem in CI. Thus we can revert the change and use the consistent command.