### PR TITLE
Add test helpers

### DIFF
--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2023 Red Hat
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	base "github.com/openstack-k8s-operators/lib-common/modules/test/helpers"
+)
+
+// InfraTestHelper is a collection of helpers for testing operators. It extends
+// the generic TestHelper from modules/test.
+type InfraTestHelper struct {
+	*base.TestHelper
+}
+
+// NewTestHelper returns a TestHelper
+func NewInfraTestHelper(
+	baseHelper *base.TestHelper,
+) *InfraTestHelper {
+	helper := &InfraTestHelper{}
+	helper.TestHelper = baseHelper
+	return helper
+}

--- a/pkg/test/memcached_helper.go
+++ b/pkg/test/memcached_helper.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2023 Red Hat
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"fmt"
+
+	t "github.com/onsi/gomega"
+	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// CreateMemcached creates a new Memcached instance with the specified namespace in the Kubernetes cluster.
+func (tc *InfraTestHelper) CreateMemcached(namespace string, memcachedName string, spec memcachedv1.MemcachedSpec) types.NamespacedName {
+	name := types.NamespacedName{
+		Name:      memcachedName,
+		Namespace: namespace,
+	}
+
+	mc := &memcachedv1.Memcached{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "memcached.openstack.org/v1beta1",
+			Kind:       "Memcached",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      memcachedName,
+			Namespace: namespace,
+		},
+		Spec: spec,
+	}
+
+	t.Expect(tc.K8sClient.Create(tc.Ctx, mc)).Should(t.Succeed())
+
+	return name
+}
+
+// DeleteMemcached deletes a Memcached instance from the Kubernetes cluster.
+func (tc *InfraTestHelper) DeleteMemcached(name types.NamespacedName) {
+	t.Eventually(func(g t.Gomega) {
+		service := &corev1.Service{}
+		err := tc.K8sClient.Get(tc.Ctx, name, service)
+		// if it is already gone that is OK
+		if k8s_errors.IsNotFound(err) {
+			return
+		}
+		g.Expect(err).NotTo(t.HaveOccurred())
+
+		g.Expect(tc.K8sClient.Delete(tc.Ctx, service)).Should(t.Succeed())
+
+		err = tc.K8sClient.Get(tc.Ctx, name, service)
+		g.Expect(k8s_errors.IsNotFound(err)).To(t.BeTrue())
+	}, tc.Timeout, tc.Interval).Should(t.Succeed())
+}
+
+// GetMemcached waits for and retrieves a Memcached instance from the Kubernetes cluster
+func (tc *InfraTestHelper) GetMemcached(name types.NamespacedName) *memcachedv1.Memcached {
+	mc := &memcachedv1.Memcached{}
+	t.Eventually(func(g t.Gomega) {
+		g.Expect(tc.K8sClient.Get(tc.Ctx, name, mc)).Should(t.Succeed())
+	}, tc.Timeout, tc.Interval).Should(t.Succeed())
+	return mc
+}
+
+// SimulateMemcachedReady simulates a ready state for a Memcached instance in a Kubernetes cluster.
+func (tc *InfraTestHelper) SimulateMemcachedReady(name types.NamespacedName) {
+	t.Eventually(func(g t.Gomega) {
+		mc := tc.GetMemcached(name)
+		mc.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
+		mc.Status.ReadyCount = *mc.Spec.Replicas
+
+		serverList := []string{}
+		serverListWithInet := []string{}
+		for i := 0; i < int(*mc.Spec.Replicas); i++ {
+			serverList = append(serverList, fmt.Sprintf("%s-%d.%s:11211", mc.Name, i, mc.Name))
+			serverListWithInet = append(serverListWithInet, fmt.Sprintf("inet:[%s-%d.%s]:11211", mc.Name, i, mc.Name))
+		}
+		mc.Status.ServerList = serverList
+		mc.Status.ServerListWithInet = serverListWithInet
+
+		// This can return conflict so we have the t.Eventually block to retry
+		g.Expect(tc.K8sClient.Status().Update(tc.Ctx, mc)).To(t.Succeed())
+
+	}, tc.Timeout, tc.Interval).Should(t.Succeed())
+
+	tc.Logger.Info("Simulated memcached ready", "on", name)
+}

--- a/pkg/test/rabbitmq_helper.go
+++ b/pkg/test/rabbitmq_helper.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2023 Red Hat
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"github.com/onsi/gomega"
+	rabbitmqv1 "github.com/openstack-k8s-operators/infra-operator/apis/rabbitmq/v1beta1"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// GetTransportURL retrieves a TransportURL resource with the specified name.
+//
+// Example usage:
+//
+//	th.GetTransportURL(types.NamespacedName{Name: "test-transporturl", Namespace: "test-namespace"})
+func (tc *InfraTestHelper) GetTransportURL(name types.NamespacedName) *rabbitmqv1.TransportURL {
+	instance := &rabbitmqv1.TransportURL{}
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect(tc.K8sClient.Get(tc.Ctx, name, instance)).Should(gomega.Succeed())
+	}, tc.Timeout, tc.Interval).Should(gomega.Succeed())
+	return instance
+}
+
+// SimulateTransportURLReady function retrieves the TransportURL and
+// simulates the readiness of a TransportURL resource.
+//
+// Example usage:
+//
+//	th.SimulateTransportURLReady(types.NamespacedName{Name: "test-transporturl", Namespace: "test-namespace"})
+func (tc *InfraTestHelper) SimulateTransportURLReady(name types.NamespacedName) {
+	gomega.Eventually(func(g gomega.Gomega) {
+		transport := tc.GetTransportURL(name)
+		transport.Status.SecretName = transport.Spec.RabbitmqClusterName + "-secret"
+		transport.Status.Conditions.MarkTrue("TransportURLReady", "Ready")
+		g.Expect(tc.K8sClient.Status().Update(tc.Ctx, transport)).To(gomega.Succeed())
+
+	}, tc.Timeout, tc.Interval).Should(gomega.Succeed())
+	tc.Logger.Info("Simulated TransportURL ready", "on", name)
+}
+
+// AssertTransportURLDoesNotExist ensures the TransportURL resource does not exist in a k8s cluster.
+func (tc *InfraTestHelper) AssertTransportURLDoesNotExist(name types.NamespacedName) {
+	instance := &rabbitmqv1.TransportURL{}
+	gomega.Eventually(func(g gomega.Gomega) {
+		err := tc.K8sClient.Get(tc.Ctx, name, instance)
+		g.Expect(k8s_errors.IsNotFound(err)).To(gomega.BeTrue())
+	}, tc.Timeout, tc.Interval).Should(gomega.Succeed())
+}


### PR DESCRIPTION
This imports test helpers for Memcached and TransportURL from lib-common to resolve the circular dependencies between infra-operator and lib-common.