### PR TITLE
Append default route in routes

### DIFF
--- a/controllers/network/ipset_controller.go
+++ b/controllers/network/ipset_controller.go
@@ -433,6 +433,8 @@ func (r *IPSetReconciler) ensureReservation(
 		}
 		if ipsetNet.DefaultRoute != nil && *ipsetNet.DefaultRoute {
 			ipsetRes.Gateway = subnetDef.Gateway
+			ipsetRes.Routes = append(ipsetRes.Routes,
+				networkv1.Route{Destination: "0.0.0.0/0", Nexthop: *subnetDef.Gateway})
 		}
 		if subnetDef.DNSDomain != nil {
 			ipsetRes.DNSDomain = *subnetDef.DNSDomain


### PR DESCRIPTION
os-net-config used networkconfig templates expect default route appended to other ctlplane static routes.