### PR TITLE
Complete webhook validation for topology references

### DIFF
--- a/apis/instanceha/v1beta1/instanceha_types.go
+++ b/apis/instanceha/v1beta1/instanceha_types.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 )
 
@@ -168,4 +169,16 @@ func (instance InstanceHa) GetLastAppliedTopologyRef() *topologyv1.TopoRef {
 			Name:	   lastAppliedTopologyName,
 			Namespace: instance.Namespace,
 	}
+}
+
+// ValidateTopology -
+func (instance *InstanceHaSpec) ValidateTopology(
+	basePath *field.Path,
+	namespace string,
+) field.ErrorList {
+	var allErrs field.ErrorList
+	allErrs = append(allErrs, topologyv1.ValidateTopologyRef(
+		instance.TopologyRef,
+		*basePath.Child("topologyRef"), namespace)...)
+	return allErrs
 }

--- a/apis/instanceha/v1beta1/instanceha_webhook.go
+++ b/apis/instanceha/v1beta1/instanceha_webhook.go
@@ -28,7 +28,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 )
 
 // InstanceHaDefaults -
@@ -87,11 +86,8 @@ func (r *InstanceHa) ValidateCreate() (admission.Warnings, error) {
 
 	// When a TopologyRef CR is referenced, fail if a different Namespace is
 	// referenced because is not supported
-	if r.Spec.TopologyRef != nil {
-		if err := topologyv1.ValidateTopologyNamespace(r.Spec.TopologyRef.Namespace, *basePath, r.Namespace); err != nil {
-			allErrs = append(allErrs, err)
-		}
-	}
+	allErrs = append(allErrs, r.Spec.ValidateTopology(basePath, r.Namespace)...)
+
 	if len(allErrs) != 0 {
 		return allWarn, apierrors.NewInvalid(
 			schema.GroupKind{Group: "instanceha.openstack.org", Kind: "InstanceHa"},
@@ -110,11 +106,8 @@ func (r *InstanceHa) ValidateUpdate(old runtime.Object) (admission.Warnings, err
 
 	// When a TopologyRef CR is referenced, fail if a different Namespace is
 	// referenced because is not supported
-	if r.Spec.TopologyRef != nil {
-		if err := topologyv1.ValidateTopologyNamespace(r.Spec.TopologyRef.Namespace, *basePath, r.Namespace); err != nil {
-			allErrs = append(allErrs, err)
-		}
-	}
+	allErrs = append(allErrs, r.Spec.ValidateTopology(basePath, r.Namespace)...)
+
 	if len(allErrs) != 0 {
 		return allWarn, apierrors.NewInvalid(
 			schema.GroupKind{Group: "instanceha.openstack.org", Kind: "InstanceHa"},

--- a/apis/memcached/v1beta1/memcached_types.go
+++ b/apis/memcached/v1beta1/memcached_types.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 const (
@@ -169,4 +170,16 @@ func (instance Memcached) GetLastAppliedTopologyRef() *topologyv1.TopoRef {
 			Name:	   lastAppliedTopologyName,
 			Namespace: instance.Namespace,
 	}
+}
+
+// ValidateTopology -
+func (instance *MemcachedSpecCore) ValidateTopology(
+	basePath *field.Path,
+	namespace string,
+) field.ErrorList {
+	var allErrs field.ErrorList
+	allErrs = append(allErrs, topologyv1.ValidateTopologyRef(
+		instance.TopologyRef,
+		*basePath.Child("topologyRef"), namespace)...)
+	return allErrs
 }

--- a/apis/network/v1beta1/dnsmasq_types.go
+++ b/apis/network/v1beta1/dnsmasq_types.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 const (
@@ -192,4 +193,16 @@ func (instance DNSMasq) GetLastAppliedTopologyRef() *topologyv1.TopoRef {
 			Name:	   lastAppliedTopologyName,
 			Namespace: instance.Namespace,
 	}
+}
+
+// ValidateTopology -
+func (instance *DNSMasqSpecCore) ValidateTopology(
+	basePath *field.Path,
+	namespace string,
+) field.ErrorList {
+	var allErrs field.ErrorList
+	allErrs = append(allErrs, topologyv1.ValidateTopologyRef(
+		instance.TopologyRef,
+		*basePath.Child("topologyRef"), namespace)...)
+	return allErrs
 }

--- a/apis/rabbitmq/v1beta1/rabbitmq_types.go
+++ b/apis/rabbitmq/v1beta1/rabbitmq_types.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	rabbitmqv2 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 const (
@@ -162,4 +163,16 @@ func (instance RabbitMq) GetLastAppliedTopologyRef() *topologyv1.TopoRef {
 		Name:      lastAppliedTopologyName,
 		Namespace: instance.Namespace,
 	}
+}
+
+// ValidateTopology -
+func (instance *RabbitMqSpecCore) ValidateTopology(
+	basePath *field.Path,
+	namespace string,
+) field.ErrorList {
+	var allErrs field.ErrorList
+	allErrs = append(allErrs, topologyv1.ValidateTopologyRef(
+		instance.TopologyRef,
+		*basePath.Child("topologyRef"), namespace)...)
+	return allErrs
 }

--- a/apis/rabbitmq/v1beta1/rabbitmq_webhook.go
+++ b/apis/rabbitmq/v1beta1/rabbitmq_webhook.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	common_webhook "github.com/openstack-k8s-operators/lib-common/modules/common/webhook"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -90,11 +89,8 @@ func (r *RabbitMq) ValidateCreate() (admission.Warnings, error) {
 
 	// When a TopologyRef CR is referenced, fail if a different Namespace is
 	// referenced because is not supported
-	if r.Spec.TopologyRef != nil {
-		if err := topologyv1.ValidateTopologyNamespace(r.Spec.TopologyRef.Namespace, *basePath, r.Namespace); err != nil {
-			allErrs = append(allErrs, err)
-		}
-	}
+	allErrs = append(allErrs, r.Spec.ValidateTopology(basePath, r.Namespace)...)
+
 	allErrs = append(allErrs, common_webhook.ValidateDNS1123Label(
 		field.NewPath("metadata").Child("name"),
 		[]string{r.Name},
@@ -122,11 +118,7 @@ func (r *RabbitMq) ValidateUpdate(_ runtime.Object) (admission.Warnings, error) 
 
 	// When a TopologyRef CR is referenced, fail if a different Namespace is
 	// referenced because is not supported
-	if r.Spec.TopologyRef != nil {
-		if err := topologyv1.ValidateTopologyNamespace(r.Spec.TopologyRef.Namespace, *basePath, r.Namespace); err != nil {
-			allErrs = append(allErrs, err)
-		}
-	}
+	allErrs = append(allErrs, r.Spec.ValidateTopology(basePath, r.Namespace)...)
 
 	if len(allErrs) != 0 {
 		return allWarn, apierrors.NewInvalid(
@@ -143,11 +135,7 @@ func (r *RabbitMqSpecCore) ValidateCreate(basePath *field.Path, namespace string
 
 	// When a TopologyRef CR is referenced, fail if a different Namespace is
 	// referenced because is not supported
-	if r.TopologyRef != nil {
-		if err := topologyv1.ValidateTopologyNamespace(r.TopologyRef.Namespace, *basePath, namespace); err != nil {
-			allErrs = append(allErrs, err)
-		}
-	}
+	allErrs = append(allErrs, r.ValidateTopology(basePath, namespace)...)
 
 	return allErrs
 }
@@ -157,12 +145,7 @@ func (r *RabbitMqSpecCore) ValidateUpdate(old RabbitMqSpecCore, basePath *field.
 
 	// When a TopologyRef CR is referenced, fail if a different Namespace is
 	// referenced because is not supported
-	if r.TopologyRef != nil {
-		if err := topologyv1.ValidateTopologyNamespace(r.TopologyRef.Namespace, *basePath, namespace); err != nil {
-			allErrs = append(allErrs, err)
-		}
-	}
-
+	allErrs = append(allErrs, r.ValidateTopology(basePath, namespace)...)
 	return allErrs
 }
 

--- a/apis/redis/v1beta1/redis_types.go
+++ b/apis/redis/v1beta1/redis_types.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 const (
@@ -150,4 +151,16 @@ func (instance Redis) GetLastAppliedTopologyRef() *topologyv1.TopoRef {
 			Name:	   lastAppliedTopologyName,
 			Namespace: instance.Namespace,
 	}
+}
+
+// ValidateTopology -
+func (instance *RedisSpecCore) ValidateTopology(
+	basePath *field.Path,
+	namespace string,
+) field.ErrorList {
+	var allErrs field.ErrorList
+	allErrs = append(allErrs, topologyv1.ValidateTopologyRef(
+		instance.TopologyRef,
+		*basePath.Child("topologyRef"), namespace)...)
+	return allErrs
 }

--- a/apis/redis/v1beta1/redis_webhook.go
+++ b/apis/redis/v1beta1/redis_webhook.go
@@ -32,7 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	common_webhook "github.com/openstack-k8s-operators/lib-common/modules/common/webhook"
 )
 
@@ -103,11 +102,7 @@ func (r *Redis) ValidateCreate() (admission.Warnings, error) {
 
 	// When a TopologyRef CR is referenced, fail if a different Namespace is
 	// referenced because is not supported
-	if r.Spec.TopologyRef != nil {
-		if err := topologyv1.ValidateTopologyNamespace(r.Spec.TopologyRef.Namespace, *basePath, r.Namespace); err != nil {
-			allErrs = append(allErrs, err)
-		}
-	}
+	allErrs = append(allErrs, r.Spec.ValidateTopology(basePath, r.Namespace)...)
 
 	if len(allErrs) != 0 {
 		return allWarn, apierrors.NewInvalid(
@@ -130,11 +125,8 @@ func (r *Redis) ValidateUpdate(_ runtime.Object) (admission.Warnings, error) {
 
 	// When a TopologyRef CR is referenced, fail if a different Namespace is
 	// referenced because is not supported
-	if r.Spec.TopologyRef != nil {
-		if err := topologyv1.ValidateTopologyNamespace(r.Spec.TopologyRef.Namespace, *basePath, r.Namespace); err != nil {
-			allErrs = append(allErrs, err)
-		}
-	}
+	allErrs = append(allErrs, r.Spec.ValidateTopology(basePath, r.Namespace)...)
+
 	return allWarn, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.20.1
 	github.com/onsi/gomega v1.34.1
 	github.com/openshift/api v3.9.0+incompatible
-	github.com/openstack-k8s-operators/infra-operator/apis v0.5.1-0.20250218115938-ae95bdfefded
+	github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250319162810-463dd75a4cc4
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20250315090821-34e570d2d5fb
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.6.1-0.20250315090821-34e570d2d5fb
 	github.com/rabbitmq/cluster-operator/v2 v2.9.0

--- a/tests/functional/memcached_controller_test.go
+++ b/tests/functional/memcached_controller_test.go
@@ -165,7 +165,7 @@ var _ = Describe("Memcached Controller", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(
 				ContainSubstring(
-					"Invalid value: \"namespace\": Customizing namespace field is not supported"),
+					"spec.topologyRef.namespace: Invalid value: \"namespace\": Customizing namespace field is not supported"),
 			)
 		})
 	})


### PR DESCRIPTION
This patch is a follow up of [1] in the validation `webhook` area. It enhances the validation workflow and it aims to complete the pattern by distributing the `ValidateTopology` logic across the `API` instances.
It is based on [2] and the key improvements include:

- `Distributed validation`: it provides a `ValidateTopology` function across all API instances, ensuring consistent validation throughout the system
- `Optimized validation calls`: it refines how validation is triggered and reduce code duplication; it still requires a basic struct refactor to fully de-duplicate the existing functions, but it can be done as part of a follow up

This patch leverages the centralized topology validator introduced in `infra-operator` [3].

Jira: https://issues.redhat.com/browse/OSPRH-14626

[1] openstack-k8s-operators#924
[2] openstack-k8s-operators/nova-operator#936
[3] openstack-k8s-operators/infra-operator#356