### PR TITLE
Make sure to log error in findObjectsForSrc()

### DIFF
--- a/controllers/redis/redis_controller.go
+++ b/controllers/redis/redis_controller.go
@@ -465,6 +465,8 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *Reconciler) findObjectsForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
+	l := log.FromContext(context.Background()).WithName("Controllers").WithName("Redis")
+
 	for _, field := range allWatchFields {
 		crList := &redisv1.RedisList{}
 		listOps := &client.ListOptions{
@@ -473,10 +475,13 @@ func (r *Reconciler) findObjectsForSrc(ctx context.Context, src client.Object) [
 		}
 		err := r.List(ctx, crList, listOps)
 		if err != nil {
-			return []reconcile.Request{}
+			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			return requests
 		}
 
 		for _, item := range crList.Items {
+			l.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
+
 			requests = append(requests,
 				reconcile.Request{
 					NamespacedName: types.NamespacedName{


### PR DESCRIPTION
It is hidden right now if there is an error in configured named fields and index. Lets log the error and return the current state of requests.

With this the findObjectsForSrc() will exit with an hidden error like:

```
"error": "Index with name field:.spec.ksmTls.caBundleSecretName does not exist"
```