### PR TITLE
memcached: replace ',' in $POD_IPS by space

### DIFF
--- a/templates/memcached/config/memcached
+++ b/templates/memcached/config/memcached
@@ -3,5 +3,5 @@ USER="memcached"
 MAXCONN="8192"
 CACHESIZE="9932"
 # explicit IP to bind to (wrap IPv6 in brackets)
-LISTEN=$(echo 127.0.0.1 ::1 $(printf %s $POD_IPS | tr ',' ' ') | tr ' ' '\n' | sed 's/\(.*\):\(.*\)/[\1:\2]/' {{ .memcachedTLSListen }})
+LISTEN=$(echo 127.0.0.1 ::1 $POD_IPS | tr ',' ' ' | tr ' ' '\n' | sed 's/\(.*\):\(.*\)/[\1:\2]/' {{ .memcachedTLSListen }})
 OPTIONS="-l $(echo $LISTEN | tr ' ' ',') {{ .memcachedTLSOptions }} -vv"

--- a/templates/memcached/config/memcached
+++ b/templates/memcached/config/memcached
@@ -3,5 +3,5 @@ USER="memcached"
 MAXCONN="8192"
 CACHESIZE="9932"
 # explicit IP to bind to (wrap IPv6 in brackets)
-LISTEN=$(echo 127.0.0.1 ::1 $POD_IPS | tr ' ' '\n' | sed 's/\(.*\):\(.*\)/[\1:\2]/' {{ .memcachedTLSListen }})
+LISTEN=$(echo 127.0.0.1 ::1 $(printf %s $POD_IPS | tr ',' ' ') | tr ' ' '\n' | sed 's/\(.*\):\(.*\)/[\1:\2]/' {{ .memcachedTLSListen }})
 OPTIONS="-l $(echo $LISTEN | tr ' ' ',') {{ .memcachedTLSOptions }} -vv"


### PR DESCRIPTION
Adjust the handling of the `$POD_IPS` variable to allow for multiple pod IPs. This change takes the comma separated list of PodIPs and replaces the comma with a space to make it work with the rest of the statement for building the listen IPs.

Implements #233