### PR TITLE
Add liveness probe and allow InstanceHa to resume evacuations

### DIFF
--- a/pkg/instanceha/funcs.go
+++ b/pkg/instanceha/funcs.go
@@ -19,6 +19,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 )
 
@@ -40,6 +41,18 @@ func Deployment(
 	// create Volume and VolumeMounts
 	volumes := instancehaPodVolumes(instance)
 	volumeMounts := instancehaPodVolumeMounts()
+
+	livenessProbe := &corev1.Probe{
+		// TODO might need tuning
+		TimeoutSeconds:      30,
+		PeriodSeconds:       30,
+		InitialDelaySeconds: 10,
+	}
+
+	livenessProbe.HTTPGet = &corev1.HTTPGetAction{
+		Path: "/",
+		Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
+	}
 
 	// add CA cert if defined
 	if instance.Spec.CaBundleSecretName != "" {
@@ -91,7 +104,8 @@ func Deployment(
 							Protocol:      "UDP",
 							Name:          "instanceha",
 						}},
-						VolumeMounts: volumeMounts,
+						VolumeMounts:  volumeMounts,
+						LivenessProbe: livenessProbe,
 					}},
 				},
 			},


### PR DESCRIPTION
This commit adds a liveness probe to the InstanceHa pod so to eventually recover from the pod not responding.

Since this could interrupt the recovery workflow we also add a way to resume evacuations if a host has been previously been disabled and marked by InstanceHa (see "Disabled Reason" in nova).

Jira: https://issues.redhat.com/browse/OSPRH-10412