### PR TITLE
Remove "tripleo" from Network/Subnet description

### DIFF
--- a/apis/bases/network.openstack.org_netconfigs.yaml
+++ b/apis/bases/network.openstack.org_netconfigs.yaml
@@ -39,7 +39,7 @@ spec:
             description: NetConfigSpec defines the desired state of NetConfig
             properties:
               networks:
-                description: Networks, list of all tripleo networks of the deployment
+                description: Networks, list of all networks of the deployment
                 items:
                   description: Network definition
                   properties:
@@ -56,7 +56,7 @@ spec:
                       pattern: ^[a-zA-Z0-9][a-zA-Z0-9\-_]*[a-zA-Z0-9]$
                       type: string
                     subnets:
-                      description: Subnets of the tripleo network
+                      description: Subnets of the network
                       items:
                         description: Subnet definition
                         properties:

--- a/apis/network/v1beta1/netconfig_types.go
+++ b/apis/network/v1beta1/netconfig_types.go
@@ -43,7 +43,7 @@ type Network struct {
 	MTU int `json:"mtu"`
 
 	// +kubebuilder:validation:Required
-	// Subnets of the tripleo network
+	// Subnets of the network
 	Subnets []Subnet `json:"subnets"`
 }
 
@@ -110,7 +110,7 @@ type Route struct {
 // NetConfigSpec defines the desired state of NetConfig
 type NetConfigSpec struct {
 	// +kubebuilder:validation:Required
-	// Networks, list of all tripleo networks of the deployment
+	// Networks, list of all networks of the deployment
 	Networks []Network `json:"networks"`
 }
 

--- a/config/crd/bases/network.openstack.org_netconfigs.yaml
+++ b/config/crd/bases/network.openstack.org_netconfigs.yaml
@@ -39,7 +39,7 @@ spec:
             description: NetConfigSpec defines the desired state of NetConfig
             properties:
               networks:
-                description: Networks, list of all tripleo networks of the deployment
+                description: Networks, list of all networks of the deployment
                 items:
                   description: Network definition
                   properties:
@@ -56,7 +56,7 @@ spec:
                       pattern: ^[a-zA-Z0-9][a-zA-Z0-9\-_]*[a-zA-Z0-9]$
                       type: string
                     subnets:
-                      description: Subnets of the tripleo network
+                      description: Subnets of the network
                       items:
                         description: Subnet definition
                         properties:


### PR DESCRIPTION
The description for networks and subnet uses the "triple network" and "tripleo subnet" wording. Drop "tripleo", it as it is not relevant.