### PR TITLE
[memcached] add funcs to return quoted serverList and update test helpers

### DIFF
--- a/apis/memcached/v1beta1/memcached_funcs.go
+++ b/apis/memcached/v1beta1/memcached_funcs.go
@@ -62,10 +62,22 @@ func (instance *Memcached) GetMemcachedServerListString() string {
 	return strings.Join(instance.Status.ServerList, ",")
 }
 
+// GetMemcachedServerListQuotedString - return the memcached servers, each quoted, as comma separated list
+// to be used in OpenStack config.
+func (instance *Memcached) GetMemcachedServerListQuotedString() string {
+	return "'" + strings.Join(instance.Status.ServerList, "','") + "'"
+}
+
 // GetMemcachedServerListWithInetString - return the memcached servers as comma separated list
 // to be used in OpenStack config.
 func (instance *Memcached) GetMemcachedServerListWithInetString() string {
-	return strings.Join(instance.Status.ServerListWithInet, ",")
+	return strings.Join(instance.Status.ServerListWithInet, "','")
+}
+
+// GetMemcachedServerListWithInetQuotedString - return the memcached servers, each quoted, as comma separated list
+// to be used in OpenStack config.
+func (instance *Memcached) GetMemcachedServerListWithInetQuotedString() string {
+	return "'" + strings.Join(instance.Status.ServerListWithInet, "','") + "'"
 }
 
 // GetMemcachedTLSSupport - return the TLS support of the memcached instance

--- a/apis/test/helpers/memcached.go
+++ b/apis/test/helpers/memcached.go
@@ -112,8 +112,8 @@ func (tc *TestHelper) SimulateMemcachedReady(name types.NamespacedName) {
 		serverList := []string{}
 		serverListWithInet := []string{}
 		for i := 0; i < int(*mc.Spec.Replicas); i++ {
-			serverList = append(serverList, fmt.Sprintf("%s-%d.%s:11211", mc.Name, i, mc.Name))
-			serverListWithInet = append(serverListWithInet, fmt.Sprintf("inet:[%s-%d.%s]:11211", mc.Name, i, mc.Name))
+			serverList = append(serverList, fmt.Sprintf("%s-%d.%s.%s.svc:11211", mc.Name, i, mc.Name, mc.Namespace))
+			serverListWithInet = append(serverListWithInet, fmt.Sprintf("inet:[%s-%d.%s.%s.svc]:11211", mc.Name, i, mc.Name, mc.Namespace))
 		}
 		mc.Status.ServerList = serverList
 		mc.Status.ServerListWithInet = serverListWithInet


### PR DESCRIPTION
For tls, in https://github.com/openstack-k8s-operators/infra-operator/pull/192 changed the server lists to contain the svc fqdn, but missed to update the test helpers.