### PR TITLE
Add Affinity to Redis

### DIFF
--- a/pkg/redis/statefulset.go
+++ b/pkg/redis/statefulset.go
@@ -5,6 +5,7 @@ import (
 
 	redisv1 "github.com/openstack-k8s-operators/infra-operator/apis/redis/v1beta1"
 	common "github.com/openstack-k8s-operators/lib-common/modules/common"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/affinity"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/clusterdns"
 	labels "github.com/openstack-k8s-operators/lib-common/modules/common/labels"
 	appsv1 "k8s.io/api/apps/v1"
@@ -142,6 +143,16 @@ func StatefulSet(
 		},
 	}
 
+	// If possible two pods of the same service should not
+	// run on the same worker node. If this is not possible
+	// the get still created on the same worker node.
+	sts.Spec.Template.Spec.Affinity = affinity.DistributePods(
+		common.AppSelector,
+		[]string{
+			r.Name,
+		},
+		corev1.LabelHostname,
+	)
 	if r.Spec.NodeSelector != nil {
 		sts.Spec.Template.Spec.NodeSelector = *r.Spec.NodeSelector
 	}


### PR DESCRIPTION
```
[zuul@controller-0 ~]$ oc get redis redis -o yaml                
apiVersion: redis.openstack.org/v1beta1
kind: Redis
metadata:                  
  annotations:                                       
    kubectl.kubernetes.io/last-applied-configuration: |                                                                                                                                                                                                                                                                                         
      {"apiVersion":"redis.openstack.org/v1beta1","kind":"Redis","metadata":{"annotations":{},"name":"redis","namespace":"openstack"},"spec":{"nodeSelector":{"foo":"bar"},"replicas":1}
  creationTimestamp: "2024-10-25T06:29:51Z"
  generation: 1                
  name: redis                                            
  namespace: openstack                                                                                                                                                                                                                                                                                                                          
  resourceVersion: "593470"                   
  uid: a6e4359d-a4f5-45d0-a09c-ff6519848986
spec:                              
  containerImage: quay.io/podified-antelope-centos9/openstack-redis@sha256:60d24dca380d2b925b13c1fedd2b28871717874755256c7e149164ec177947d3
  nodeSelector:         
    foo: bar                                      
  replicas: 1
  tls: {}
```

```
[zuul@controller-0 ~]$ oc get nodes worker-2 -o json |jq .metadata.labels.foo
"bar"
```

```
[zuul@controller-0 ~]$ oc get pods -o wide |grep redis
redis-redis-0                                                     2/2     Running     0          5m53s   192.168.48.67    worker-2   <none>           <none>
```
