### PR TITLE
Add ServiceNetwork attribute to networks in netconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Dockerfile.cross
 
 bundle
 bundle.Dockerfile
+config/manager/kustomization.yaml
 
 # Test binary, build with `go test -c`
 *.test

--- a/apis/bases/network.openstack.org_ipsets.yaml
+++ b/apis/bases/network.openstack.org_ipsets.yaml
@@ -180,6 +180,10 @@ spec:
                         - nexthop
                         type: object
                       type: array
+                    serviceNetwork:
+                      description: ServiceNetwork mapping
+                      pattern: ^[a-z0-9][a-z0-9\-_]*[a-z0-9]$
+                      type: string
                     subnet:
                       description: Subnet name
                       pattern: ^[a-zA-Z0-9][a-zA-Z0-9\-_]*[a-zA-Z0-9]$
@@ -191,6 +195,7 @@ spec:
                   - address
                   - dnsDomain
                   - network
+                  - serviceNetwork
                   - subnet
                   type: object
                 type: array

--- a/apis/bases/network.openstack.org_netconfigs.yaml
+++ b/apis/bases/network.openstack.org_netconfigs.yaml
@@ -55,6 +55,10 @@ spec:
                         ...
                       pattern: ^[a-zA-Z0-9][a-zA-Z0-9\-_]*[a-zA-Z0-9]$
                       type: string
+                    serviceNetwork:
+                      description: Service network mapping
+                      pattern: ^[a-z0-9][a-z0-9\-_]*[a-z0-9]$
+                      type: string
                     subnets:
                       description: Subnets of the network
                       items:

--- a/apis/network/v1beta1/ipset_types.go
+++ b/apis/network/v1beta1/ipset_types.go
@@ -82,6 +82,9 @@ type IPSetReservation struct {
 
 	// DNSDomain of the subnet
 	DNSDomain string `json:"dnsDomain"`
+
+	// ServiceNetwork mapping
+	ServiceNetwork ServiceNetNameStr `json:"serviceNetwork"`
 }
 
 // IPSetStatus defines the observed state of IPSet

--- a/apis/network/v1beta1/netconfig_types.go
+++ b/apis/network/v1beta1/netconfig_types.go
@@ -28,6 +28,13 @@ import (
 // NetNameStr is used for validation of a net name.
 type NetNameStr string
 
+// +kubebuilder:validation:Pattern="^[a-z0-9][a-z0-9\\-_]*[a-z0-9]$"
+type ServiceNetNameStr string
+
+func ToDefaultServiceNetwork(n NetNameStr) ServiceNetNameStr {
+	return ServiceNetNameStr(strings.ToLower(string(n)))
+}
+
 // Network definition
 type Network struct {
 	// +kubebuilder:validation:Required
@@ -46,6 +53,10 @@ type Network struct {
 	// +kubebuilder:validation:Required
 	// Subnets of the network
 	Subnets []Subnet `json:"subnets"`
+
+	// +kubebuilder:validation:optional
+	// Service network mapping
+	ServiceNetwork ServiceNetNameStr `json:"serviceNetwork,omitempty"`
 }
 
 // Subnet definition

--- a/apis/network/v1beta1/netconfig_webhook.go
+++ b/apis/network/v1beta1/netconfig_webhook.go
@@ -51,9 +51,12 @@ var _ webhook.Defaulter = &NetConfig{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *NetConfig) Default() {
-	netconfiglog.Info("default", "name", r.Name)
+	for _, net := range r.Spec.Networks {
+		if net.ServiceNetwork == "" {
+			net.ServiceNetwork = ToDefaultServiceNetwork(net.Name)
+		}
+	}
 
-	// TODO(user): fill in your defaulting logic.
 }
 
 //+kubebuilder:webhook:path=/validate-network-openstack-org-v1beta1-netconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=network.openstack.org,resources=netconfigs,verbs=create;update;delete,versions=v1beta1,name=vnetconfig.kb.io,admissionReviewVersions=v1
@@ -146,7 +149,6 @@ func valiateNetworks(
 	allErrs := field.ErrorList{}
 	netNames := map[string]field.Path{}
 	netCIDR := map[string]field.Path{}
-
 	for netIdx, _net := range networks {
 		path := path.Child("networks").Index(netIdx)
 
@@ -172,7 +174,6 @@ func valiateNetworks(
 			}
 		}
 	}
-
 	return allErrs
 }
 

--- a/config/crd/bases/network.openstack.org_ipsets.yaml
+++ b/config/crd/bases/network.openstack.org_ipsets.yaml
@@ -180,6 +180,10 @@ spec:
                         - nexthop
                         type: object
                       type: array
+                    serviceNetwork:
+                      description: ServiceNetwork mapping
+                      pattern: ^[a-z0-9][a-z0-9\-_]*[a-z0-9]$
+                      type: string
                     subnet:
                       description: Subnet name
                       pattern: ^[a-zA-Z0-9][a-zA-Z0-9\-_]*[a-zA-Z0-9]$
@@ -191,6 +195,7 @@ spec:
                   - address
                   - dnsDomain
                   - network
+                  - serviceNetwork
                   - subnet
                   type: object
                 type: array

--- a/config/crd/bases/network.openstack.org_netconfigs.yaml
+++ b/config/crd/bases/network.openstack.org_netconfigs.yaml
@@ -55,6 +55,10 @@ spec:
                         ...
                       pattern: ^[a-zA-Z0-9][a-zA-Z0-9\-_]*[a-zA-Z0-9]$
                       type: string
+                    serviceNetwork:
+                      description: Service network mapping
+                      pattern: ^[a-z0-9][a-z0-9\-_]*[a-z0-9]$
+                      type: string
                     subnets:
                       description: Subnets of the network
                       items:

--- a/config/manifests/bases/infra-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/infra-operator.clusterserviceversion.yaml
@@ -28,6 +28,11 @@ spec:
       kind: DNSMasq
       name: dnsmasqs.network.openstack.org
       version: v1beta1
+    - description: InstanceHA is the Schema for the instancehas API
+      displayName: Instance HA
+      kind: InstanceHA
+      name: instancehas.instanceha.openstack.org
+      version: v1beta1
     - description: IPSet is the Schema for the ipsets API
       displayName: IPSet
       kind: IPSet
@@ -51,6 +56,10 @@ spec:
       displayName: Redis
       kind: Redis
       name: redises.redis.openstack.org
+      specDescriptors:
+      - description: TLS settings for Redis service and internal Redis replication
+        displayName: TLS
+        path: tls
       version: v1beta1
     - description: Reservation is the Schema for the reservations API
       displayName: Reservation

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -482,6 +482,20 @@ func GetNetSpec(name string, subnets ...networkv1.Subnet) networkv1.Network {
 	return net
 }
 
+func GetNetCtlplaneSpec(name string, subnets ...networkv1.Subnet) networkv1.Network {
+	net := networkv1.Network{
+		Name:           networkv1.NetNameStr(name),
+		DNSDomain:      fmt.Sprintf("%s.example.com", strings.ToLower(name)),
+		MTU:            1400,
+		Subnets:        []networkv1.Subnet{},
+		ServiceNetwork: "ctlplane",
+	}
+
+	net.Subnets = append(net.Subnets, subnets...)
+
+	return net
+}
+
 func GetDefaultNetConfigSpec() map[string]interface{} {
 	net := GetNetSpec(net1, GetSubnet1(subnet1))
 	return GetNetConfigSpec(net)


### PR DESCRIPTION
This would allow us to identify the ctlplane network when
using custom network and also generate inventory using
the ServiceNetwork.

Jira: https://issues.redhat.com/browse/OSPRH-10125