### PR TITLE
Support disconnected network environments

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: tools
   namespace: openstack-k8s-operators
-  tag: ci-build-root-golang-1.19-sdk-1.26
+  tag: ci-build-root-golang-1.19-sdk-1.31

--- a/.github/create_bundle.sh
+++ b/.github/create_bundle.sh
@@ -1,69 +1,16 @@
 #!/bin/bash
 set -e
 
-CLUSTER_BUNDLE_FILE="bundle/manifests/infra-operator.clusterserviceversion.yaml"
-
-echo "Creating openstack operator bundle"
+echo "Creating infra operator bundle"
 cd ..
 echo "${GITHUB_SHA}"
 echo "${BASE_IMAGE}"
-skopeo --version
-
-echo "Calculating image digest for docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA}"
-DIGEST=$(skopeo inspect docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA} | jq '.Digest' -r)
-# Output:
-# Calculating image digest for docker://quay.io/openstack-k8s-operators/infra-operator:d03f2c1c362c04fc5ef819f92a218f9ea59bbd0c
-# Digest: sha256:1d5b578fd212f8dbd03c0235f1913ef738721766f8c94236af5efecc6d8d8cb1
-echo "Digest: ${DIGEST}"
 
 RELEASE_VERSION=$(grep "^VERSION" Makefile | awk -F'?= ' '{ print $2 }')
-OPERATOR_IMG_WITH_DIGEST="${REGISTRY}/${BASE_IMAGE}@${DIGEST}"
-
-echo "New Operator Image with Digest: $OPERATOR_IMG_WITH_DIGEST"
 echo "Release Version: $RELEASE_VERSION"
 
+#FIXME(dprince) just a test to see if this works in CI
+skopeo inspect docker://registry.redhat.io/rhel9/redis-6:latest
+
 echo "Creating bundle image..."
