### PR TITLE
Run memcached service using memcached user

### DIFF
--- a/pkg/memcached/const.go
+++ b/pkg/memcached/const.go
@@ -20,4 +20,7 @@ const (
 	MemcachedPort int32 = 11211
 	// MemcachedTLSPort -
 	MemcachedTLSPort int32 = 11212
+	// MemcachedUID -
+	// https://github.com/openstack/kolla/blob/master/kolla/common/users.py
+	MemcachedUID int64 = 42457
 )

--- a/pkg/memcached/statefulset.go
+++ b/pkg/memcached/statefulset.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 )
 
 // StatefulSet returns a Stateful resource for the Memcached CR
@@ -25,7 +26,6 @@ func StatefulSet(
 		common.OwnerSelector: "infra-operator",
 	}
 	ls := labels.GetLabels(m, "memcached", matchls)
-	runAsUser := int64(0)
 
 	livenessProbe := &corev1.Probe{
 		// TODO might need tuning
@@ -69,7 +69,8 @@ func StatefulSet(
 						Name:    "memcached",
 						Command: []string{"/usr/bin/dumb-init", "--", "/usr/local/bin/kolla_start"},
 						SecurityContext: &corev1.SecurityContext{
-							RunAsUser: &runAsUser,
+							RunAsUser:  ptr.To(MemcachedUID),
+							RunAsGroup: ptr.To(MemcachedUID),
 						},
 						Env: []corev1.EnvVar{{
 							Name:  "KOLLA_CONFIG_STRATEGY",


### PR DESCRIPTION
This patch represents an improvement of the existing code to make sure we run memcached services using the memcached user (provided by kolla) instead of root.

Jira: https://issues.redhat.com/browse/OSPRH-15334