### PR TITLE
Create reservations using the networks in NetConfig

### DIFF
--- a/controllers/network/ipset_controller.go
+++ b/controllers/network/ipset_controller.go
@@ -426,7 +426,7 @@ func (r *IPSetReconciler) ensureReservation(
 		}
 
 		// add IP to the reservation and IPSet status reservations
-		reservationSpec.Reservation[string(ipsetNet.Name)] = *ip
+		reservationSpec.Reservation[string(netDef.Name)] = *ip
 		ipsetRes := networkv1.IPSetReservation{
 			Network:   netDef.Name,
 			Subnet:    subnetDef.Name,


### PR DESCRIPTION
Otherwise networks in reservations does not match that of NetConfig and hence reservations don't work if there are more than one node.