### PR TITLE
Stop executing zuul jobs in test code change

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -9,7 +9,7 @@
           src: "~/src/github.com/{{ cifmw_operator_build_org }}/openstack-operator"
           image_base: infra
     irrelevant-files: &irrev
-      - tests/kuttl
+      - tests/
       - docs
       - containers/ci
       - .github/workflows


### PR DESCRIPTION
We don't have to run zuul jobs when the change affects only kuttl tests or env tests.