### PR TITLE
Fix bundle validations (add sample reservation)

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -66,11 +66,6 @@ resources:
   kind: DNSData
   path: github.com/openstack-k8s-operators/infra-operator/apis/network/v1beta1
   version: v1beta1
-- controller: true
-  domain: openstack.org
-  group: network
-  kind: Service
-  version: v1beta1
 - api:
     crdVersion: v1
     namespaced: true

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
 - network_v1beta1_dnsdata.yaml
 - network_v1beta1_netconfig.yaml
 - network_v1beta1_ipset.yaml
+- network_v1beta1_reservation.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/network_v1beta1_reservation.yaml
+++ b/config/samples/network_v1beta1_reservation.yaml
@@ -1,0 +1,30 @@
+apiVersion: network.openstack.org/v1beta1
+kind: Reservation
+metadata:
+  name: edpm-compute-0
+spec:
+  ipSetRef:
+    name: edpm-compute-0
+    namespace: openstack
+    uid: 56753ffb-e486-43ab-a79a-f85f27b2ac14
+  reservation:
+    CtlPlane:
+      address: 192.168.122.100
+      network: CtlPlane
+      subnet: subnet1
+    InternalApi:
+      address: 172.17.0.100
+      network: InternalApi
+      subnet: subnet1
+    Storage:
+      address: 172.18.0.100
+      network: Storage
+      subnet: subnet1
+    StorageMgmt:
+      address: 172.20.0.100
+      network: StorageMgmt
+      subnet: subnet1
+    Tenant:
+      address: 172.19.0.100
+      network: Tenant
+      subnet: subnet1


### PR DESCRIPTION
This PR fixes some bundle validations:

WARN[0000] Skipping definitions parsing for API {}: Go type not found
WARN[0000] Warning: Value network.openstack.org/v1beta1, Kind=Reservation: provided API should have an example annotation

Adds a sample for the Reservation CR. Even though this is only used internally it won't hurt to add it.

Additionally, removes the 'service' definition from PROJECT as it only has a controller.