### PR TITLE
Enable toggling tagged flavors/images and small fixes

### DIFF
--- a/templates/instanceha/config/config.yaml
+++ b/templates/instanceha/config/config.yaml
@@ -1,5 +1,7 @@
 config:
   EVACUABLE_TAG: "evacuable"
+  TAGGED_IMAGES: "true"
+  TAGGED_FLAVORS: "true"
   SMART_EVACUATION: "false"
   DELTA: "30"
   POLL: "30"


### PR DESCRIPTION
This commit fixes a couple of issues:

1. Catch case where all the faulty computes are dumping

   In case all the stale_computes are kdumping we want to make sure
   the check_kdump function returns an empty list, otherwise they may
   be evacuated without waiting the dump to be collected.

2. Wrap reverse dns lookup in try/except block

   If DNS is broken calling socket.gethostbyaddr() could result in
   an unexpected pod crash.
   Let's wrap the call in try/except with the expectation that a
   reverse dns lookup failure should not prevent evacuation,
   worst case scenario we would not capture the memory dump and
   the user will have a "ERROR Could not perform reverse dns lookup for: X"
   in the logs hinting at resolution not working.

It also introduces two new config options:

TAGGED_IMAGES (default=true)
TAGGED_FLAVORS (default=true)

Setting any of these to false will exclude respectively tagged
images or flavors from being considered when deciding which vm
needs to be evacuated, essentially allowing operators to decide
if they want to use either tagged images or flavors, or both.
