### PR TITLE
ensure network order is preserved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ CI_TOOLS_REPO
 # generated workspace file
 go.work
 go.work.sum
+
+# python virtual environment
+.venv

--- a/controllers/network/ipset_controller.go
+++ b/controllers/network/ipset_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"sort"
 
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
@@ -274,11 +273,6 @@ func (r *IPSetReconciler) reconcileNormal(ctx context.Context, instance *network
 
 			return ctrl.Result{}, err
 		}
-
-		// sort instance.Status.Reservations by Network
-		sort.Slice(instance.Status.Reservation, func(i, j int) bool {
-			return instance.Status.Reservation[i].Network < instance.Status.Reservation[j].Network
-		})
 
 		instance.Status.Conditions.MarkTrue(networkv1.ReservationReadyCondition, networkv1.ReservationReadyMessage)
 

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -48,6 +48,7 @@ const (
 	net1     = "net-1"
 	uNet1    = "Net-1"
 	net2     = "net-2"
+	net3     = "net-3"
 	subnet1  = "subnet1"
 	uSubnet1 = "Subnet1"
 	host1    = "host1"
@@ -522,6 +523,23 @@ func GetSubnet2(name string) networkv1.Subnet {
 	}
 }
 
+func GetSubnet3(name string) networkv1.Subnet {
+	var gw = "172.19.0.1"
+	var vlan = 21
+	return networkv1.Subnet{
+		Name:    networkv1.NetNameStr(name),
+		Cidr:    "172.19.0.0/24",
+		Vlan:    &vlan,
+		Gateway: &gw,
+		AllocationRanges: []networkv1.AllocationRange{
+			{
+				Start: "172.19.0.100",
+				End:   "172.19.0.200",
+			},
+		},
+	}
+}
+
 func GetSubnetWithWrongExcludeAddress() networkv1.Subnet {
 	var vlan = 20
 	return networkv1.Subnet{
@@ -577,6 +595,12 @@ func GetIPSetNet1() networkv1.IPSetNetwork {
 		SubnetName: uSubnet1,
 	}
 }
+func GetIPSetNet1Lower() networkv1.IPSetNetwork {
+	return networkv1.IPSetNetwork{
+		Name:       net1,
+		SubnetName: uSubnet1,
+	}
+}
 
 func GetIPSetNet1WithFixedIP(ip string) networkv1.IPSetNetwork {
 	return networkv1.IPSetNetwork{
@@ -600,6 +624,13 @@ func GetIPSetNet1WithDefaultRoute() networkv1.IPSetNetwork {
 func GetIPSetNet2() networkv1.IPSetNetwork {
 	return networkv1.IPSetNetwork{
 		Name:       net2,
+		SubnetName: subnet1,
+	}
+}
+
+func GetIPSetNet3() networkv1.IPSetNetwork {
+	return networkv1.IPSetNetwork{
+		Name:       net3,
 		SubnetName: subnet1,
 	}
 }


### PR DESCRIPTION
This change ensure that the ipset network order
is preserved in the status.reservation

This is requried to ensure the dns search domain order
is defined by the order of the network list.

Closes: [OSPRH-6672](https://issues.redhat.com//browse/OSPRH-6672)
