### PR TITLE
Increase POLL interval to avoid race with check_kdump

### DIFF
--- a/templates/instanceha/config/config.yaml
+++ b/templates/instanceha/config/config.yaml
@@ -4,7 +4,7 @@ config:
   TAGGED_FLAVORS: "true"
   SMART_EVACUATION: "false"
   DELTA: "30"
-  POLL: "30"
+  POLL: "45"
   THRESHOLD: "50"
   WORKERS: "4"
   RESERVED_HOSTS: "false"


### PR DESCRIPTION
This commit increases the default value of 'POLL' from 30s to 45s. 
The reason is that the check_kdump functionality has an internal hard-coded timeout of 30s and this may induce race conditions if POLL is set to the same value.
A warning has been added to make sure users are notified if POLL=30s.

Finally, we take the chance to normalize the retcode for bmh_fencing.