### PR TITLE
Add centralized topology validation function for service operators

### DIFF
--- a/apis/topology/v1beta1/topology_types.go
+++ b/apis/topology/v1beta1/topology_types.go
@@ -107,11 +107,24 @@ func GetTopologyByName(
 	return topology, hash, nil
 }
 
+// ValidateTopologyRef - returns a field.ErrorList when the Service references an
+// invalid Topology. It currently validates the Namespace but it can be extended
+// as needed
+func ValidateTopologyRef(t *TopoRef, basePath field.Path, namespace string) field.ErrorList {
+	error := field.ErrorList{}
+	if t != nil {
+		if err := ValidateTopologyNamespace(t.Namespace, basePath, namespace); err != nil {
+			error = append(error, err)
+		}
+	}
+	return error
+}
+
 // ValidateTopologyNamespace - returns a field.Error when the Service
 // references a Topoology deployed on a different namespace
 func ValidateTopologyNamespace(refNs string, basePath field.Path, validNs string) *field.Error {
 	if refNs != "" && refNs != validNs {
-		topologyNamespace := basePath.Child("topology").Key("namespace")
+		topologyNamespace := basePath.Key("namespace")
 		return field.Invalid(topologyNamespace, "namespace", "Customizing namespace field is not supported")
 	}
 	return nil


### PR DESCRIPTION
This patch introduces a unified topology validation function that service operators can use to validate `TopologyRef` definitions in their `CRs`.
 Key improvements:
- It creates a single entry point (that can be extended as needed) for all topology validation logic
- It accepts a `TopoRef` parameter and handles `nil` checks internally
- It validates `namespace` correctly without requiring `basePath` centralization (that lives in the service API definition)
- Fixes a bug in `ValidateTopologyNamespace` where a `topology` key was erroneously referenced (there's no topology entry in the CRD).

The new validation function provides a base that can be extended for more complex validation requirements in the future while maintaining consistent behavior across all service operators.

Jira: https://issues.redhat.com/browse/OSPRH-14626