### PR TITLE
Set ObservedGeneration in test helpers

### DIFF
--- a/apis/test/helpers/memcached.go
+++ b/apis/test/helpers/memcached.go
@@ -106,6 +106,7 @@ func (tc *TestHelper) GetMemcached(name types.NamespacedName) *memcachedv1.Memca
 func (tc *TestHelper) SimulateMemcachedReady(name types.NamespacedName) {
 	t.Eventually(func(g t.Gomega) {
 		mc := tc.GetMemcached(name)
+		mc.Status.ObservedGeneration = mc.Generation
 		mc.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
 		mc.Status.ReadyCount = *mc.Spec.Replicas
 
@@ -130,6 +131,7 @@ func (tc *TestHelper) SimulateMemcachedReady(name types.NamespacedName) {
 func (tc *TestHelper) SimulateTLSMemcachedReady(name types.NamespacedName) {
 	t.Eventually(func(g t.Gomega) {
 		mc := tc.GetMemcached(name)
+		mc.Status.ObservedGeneration = mc.Generation
 		mc.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
 		mc.Status.ReadyCount = *mc.Spec.Replicas
 

--- a/apis/test/helpers/transport.go
+++ b/apis/test/helpers/transport.go
@@ -42,6 +42,7 @@ func (tc *TestHelper) GetTransportURL(name types.NamespacedName) *rabbitmqv1.Tra
 func (tc *TestHelper) SimulateTransportURLReady(name types.NamespacedName) {
 	gomega.Eventually(func(g gomega.Gomega) {
 		transport := tc.GetTransportURL(name)
+		transport.Status.ObservedGeneration = transport.Generation
 		transport.Status.SecretName = transport.Spec.RabbitmqClusterName + "-secret"
 		transport.Status.Conditions.MarkTrue("TransportURLReady", "Ready")
 		g.Expect(tc.K8sClient.Status().Update(tc.Ctx, transport)).To(gomega.Succeed())


### PR DESCRIPTION
This updates the test helpers for memcached and transport URL to set ObservedGeneration