### PR TITLE
Fix link and maturity in csv

### DIFF
--- a/config/manifests/bases/infra-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/infra-operator.clusterserviceversion.yaml
@@ -74,8 +74,8 @@ spec:
   - Infrastructure
   links:
   - name: Infra Operator
-    url: https://infra-operator.domain
-  maturity: alpha
+    url: https://github.com/openstack-k8s-operators/infra-operator
+  maturity: beta
   provider:
     name: Red Hat Inc.
     url: https://redhat.com/


### PR DESCRIPTION
The existing link is invalid. Also maturity was not consistent with API version(v1beta) currently presented by this operator.