-VERSION=$RELEASE_VERSION IMG=$OPERATOR_IMG_WITH_DIGEST make bundle
-
-echo "Bundle file images:"
-cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
-# FIXME: display any ENV variables once we have offline support implemented
-#grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"
-
-# We do not want to exit here. Some images are in different registries, so
-# error will be reported to the console.
-set +e
-for csv_image in $(cat "${CLUSTER_BUNDLE_FILE}" | grep "image:" | sed -e "s|.*image:||" | sort -u); do
-  digest_image=""
-  echo "CSV line: ${csv_image}"
-
-  # case where @ is in the csv_image image
-  if [[ "$csv_image" =~ .*"@".* ]]; then
-    delimeter='@'
-  else
-    delimeter=':'
-  fi
-
-  base_image=$(echo $csv_image | cut -f 1 -d${delimeter})
-  tag_image=$(echo $csv_image | cut -f 2 -d${delimeter})
-
-  if [[ "$base_image:$tag_image" == "controller:latest" ]]; then
-    echo "$base_image:$tag_image becomes $OPERATOR_IMG_WITH_DIGEST"
-    sed -e "s|$base_image:$tag_image|$OPERATOR_IMG_WITH_DIGEST|g" -i "${CLUSTER_BUNDLE_FILE}"
-  else
-    digest_image=$(skopeo inspect docker://${base_image}${delimeter}${tag_image} | jq '.Digest' -r)
-    echo "Base image: $base_image"
-    if [ -n "$digest_image" ]; then
-      echo "$base_image${delimeter}$tag_image becomes $base_image@$digest_image"
-      sed -i "s|$base_image$delimeter$tag_image|$base_image@$digest_image|g" "${CLUSTER_BUNDLE_FILE}"
-    else
-      echo "$base_image${delimeter}$tag_image not changed"
-    fi
-  fi
-done
-
-echo "Resulting bundle file images:"
-cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
-
-# FIXME: display any ENV variables once we have offline support implemented
-#grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"
+USE_IMAGE_DIGESTS=true VERSION=$RELEASE_VERSION IMG=${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA} make bundle

--- a/.github/create_bundle.sh
+++ b/.github/create_bundle.sh
@@ -9,8 +9,5 @@ echo "${BASE_IMAGE}"
 RELEASE_VERSION=$(grep "^VERSION" Makefile | awk -F'?= ' '{ print $2 }')
 echo "Release Version: $RELEASE_VERSION"
 
-#FIXME(dprince) just a test to see if this works in CI
-skopeo inspect docker://registry.redhat.io/rhel9/redis-6:latest
-
 echo "Creating bundle image..."
 USE_IMAGE_DIGESTS=true VERSION=$RELEASE_VERSION IMG=${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA} make bundle

--- a/.github/workflows/build-infra-operator.yaml
+++ b/.github/workflows/build-infra-operator.yaml
@@ -77,7 +77,7 @@ jobs:
       uses: redhat-actions/openshift-tools-installer@v1
       with:
         source: github
-        operator-sdk: '1.23.0'
+        operator-sdk: '1.31.0'
 
     - name: Log in to Quay Registry
       uses: redhat-actions/podman-login@v1

--- a/.prow_ci.env
+++ b/.prow_ci.env
@@ -1,0 +1,1 @@
+export USE_IMAGE_DIGESTS=true

--- a/apis/memcached/v1beta1/memcached_types.go
+++ b/apis/memcached/v1beta1/memcached_types.go
@@ -107,7 +107,7 @@ func (instance Memcached) RbacResourceName() string {
 func SetupDefaults() {
 	// Acquire environmental defaults and initialize Memcached defaults with them
 	memcachedDefaults := MemcachedDefaults{
-		ContainerImageURL: util.GetEnvVar("INFRA_MEMCACHED_IMAGE_URL_DEFAULT", MemcachedContainerImage),
+		ContainerImageURL: util.GetEnvVar("RELATED_IMAGE_INFRA_MEMCACHED_IMAGE_URL_DEFAULT", MemcachedContainerImage),
 	}
 
 	SetupMemcachedDefaults(memcachedDefaults)

--- a/apis/network/v1beta1/dnsmasq_types.go
+++ b/apis/network/v1beta1/dnsmasq_types.go
@@ -185,7 +185,7 @@ func (s DNSMasqStatus) GetConditions() condition.Conditions {
 func SetupDefaults() {
 	// Acquire environmental defaults and initialize DNSMasq defaults with them
 	dnsMasqDefaults := DNSMasqDefaults{
-		ContainerImageURL: util.GetEnvVar("INFRA_DNSMASQ_IMAGE_URL_DEFAULT", DNSMasqContainerImage),
+		ContainerImageURL: util.GetEnvVar("RELATED_IMAGE_INFRA_DNSMASQ_IMAGE_URL_DEFAULT", DNSMasqContainerImage),
 	}
 
 	SetupDNSMasqDefaults(dnsMasqDefaults)

--- a/apis/redis/v1beta1/redis_types.go
+++ b/apis/redis/v1beta1/redis_types.go
@@ -97,7 +97,7 @@ func (instance Redis) RbacResourceName() string {
 func SetupDefaults() {
 	// Acquire environmental defaults and initialize Redis defaults with them
 	redisDefaults := RedisDefaults{
-		ContainerImageURL: util.GetEnvVar("INFRA_REDIS_IMAGE_URL_DEFAULT", RedisContainerImage),
+		ContainerImageURL: util.GetEnvVar("RELATED_IMAGE_INFRA_REDIS_IMAGE_URL_DEFAULT", RedisContainerImage),
 	}
 
 	SetupRedisDefaults(redisDefaults)

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -11,10 +11,10 @@ spec:
       containers:
       - name: manager
         env:
-        - name: INFRA_MEMCACHED_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_INFRA_MEMCACHED_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-memcached:current-podified
-        - name: INFRA_REDIS_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_INFRA_REDIS_IMAGE_URL_DEFAULT
           value: registry.redhat.io/rhel9/redis-6:latest
         # TODO create its own container image, instead of using neutron one
-        - name: INFRA_DNSMASQ_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_INFRA_DNSMASQ_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-neutron-server:current-podified

--- a/config/manifests/bases/infra-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/infra-operator.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/operator-type: non-standalone
   name: infra-operator.v0.0.0
   namespace: placeholder

--- a/tests/kuttl/tests/memcached/01-assert.yaml
+++ b/tests/kuttl/tests/memcached/01-assert.yaml
@@ -9,7 +9,6 @@ kind: Memcached
 metadata:
   name: memcached
 spec:
-  containerImage: quay.io/podified-antelope-centos9/openstack-memcached:current-podified
   replicas: 1
 status:
   readyCount: 1


### PR DESCRIPTION
This PR adds support for installing the operator in disconnected network environments. To build with image-digests set USE_IMAGE_DIGESTS=true before running make bundle.

For Prow jobs we are enabling this via .prow-ci.env

This drops the old logic from create_bundle.sh which has been broken with operator-sdk's make bundle for some time.

(NOTE: this currently requires a secure registry)