### PR TITLE
Use dns cluster info from lib common get function

### DIFF
--- a/pkg/redis/statefulset.go
+++ b/pkg/redis/statefulset.go
@@ -5,6 +5,7 @@ import (
 
 	redisv1 "github.com/openstack-k8s-operators/infra-operator/apis/redis/v1beta1"
 	common "github.com/openstack-k8s-operators/lib-common/modules/common"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/clusterdns"
 	labels "github.com/openstack-k8s-operators/lib-common/modules/common/labels"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -61,6 +62,7 @@ func StatefulSet(
 		Port: intstr.IntOrString{Type: intstr.Int, IntVal: int32(26379)},
 	}
 	name := r.Name + "-" + "redis"
+	clusterDomain := clusterdns.GetDNSClusterDomain()
 
 	commonEnvVars := []corev1.EnvVar{{
 		Name:  "KOLLA_CONFIG_STRATEGY",
@@ -69,8 +71,7 @@ func StatefulSet(
 		Name: "SVC_FQDN",
 		// https://github.com/kubernetes/dns/blob/master/docs/specification.md
 		// Headless services only publish dns entries that include cluster domain.
-		// For the time being, assume this is .cluster.local
-		Value: name + "." + r.GetNamespace() + ".svc.cluster.local",
+		Value: name + "." + r.GetNamespace() + ".svc." + clusterDomain,
 	}, {
 		Name:  "CONFIG_HASH",
 		Value: configHash,


### PR DESCRIPTION
Openshift coreDNS creates the domain name using an string located in dnses.operator.openshift.io. This string can change in the future, calling lib-common/GetDNSClusterDomain the responsability of gathering this information correctly only falls under lib-common intead of all operators.

Resolves: [OSPRH-3627](https://issues.redhat.com//browse/OSPRH-3627)
Depends-on: openstack-k8s-operators/lib-common#580