### PR TITLE
[18.0-fr1][make]Add force-bump target to bump operator deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,3 +371,13 @@ run-with-webhook: export HEALTH_PORT?=8081
 run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/configure_local_webhook.sh
 	go run ./main.go -metrics-bind-address ":$(METRICS_PORT)" -health-probe-bind-address ":$(HEALTH_PORT)"
+
+BRANCH=18.0-fr1
+.PHONY: force-bump
+force-bump: ## Force bump operator and lib-common dependencies
+	for dep in $$(cat go.mod | grep openstack-k8s-operators | grep -vE -- 'indirect|infra-operator|^replace' | awk '{print $$1}'); do \
+		go get $$dep@$(BRANCH) ; \
+	done
+	for dep in $$(cat apis/go.mod | grep openstack-k8s-operators | grep -vE -- 'indirect|infra-operator|^replace' | awk '{print $$1}'); do \
+		cd ./apis && go get $$dep@$(BRANCH) && cd .. ; \
+	done


### PR DESCRIPTION
The new force-bump target bumps operator and lib-common dependencies of this operator by tracking the same branch from these dependencies.

18.0-fr1 only change:
* resolve the merge conflict in Makefile due to df18c6b79456ee653bf33103f89f9ed3edcd677e is not in 18.0-fr1
* switched the branch target of force-bump to 18.0-fr1

Related: OSPRH-8355
(cherry picked from commit ee3ca333195626bcd78199acc479547f482c02dd)