### PR TITLE
Automate OLM cleanup for running local operator w/ webhooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -359,16 +359,11 @@ operator-lint: gowork ## Runs operator-lint
 	go vet -vettool=$(LOCALBIN)/operator-lint ./... ./apis/...
 
 # Used for webhook testing
-# Please ensure the infra-controller-manager deployment and
-# webhook definitions are removed from the csv before running
-# this. Also, cleanup the webhook configuration for local testing
-# before deplying with olm again.
-# $oc delete validatingwebhookconfiguration/vmemcached.kb.io
-# $oc delete mutatingwebhookconfiguration/mmemcached.kb.io
-# $oc delete validatingwebhookconfiguration/vdnsmasq.kb.io
-# $oc delete mutatingwebhookconfiguration/mdnsmasq.kb.io
-# $oc delete validatingwebhookconfiguration/vredis.kb.io
-# $oc delete mutatingwebhookconfiguration/mredis.kb.io
+# The configure_local_webhooks.sh script below will remove any OLM webhooks
+# for the operator and also scale its deployment replicas down to 0 so that
+# the operator can run locally.
+# Make sure to cleanup the webhook configuration for local testing by running
+# ./hack/clean_local_webhook.sh before deplying with OLM again.
 SKIP_CERT ?=false
 .PHONY: run-with-webhook
 run-with-webhook: export METRICS_PORT?=8080

--- a/hack/clean_local_webhook.sh
+++ b/hack/clean_local_webhook.sh
@@ -13,3 +13,5 @@ oc delete validatingwebhookconfiguration/vreservation.kb.io --ignore-not-found
 oc delete mutatingwebhookconfiguration/mreservation.kb.io --ignore-not-found
 oc delete validatingwebhookconfiguration/vipset.kb.io --ignore-not-found
 oc delete mutatingwebhookconfiguration/mipset.kb.io --ignore-not-found
+oc delete validatingwebhookconfiguration/vinstanceha.kb.io --ignore-not-found
+oc delete mutatingwebhookconfiguration/minstanceha.kb.io --ignore-not-found


### PR DESCRIPTION
When using make `run-with-webhook`, local versions of the operator and its webhooks are added to the cluster. If the operator was previously installed via OLM, then there might be lingering webhooks from that installation. We've previously been assuming that the user would manually remove them, but we should just get rid of them ourselves since those OLM webhooks need to be deleted anyhow for the local webhooks to function unimpeded.  We can also automatically scale down the operator's OLM deployment in such a scenario.

Also adds missing local webhooks for `InstanceHA` resources.