### PR TITLE
[make]Add force-bump target to bump operator deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,3 +371,13 @@ run-with-webhook: export METRICS_PORT?=8080
 run-with-webhook: export HEALTH_PORT?=8081
 run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/run_with_local_webhook.sh
+
+BRANCH=main
+.PHONY: force-bump
+force-bump: ## Force bump operator and lib-common dependencies
+	for dep in $$(cat go.mod | grep openstack-k8s-operators | grep -vE -- 'indirect|infra-operator|^replace' | awk '{print $$1}'); do \
+		go get $$dep@$(BRANCH) ; \
+	done
+	for dep in $$(cat apis/go.mod | grep openstack-k8s-operators | grep -vE -- 'indirect|infra-operator|^replace' | awk '{print $$1}'); do \
+		cd ./apis && go get $$dep@$(BRANCH) && cd .. ; \
+	done


### PR DESCRIPTION
The new force-bump target bumps operator and lib-common dependencies of
this operator by tracking the same branch from these dependencies.

Related: OSPRH-8355
