### PR TITLE
TransportURL: rely on PatchInstance instead of manual Update

### DIFF
--- a/controllers/rabbitmq/transporturl_controller.go
+++ b/controllers/rabbitmq/transporturl_controller.go
@@ -150,10 +150,8 @@ func (r *TransportURLReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	instance.Status.ObservedGeneration = instance.Generation
 
 	if isNewInstance {
-		// Register overall status immediately to have an early feedback e.g. in the cli
-		if err := r.Status().Update(ctx, instance); err != nil {
-			return ctrl.Result{}, err
-		}
+		// Return to register overall status immediately to have an early feedback e.g. in the cli
+		return ctrl.Result{}, nil
 	}
 
 	return r.reconcileNormal(ctx, instance, helper)


### PR DESCRIPTION
The transporturl  controller did a separate client.Update after
it initialized it status then continued the normal reconciliation. As it
is explicitly updated the status subresource and no finalizer is added
this probably works. However to allow easier reasoning about when the
instance is updated this patch removes the explicit Update call and
instead returns immediately to use the deferred PatchInstance call
as the only place that persists the instance.