### PR TITLE
[ipset] add validation in ipset webhook for default gw to be configured

### DIFF
--- a/apis/network/v1beta1/common_webhook.go
+++ b/apis/network/v1beta1/common_webhook.go
@@ -34,6 +34,7 @@ const (
 	errFixedIPChanged         = "fixedIP must not change"
 	errDefaultRouteChanged    = "defaultRoute must not change"
 	errMultiDefaultRoute      = "%s defaultRoute can only be requested on a singe network"
+	errNoDefaultRoute         = "defaultRoute requested, but not configured for subnet %s"
 )
 
 func getNetConfig(

--- a/apis/network/v1beta1/ipset_webhook.go
+++ b/apis/network/v1beta1/ipset_webhook.go
@@ -194,9 +194,9 @@ func valiateIPSetNetwork(
 
 			if subNetIdx >= 0 {
 				// net and subnet are valid
-
+				subNetCfg := netCfgSpec.Networks[netIdx].Subnets[subNetIdx]
 				if _net.FixedIP != nil || _net.DefaultRoute != nil {
-					cidr := netCfgSpec.Networks[netIdx].Subnets[subNetIdx].Cidr
+					cidr := subNetCfg.Cidr
 					_, ipPrefix, ipPrefixErr := net.ParseCIDR(cidr)
 					if ipPrefixErr != nil {
 						// this should never happen as the subnet CIDR was already validated
@@ -222,6 +222,11 @@ func valiateIPSetNetwork(
 							if count > 1 {
 								allErrs = append(allErrs, field.Invalid(path.Child("defaultRoute"), _net.Name, fmt.Sprintf(errMultiDefaultRoute, string(fam))))
 							}
+						}
+
+						// validate that default GW is configured on subnet when requested
+						if subNetCfg.Gateway == nil || (subNetCfg.Gateway != nil && *subNetCfg.Gateway == "") {
+							allErrs = append(allErrs, field.Invalid(path.Child("defaultRoute"), _net.Name, fmt.Sprintf(errNoDefaultRoute, subNetCfg.Name)))
 						}
 					}
 				}

--- a/apis/network/v1beta1/ipset_webhook_test.go
+++ b/apis/network/v1beta1/ipset_webhook_test.go
@@ -261,6 +261,26 @@ func TestIPSetValiateIPSetNetwork(t *testing.T) {
 			},
 			n: getDefaultIPv4IPv6NetConfigSpec(),
 		},
+		{
+			name:      "should fail when defaultRoute is requested but not configured on the subnet",
+			expectErr: true,
+			c: &IPSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "netcfg",
+					Namespace: "foo",
+				},
+				Spec: IPSetSpec{
+					Networks: []IPSetNetwork{
+						{
+							Name:         "net1",
+							SubnetName:   "subnet2",
+							DefaultRoute: ptr.To(true),
+						},
+					},
+				},
+			},
+			n: getDefaultIPv4IPv6NetConfigSpec(),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This allows to only request the default gw for a network if it is configured on the referenced subnet.

Closes: https://github.com/openstack-k8s-operators/infra-operator/issues/200