### PR TITLE
Wrap reverse dns lookup in try/except block

### DIFF
--- a/templates/instanceha/bin/instanceha.py
+++ b/templates/instanceha/bin/instanceha.py
@@ -419,7 +419,11 @@ def _check_kdump(stale_services):
         #logging.debug("address is %s" % address[0])
 
         # short hostname
-        name = socket.gethostbyaddr(address[0])[0].split('.', 1)[0]
+        try:
+            name = socket.gethostbyaddr(address[0])[0].split('.', 1)[0]
+        except Exception as msg:
+            logging.error('Failed reverse dns lookup for: %s - %s' % (address[0], msg))
+            continue
 
         # fence_kdump checks if the magic number matches, so let's do it here too
         if hex(struct.unpack('ii',data)[0]).upper() != FENCE_KDUMP_MAGIC.upper() :


### PR DESCRIPTION
If DNS is broken calling socket.gethostbyaddr() could result in an unexpected pod crash.
Let's wrap the call in try/except with the expectation that a reverse dns lookup failure should not prevent evacuation, worst case scenario we would not capture the memory dump and the user will have a "ERROR Could not perform reverse dns lookup for: X" in the logs hinting at resolution not working.