### PR TITLE
[DNSMasq]Check delete before creating ServiceAccount

### DIFF
--- a/controllers/network/dnsmasq_controller.go
+++ b/controllers/network/dnsmasq_controller.go
@@ -165,6 +165,11 @@ func (r *DNSMasqReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		instance.Status.Hash = map[string]string{}
 	}
 
+	// Handle service delete
+	if !instance.DeletionTimestamp.IsZero() {
+		return r.reconcileDelete(ctx, instance, helper)
+	}
+
 	// Service account, role, binding
 	rbacRules := []rbacv1.PolicyRule{
 		{
@@ -184,11 +189,6 @@ func (r *DNSMasqReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		return rbacResult, err
 	} else if (rbacResult != ctrl.Result{}) {
 		return rbacResult, nil
-	}
-
-	// Handle service delete
-	if !instance.DeletionTimestamp.IsZero() {
-		return r.reconcileDelete(ctx, instance, helper)
 	}
 
 	// Handle non-deleted clusters


### PR DESCRIPTION
When the namespace is deleted ServiceAccount creation will fail and because that runs before checking if the DNSMasq is being deleted too the DNSMasq will never be deleted. This patch moves the check before the SA creation.

Fixes: [OSP-27793](https://issues.redhat.com//browse/OSP-27793)