### PR TITLE
Make InstanceHA ContainerImage optional

### DIFF
--- a/apis/bases/instanceha.openstack.org_instancehas.yaml
+++ b/apis/bases/instanceha.openstack.org_instancehas.yaml
@@ -99,7 +99,6 @@ spec:
                   the secure.yaml
                 type: string
             required:
-            - containerImage
             - fencingSecret
             - instanceHaConfigMap
             - instanceHaKdumpPort

--- a/apis/instanceha/v1beta1/instanceha_types.go
+++ b/apis/instanceha/v1beta1/instanceha_types.go
@@ -33,7 +33,7 @@ const (
 
 // InstanceHaSpec defines the desired state of InstanceHa
 type InstanceHaSpec struct {
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	// ContainerImage for the the InstanceHa container (will be set to environmental default if empty)
 	ContainerImage string `json:"containerImage"`
 

--- a/config/crd/bases/instanceha.openstack.org_instancehas.yaml
+++ b/config/crd/bases/instanceha.openstack.org_instancehas.yaml
@@ -99,7 +99,6 @@ spec:
                   the secure.yaml
                 type: string
             required:
-            - containerImage
             - fencingSecret
             - instanceHaConfigMap
             - instanceHaKdumpPort


### PR DESCRIPTION
With 502a989f7bbe8291e86750ce1d055feb43f22585 we removed the default value for ContainerImage but forgot to make the parameter optional. 
This commit rectifies this, so users can rely on the defaults set by the operator/webhook.