### PR TITLE
Pin setup-envtest to last working commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@c7e1dc9
 
 .PHONY: ginkgo
 ginkgo: $(GINKGO) ## Download ginkgo locally if necessary.


### PR DESCRIPTION
Change[0] in controller-runtime is causing our tests to fail with go version mismatch.

This version restriction should be removed once the issue is fixed in the controller-runtime


[0] https://github.com/kubernetes-sigs/controller-runtime/pull/2693