### PR TITLE
[memcached]Fix nil dereference during Service create

### DIFF
--- a/controllers/memcached/memcached_controller.go
+++ b/controllers/memcached/memcached_controller.go
@@ -217,7 +217,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 			condition.ErrorReason,
 			condition.SeverityWarning,
 			condition.ExposeServiceReadyErrorMessage,
-			err.Error()))
+			serr.Error()))
 		return sres, serr
 	}
 


### PR DESCRIPTION
When service creation fails the reconciler uses the `err` variable but the error is stored in `serr` instead so `err` is nil.

```
2024-02-13T16:31:10Z	INFO	Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference	{"controller": "memcached", "controllerGroup": "memcached.openstack.org", "controllerKind": "Memcached", "Memcached": {"name":"memcached","namespace":"openstack"}, "namespace": "openstack", "name": "memcached", "reconcileID": "f293fe77-a1f7-4b39-8741-f357073ca685"}
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x16345f1]

goroutine 512 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.7/pkg/internal/controller/controller.go:119 +0x1fa
panic({0x181abc0, 0x2956790})
	/usr/local/go/src/runtime/panic.go:884 +0x212
github.com/openstack-k8s-operators/infra-operator/controllers/memcached.(*Reconciler).Reconcile(0xc0005b2e40, {0x1ccef58, 0xc0020e9d10}, {{{0xc0041f4f40?, 0x9?}, {0xc0041f4fd0?, 0x9?}}})
	/remote-source/controllers/memcached/memcached_controller.go:220 +0x1191
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x1ccef58?, {0x1ccef58?, 0xc0020e9d10?}, {{{0xc0041f4f40?, 0x1750940?}, {0xc0041f4fd0?, 0x0?}}})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.7/pkg/internal/controller/controller.go:122 +0xc8
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0004477c0, {0x1cceeb0, 0xc00087aa40}, {0x1893880?, 0xc002464060?})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.7/pkg/internal/controller/controller.go:323 +0x3a5
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0004477c0, {0x1cceeb0, 0xc00087aa40})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.7/pkg/internal/controller/controller.go:274 +0x1d9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.7/pkg/internal/controller/controller.go:235 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.7/pkg/internal/controller/controller.go:231 +0x333
```