### PR TITLE
crd-schema-check: allow new CRDs

### DIFF
--- a/hack/crd-schema-checker.sh
+++ b/hack/crd-schema-checker.sh
@@ -14,8 +14,9 @@ trap cleanup EXIT
 
 for crd in config/crd/bases/*.yaml; do
     mkdir -p "$(dirname "$TMP_DIR/$crd")"
-    git show "$BASE_REF:$crd" > "$TMP_DIR/$crd"
-    $CHECKER check-manifests \
-        --existing-crd-filename="$TMP_DIR/$crd" \
-        --new-crd-filename="$crd"
+    if git show "$BASE_REF:$crd" > "$TMP_DIR/$crd"; then
+        $CHECKER check-manifests \
+            --existing-crd-filename="$TMP_DIR/$crd" \
+            --new-crd-filename="$crd"
+    fi
 done


### PR DESCRIPTION
If the 'git show BASE_REF' fails assume it is a net new CRD and should be fine.