### PR TITLE
Make the network names case insensitive

### DIFF
--- a/apis/network/v1beta1/ipset_webhook.go
+++ b/apis/network/v1beta1/ipset_webhook.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	"golang.org/x/exp/slices"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -179,14 +180,14 @@ func valiateIPSetNetwork(
 
 		// validate if requested network is in NetConfig
 		f := func(n Network) bool {
-			return n.Name == _net.Name
+			return strings.EqualFold(string(n.Name), string(_net.Name))
 		}
 		netIdx := slices.IndexFunc(netCfgSpec.Networks, f)
 
 		if netIdx >= 0 {
 			// validate if requested subnet is in NetConfig
 			f := func(n Subnet) bool {
-				return n.Name == _net.SubnetName
+				return strings.EqualFold(string(n.Name), string(_net.SubnetName))
 			}
 			subNetIdx := slices.IndexFunc(netCfgSpec.Networks[netIdx].Subnets, f)
 

--- a/apis/network/v1beta1/netconfig_types.go
+++ b/apis/network/v1beta1/netconfig_types.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	"fmt"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -147,11 +148,11 @@ func init() {
 // GetNet returns the network with name
 func (instance NetConfig) GetNet(name NetNameStr) (*Network, error) {
 	for _, net := range instance.Spec.Networks {
-		if net.Name == name {
+		if strings.EqualFold(string(net.Name), string(name)) {
 			return &net, nil
 		}
 	}
-	return nil, fmt.Errorf("No network with name: %s", name)
+	return nil, fmt.Errorf("no network with name: %s", name)
 }
 
 // GetNetAndSubnet returns the network and subnet with name
@@ -161,9 +162,9 @@ func (instance NetConfig) GetNetAndSubnet(name NetNameStr, subnetName NetNameStr
 		return nil, nil, err
 	}
 	for _, subnet := range net.Subnets {
-		if subnet.Name == subnetName {
+		if strings.EqualFold(string(subnet.Name), string(subnetName)) {
 			return net, &subnet, nil
 		}
 	}
-	return nil, nil, fmt.Errorf("No subnet found with name: %s in network: %s", subnetName, name)
+	return nil, nil, fmt.Errorf("no subnet found with name: %s in network: %s", subnetName, name)
 }

--- a/config/samples/network_v1beta1_netconfig.yaml
+++ b/config/samples/network_v1beta1_netconfig.yaml
@@ -4,7 +4,7 @@ metadata:
   name: netconfig
 spec:
   networks:
-  - name: CtlPlane
+  - name: ctlplane
     dnsDomain: ctlplane.example.com
     subnets:
     - name: subnet1
@@ -15,7 +15,7 @@ spec:
         start: 192.168.122.150
       cidr: 192.168.122.0/24
       gateway: 192.168.122.1
-  - name: InternalApi
+  - name: internalapi
     dnsDomain: internalapi.example.com
     subnets:
     - name: subnet1
@@ -24,7 +24,7 @@ spec:
         start: 172.17.0.100
       cidr: 172.17.0.0/24
       vlan: 20
-  - name: External
+  - name: external
     dnsDomain: external.example.com
     subnets:
     - name: subnet1
@@ -33,7 +33,7 @@ spec:
         start: 10.0.0.100
       cidr: 10.0.0.0/24
       gateway: 10.0.0.1
-  - name: Storage
+  - name: storage
     dnsDomain: storage.example.com
     subnets:
     - name: subnet1
@@ -42,7 +42,7 @@ spec:
         start: 172.18.0.100
       cidr: 172.18.0.0/24
       vlan: 21
-  - name: StorageMgmt
+  - name: storagemgmt
     dnsDomain: storagemgmt.example.com
     subnets:
     - name: subnet1
@@ -51,7 +51,7 @@ spec:
         start: 172.20.0.100
       cidr: 172.20.0.0/24
       vlan: 23
-  - name: Tenant
+  - name: tenant
     dnsDomain: tenant.example.com
     subnets:
     - name: subnet1

--- a/controllers/network/ipset_controller.go
+++ b/controllers/network/ipset_controller.go
@@ -408,7 +408,7 @@ func (r *IPSetReconciler) ensureReservation(
 
 		ipDetails := ipam.AssignIPDetails{
 			IPSet:       ipset.Name,
-			NetName:     string(ipsetNet.Name),
+			NetName:     string(netDef.Name),
 			SubNet:      subnetDef,
 			Reservelist: reservations,
 		}
@@ -416,20 +416,20 @@ func (r *IPSetReconciler) ensureReservation(
 		if ipsetNet.FixedIP != nil {
 			ipDetails.FixedIP = net.ParseIP(string(*ipsetNet.FixedIP))
 			if ipDetails.FixedIP == nil {
-				return nil, fmt.Errorf("Failed parse FixedIP %s", string(*ipsetNet.FixedIP))
+				return nil, fmt.Errorf("failed parse FixedIP %s", string(*ipsetNet.FixedIP))
 			}
 		}
 
 		ip, err := ipDetails.AssignIP()
 		if err != nil {
-			return nil, fmt.Errorf("Failed to do ip reservation: %w", err)
+			return nil, fmt.Errorf("failed to do ip reservation: %w", err)
 		}
 
 		// add IP to the reservation and IPSet status reservations
 		reservationSpec.Reservation[string(ipsetNet.Name)] = *ip
 		ipsetRes := networkv1.IPSetReservation{
-			Network:   ipsetNet.Name,
-			Subnet:    ipsetNet.SubnetName,
+			Network:   netDef.Name,
+			Subnet:    subnetDef.Name,
 			Address:   ip.Address,
 			MTU:       netDef.MTU,
 			Cidr:      subnetDef.Cidr,

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -18,6 +18,7 @@ package functional_test
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/onsi/gomega"
@@ -44,10 +45,12 @@ const (
 	interval       = timeout / 100
 	containerImage = "test-dnsmasq-container-image"
 
-	net1    = "net-1"
-	net2    = "net-2"
-	subnet1 = "subnet1"
-	host1   = "host1"
+	net1     = "net-1"
+	uNet1    = "Net-1"
+	net2     = "net-2"
+	subnet1  = "subnet1"
+	uSubnet1 = "Subnet1"
+	host1    = "host1"
 )
 
 func CreateDNSMasq(namespace string, spec map[string]interface{}) client.Object {
@@ -467,7 +470,7 @@ func GetNetConfigSpec(nets ...networkv1.Network) map[string]interface{} {
 func GetNetSpec(name string, subnets ...networkv1.Subnet) networkv1.Network {
 	net := networkv1.Network{
 		Name:      networkv1.NetNameStr(name),
-		DNSDomain: fmt.Sprintf("%s.example.com", name),
+		DNSDomain: fmt.Sprintf("%s.example.com", strings.ToLower(name)),
 		MTU:       1400,
 		Subnets:   []networkv1.Subnet{},
 	}
@@ -570,8 +573,8 @@ func GetDefaultIPSetSpec() map[string]interface{} {
 
 func GetIPSetNet1() networkv1.IPSetNetwork {
 	return networkv1.IPSetNetwork{
-		Name:       net1,
-		SubnetName: subnet1,
+		Name:       uNet1,
+		SubnetName: uSubnet1,
 	}
 }
 
@@ -599,7 +602,7 @@ func GetReservationFromNet(ipsetName types.NamespacedName, netName string) netwo
 	}, timeout, interval).Should(Succeed())
 
 	for _, ipSetRes := range ipSet.Status.Reservation {
-		if string(ipSetRes.Network) == netName {
+		if strings.EqualFold(string(ipSetRes.Network), netName) {
 			res = ipSetRes
 			break
 		}


### PR DESCRIPTION
This could be a temporary change to make dataplane networks small case and align with what we use in
control plane network attachments etc or permanent if we want to make networks/subnets case in-sensitive.
