### PR TITLE
Fix topology namespace dereference

### DIFF
--- a/apis/topology/v1beta1/topology_types.go
+++ b/apis/topology/v1beta1/topology_types.go
@@ -124,7 +124,7 @@ func ValidateTopologyRef(t *TopoRef, basePath field.Path, namespace string) fiel
 // references a Topoology deployed on a different namespace
 func ValidateTopologyNamespace(refNs string, basePath field.Path, validNs string) *field.Error {
 	if refNs != "" && refNs != validNs {
-		topologyNamespace := basePath.Key("namespace")
+		topologyNamespace := basePath.Child("namespace")
 		return field.Invalid(topologyNamespace, "namespace", "Customizing namespace field is not supported")
 	}
 	return nil


### PR DESCRIPTION
This patch fixes how we dereference `topologyRef.namespace`. This is a struct and should have `.Child` to access the fields, and not `.Key` which suggests we're accessing an index of a map.

Jira: https://issues.redhat.com/browse/OSPRH-14626