### PR TITLE
[netconfig] limit network names to be one of the known

### DIFF
--- a/apis/bases/network.openstack.org_netconfigs.yaml
+++ b/apis/bases/network.openstack.org_netconfigs.yaml
@@ -51,8 +51,15 @@ spec:
                       description: MTU of the network
                       type: integer
                     name:
-                      description: Name of the network, e.g. External, InternalApi,
-                        ...
+                      description: Name of the network, could be one of ctlplane,
+                        internalapi, external, storage, storagemgmt or tenant
+                      enum:
+                      - ctlplane
+                      - internalapi
+                      - external
+                      - storage
+                      - storagemgmt
+                      - tenant
                       pattern: ^[a-zA-Z0-9][a-zA-Z0-9\-_]*[a-zA-Z0-9]$
                       type: string
                     subnets:

--- a/apis/network/v1beta1/netconfig_types.go
+++ b/apis/network/v1beta1/netconfig_types.go
@@ -31,7 +31,8 @@ type NetNameStr string
 // Network definition
 type Network struct {
 	// +kubebuilder:validation:Required
-	// Name of the network, e.g. External, InternalApi, ...
+	// +kubebuilder:validation:Enum=ctlplane;internalapi;external;storage;storagemgmt;tenant
+	// Name of the network, could be one of ctlplane, internalapi, external, storage, storagemgmt or tenant
 	Name NetNameStr `json:"name"`
 
 	// +kubebuilder:validation:Required

--- a/config/crd/bases/network.openstack.org_netconfigs.yaml
+++ b/config/crd/bases/network.openstack.org_netconfigs.yaml
@@ -51,8 +51,15 @@ spec:
                       description: MTU of the network
                       type: integer
                     name:
-                      description: Name of the network, e.g. External, InternalApi,
-                        ...
+                      description: Name of the network, could be one of ctlplane,
+                        internalapi, external, storage, storagemgmt or tenant
+                      enum:
+                      - ctlplane
+                      - internalapi
+                      - external
+                      - storage
+                      - storagemgmt
+                      - tenant
                       pattern: ^[a-zA-Z0-9][a-zA-Z0-9\-_]*[a-zA-Z0-9]$
                       type: string
                     subnets:

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -46,10 +46,10 @@ const (
 	interval       = timeout / 100
 	containerImage = "test-dnsmasq-container-image"
 
-	net1     = "net-1"
-	uNet1    = "Net-1"
-	net2     = "net-2"
-	net3     = "net-3"
+	net1     = "ctlplane"
+	uNet1    = "CtlPlane"
+	net2     = "tenant"
+	net3     = "storage"
 	subnet1  = "subnet1"
 	uSubnet1 = "Subnet1"
 	host1    = "host1"

--- a/tests/functional/ipset_controller_test.go
+++ b/tests/functional/ipset_controller_test.go
@@ -84,9 +84,9 @@ var _ = Describe("IPSet controller", func() {
 
 		It("should have created an IPSet", func() {
 			Eventually(func(g Gomega) {
-				res := GetReservationFromNet(ipSetName, "net-1")
+				res := GetReservationFromNet(ipSetName, net1)
 				g.Expect(res.Address).To(Equal("172.17.0.100"))
-				g.Expect(res.DNSDomain).To(Equal("net-1.example.com"))
+				g.Expect(res.DNSDomain).To(Equal("ctlplane.example.com"))
 			}, timeout, interval).Should(Succeed())
 		})
 
@@ -125,7 +125,7 @@ var _ = Describe("IPSet controller", func() {
 
 		It("should have created an IPSet with IP 172.17.0.150 on net-1", func() {
 			Eventually(func(g Gomega) {
-				res := GetReservationFromNet(ipSetName, "net-1")
+				res := GetReservationFromNet(ipSetName, net1)
 				g.Expect(res.Address).To(Equal("172.17.0.150"))
 			}, timeout, interval).Should(Succeed())
 		})
@@ -165,7 +165,7 @@ var _ = Describe("IPSet controller", func() {
 
 		It("should have created an IPSet with default route on net-1", func() {
 			Eventually(func(g Gomega) {
-				res := GetReservationFromNet(ipSetName, "net-1")
+				res := GetReservationFromNet(ipSetName, net1)
 				g.Expect(res.Routes).Should(HaveLen(1))
 			}, timeout, interval).Should(Succeed())
 		})
@@ -205,7 +205,7 @@ var _ = Describe("IPSet controller", func() {
 
 		It("should have created an IPSet with IP 172.17.0.220 on net-1", func() {
 			Eventually(func(g Gomega) {
-				res := GetReservationFromNet(ipSetName, "net-1")
+				res := GetReservationFromNet(ipSetName, net1)
 				g.Expect(res.Address).To(Equal("172.17.0.220"))
 			}, timeout, interval).Should(Succeed())
 		})
@@ -245,7 +245,7 @@ var _ = Describe("IPSet controller", func() {
 
 		It("should have created an IPSet with IP 172.17.0.201 on net-1", func() {
 			Eventually(func(g Gomega) {
-				res := GetReservationFromNet(ipSetName, "net-1")
+				res := GetReservationFromNet(ipSetName, net1)
 				g.Expect(res).To(Equal(networkv1.IPSetReservation{}))
 			}, timeout, interval).Should(Succeed())
 		})
@@ -281,7 +281,7 @@ var _ = Describe("IPSet controller", func() {
 	When("a GetDefaultIPSetSpec IPSet gets created using a custom NetConfig", func() {
 		BeforeEach(func() {
 			netSpec := GetNetSpec(net1, GetSubnet1(subnet1))
-			netSpec.Subnets[0].DNSDomain = ptr.To("subnet1.net-1.example.com")
+			netSpec.Subnets[0].DNSDomain = ptr.To("subnet1.ctlplane.example.com")
 			netCfg := CreateNetConfig(namespace, GetNetConfigSpec(netSpec))
 			ipset := CreateIPSet(namespace, GetDefaultIPSetSpec())
 
@@ -298,9 +298,9 @@ var _ = Describe("IPSet controller", func() {
 
 		It("should have created an IPSet with DNSDomain from subnet", func() {
 			Eventually(func(g Gomega) {
-				res := GetReservationFromNet(ipSetName, "net-1")
+				res := GetReservationFromNet(ipSetName, net1)
 				g.Expect(res.Address).To(Equal("172.17.0.100"))
-				g.Expect(res.DNSDomain).To(Equal("subnet1.net-1.example.com"))
+				g.Expect(res.DNSDomain).To(Equal("subnet1.ctlplane.example.com"))
 			}, timeout, interval).Should(Succeed())
 		})
 
@@ -407,7 +407,7 @@ var _ = Describe("IPSet controller", func() {
 
 		It("should have created an IPSet with IP 172.17.0.220 on net-1", func() {
 			Eventually(func(g Gomega) {
-				res := GetReservationFromNet(ipSetName, "net-1")
+				res := GetReservationFromNet(ipSetName, net1)
 				g.Expect(res.Address).To(Equal("172.17.0.220"))
 			}, timeout, interval).Should(Succeed())
 		})


### PR DESCRIPTION
network names should be one of
- ctlplane
- internalapi
- external
- tenant
- storage
- storagemgmt

The dataplane is creating the inventory based on the network name and passes ip information as ansible vars like e.g. tenant_ip.

If a custom network name is used, as a follow up custom information needs to be passed into the services. Therefore only allow network names to be one of the expected, while the subnet names can be customized.