### PR TITLE
Drop the default containerImage parameter and use VAR

### DIFF
--- a/apis/bases/instanceha.openstack.org_instancehas.yaml
+++ b/apis/bases/instanceha.openstack.org_instancehas.yaml
@@ -53,7 +53,6 @@ spec:
                   bundle file
                 type: string
               containerImage:
-                default: quay.io/podified-antelope-centos9/openstack-openstackclient:current-podified
                 description: ContainerImage for the the InstanceHa container (will
                   be set to environmental default if empty)
                 type: string

--- a/apis/instanceha/v1beta1/instanceha_types.go
+++ b/apis/instanceha/v1beta1/instanceha_types.go
@@ -34,7 +34,6 @@ const (
 // InstanceHaSpec defines the desired state of InstanceHa
 type InstanceHaSpec struct {
 	// +kubebuilder:validation:Required
-	// +kubebuilder:default="quay.io/podified-antelope-centos9/openstack-openstackclient:current-podified"
 	// ContainerImage for the the InstanceHa container (will be set to environmental default if empty)
 	ContainerImage string `json:"containerImage"`
 

--- a/config/crd/bases/instanceha.openstack.org_instancehas.yaml
+++ b/config/crd/bases/instanceha.openstack.org_instancehas.yaml
@@ -53,7 +53,6 @@ spec:
                   bundle file
                 type: string
               containerImage:
-                default: quay.io/podified-antelope-centos9/openstack-openstackclient:current-podified
                 description: ContainerImage for the the InstanceHa container (will
                   be set to environmental default if empty)
                 type: string

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -18,3 +18,5 @@ spec:
         # TODO create its own container image, instead of using neutron one
         - name: RELATED_IMAGE_INFRA_DNSMASQ_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-neutron-server:current-podified
+        - name: RELATED_IMAGE_INSTANCE_HA_IMAGE_URL_DEFAULT
+          value: quay.io/podified-antelope-centos9/openstack-openstackclient:current-podified

--- a/config/manifests/bases/infra-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/infra-operator.clusterserviceversion.yaml
@@ -18,6 +18,11 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
+    - description: BGPConfiguration is the Schema for the bgpconfigurations API
+      displayName: BGPConfiguration
+      kind: BGPConfiguration
+      name: bgpconfigurations.network.openstack.org
+      version: v1beta1
     - description: DNSData is the Schema for the dnsdata API
       displayName: DNSData
       kind: DNSData


### PR DESCRIPTION
Hard coding the containerImage value is problematic b/c our build system would not override the value set in the crd automatically, so the variable ends up being set to the wrong image in the crd definition.
Let's try using RELATED_* vars (set by the infra-operator itself, because we can't have two vars using the same value, see https://github.com/openstack-k8s-operators/openstack-operator/pull/1150).

Jira: [OSPRH-13093](https://issues.redhat.com//browse/OSPRH-13093)