### PR TITLE
Add missing tests for no-negcache option

### DIFF
--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -70,6 +70,10 @@ func GetDefaultDNSMasqSpec() map[string]interface{} {
 			Key:    "server",
 			Values: []string{"1.1.1.1"},
 		},
+		{
+			Key:    "no-negcache",
+			Values: []string{},
+		},
 	})
 
 	var externalEndpoints []interface{}

--- a/tests/functional/dnsmasq_controller_test.go
+++ b/tests/functional/dnsmasq_controller_test.go
@@ -128,6 +128,8 @@ var _ = Describe("DNSMasq controller", func() {
 			Expect(configData).ShouldNot(BeNil())
 			Expect(configData.Data[dnsMasqName.Name]).Should(
 				ContainSubstring("server=1.1.1.1"))
+			Expect(configData.Data[dnsMasqName.Name]).Should(
+				ContainSubstring("no-negcache\n"))
 			Expect(configData.Labels["dnsmasq.openstack.org/name"]).To(Equal(dnsMasqName.Name))
 		})
 


### PR DESCRIPTION
Following #114, we need to ensure the formatting is correct for option without any value such as the new no-negcache one we added.