### PR TITLE
Allow no-negcache option in dnsmasq

### DIFF
--- a/apis/bases/network.openstack.org_dnsmasqs.yaml
+++ b/apis/bases/network.openstack.org_dnsmasqs.yaml
@@ -124,6 +124,7 @@ spec:
                       - dns-rr
                       - auth-zone
                       - synth-domain
+                      - no-negcache
                       type: string
                     values:
                       items:

--- a/apis/network/v1beta1/dnsmasq_types.go
+++ b/apis/network/v1beta1/dnsmasq_types.go
@@ -38,7 +38,7 @@ const (
 
 // DNSMasqOption defines allowed options for dnsmasq
 type DNSMasqOption struct {
-	// +kubebuilder:validation:Enum=server;rev-server;srv-host;txt-record;ptr-record;rebind-domain-ok;naptr-record;cname;host-record;caa-record;dns-rr;auth-zone;synth-domain
+	// +kubebuilder:validation:Enum=server;rev-server;srv-host;txt-record;ptr-record;rebind-domain-ok;naptr-record;cname;host-record;caa-record;dns-rr;auth-zone;synth-domain;no-negcache
 	Key    string   `json:"key"`
 	Values []string `json:"values"`
 }

--- a/config/crd/bases/network.openstack.org_dnsmasqs.yaml
+++ b/config/crd/bases/network.openstack.org_dnsmasqs.yaml
@@ -124,6 +124,7 @@ spec:
                       - dns-rr
                       - auth-zone
                       - synth-domain
+                      - no-negcache
                       type: string
                     values:
                       items:

--- a/controllers/network/dnsmasq_controller.go
+++ b/controllers/network/dnsmasq_controller.go
@@ -475,9 +475,12 @@ func (r *DNSMasqReconciler) generateServiceConfigMaps(
 
 	var cfg string
 	for _, option := range instance.Spec.Options {
-		cfg += option.Key + "="
-		values := strings.Join(option.Values, ",")
-		cfg += values + "\n"
+		cfg += option.Key
+		if len(option.Values) > 0 {
+			values := strings.Join(option.Values, ",")
+			cfg += "=" + values
+		}
+		cfg += "\n"
 	}
 	configMapData[instance.Name] = cfg
 


### PR DESCRIPTION
This option allows to not cache the NXDOMAIN nor any other negative answer from the forwarders.

This is especially interesting when a DNS query happens when an operator endpoint isn't 100% ready, meaning its DNS record isn't known from the internal openshift-dns services.

Without that option, the dnsmasq service will cache the NXDOMAIN for the default TTL duration, meaning it will serve the cached answer instead of checking back.