### PR TITLE
Optimize EnsureDeletedTopologyRef condition

### DIFF
--- a/apis/memcached/v1beta1/memcached_types.go
+++ b/apis/memcached/v1beta1/memcached_types.go
@@ -159,19 +159,6 @@ func init() {
 	SchemeBuilder.Register(&Memcached{}, &MemcachedList{})
 }
 
-// GetLastAppliedTopologyRef - Returns the lastAppliedTopologyName that can be
-// processed by the handle topology logic
-func (instance Memcached) GetLastAppliedTopologyRef() *topologyv1.TopoRef {
-	lastAppliedTopologyName := ""
-	if instance.Status.LastAppliedTopology != nil {
-			lastAppliedTopologyName = instance.Status.LastAppliedTopology.Name
-	}
-	return &topologyv1.TopoRef{
-			Name:	   lastAppliedTopologyName,
-			Namespace: instance.Namespace,
-	}
-}
-
 // ValidateTopology -
 func (instance *MemcachedSpecCore) ValidateTopology(
 	basePath *field.Path,

--- a/apis/network/v1beta1/dnsmasq_types.go
+++ b/apis/network/v1beta1/dnsmasq_types.go
@@ -182,19 +182,6 @@ func SetupDefaults() {
 	SetupDNSMasqDefaults(dnsMasqDefaults)
 }
 
-// GetLastAppliedTopologyRef - Returns the lastAppliedTopologyName that can be
-// processed by the handle topology logic
-func (instance DNSMasq) GetLastAppliedTopologyRef() *topologyv1.TopoRef {
-	lastAppliedTopologyName := ""
-	if instance.Status.LastAppliedTopology != nil {
-			lastAppliedTopologyName = instance.Status.LastAppliedTopology.Name
-	}
-	return &topologyv1.TopoRef{
-			Name:	   lastAppliedTopologyName,
-			Namespace: instance.Namespace,
-	}
-}
-
 // ValidateTopology -
 func (instance *DNSMasqSpecCore) ValidateTopology(
 	basePath *field.Path,

--- a/apis/rabbitmq/v1beta1/rabbitmq_types.go
+++ b/apis/rabbitmq/v1beta1/rabbitmq_types.go
@@ -152,19 +152,6 @@ func SetupDefaults() {
 	SetupRabbitMqDefaults(rabbitMqDefaults)
 }
 
-// GetLastAppliedTopologyRef - Returns the lastAppliedTopologyName that can be
-// processed by the handle topology logic
-func (instance RabbitMq) GetLastAppliedTopologyRef() *topologyv1.TopoRef {
-	lastAppliedTopologyName := ""
-	if instance.Status.LastAppliedTopology != nil {
-		lastAppliedTopologyName = instance.Status.LastAppliedTopology.Name
-	}
-	return &topologyv1.TopoRef{
-		Name:      lastAppliedTopologyName,
-		Namespace: instance.Namespace,
-	}
-}
-
 // ValidateTopology -
 func (instance *RabbitMqSpecCore) ValidateTopology(
 	basePath *field.Path,

--- a/apis/test/helpers/topology.go
+++ b/apis/test/helpers/topology.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2025 Red Hat
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	t "github.com/onsi/gomega"
+)
+
+// CreateTopology - Creates a Topology CR based on the spec passed as input
+func (tc *TestHelper) CreateTopology(topology types.NamespacedName, spec map[string]interface{}) (client.Object, topologyv1.TopoRef) {
+	raw := map[string]interface{}{
+		"apiVersion": "topology.openstack.org/v1beta1",
+		"kind":       "Topology",
+		"metadata": map[string]interface{}{
+			"name":      topology.Name,
+			"namespace": topology.Namespace,
+		},
+		"spec": spec,
+	}
+	// other than creating the topology based on the raw spec, we return the
+	// TopoRef that can be referenced
+	topologyRef := topologyv1.TopoRef{
+		Name:      topology.Name,
+		Namespace: topology.Namespace,
+	}
+	return tc.CreateUnstructured(raw), topologyRef
+}
+
+// GetTopology - Returns the referenced Topology
+func (tc *TestHelper) GetTopology(name types.NamespacedName) *topologyv1.Topology {
+	instance := &topologyv1.Topology{}
+	t.Eventually(func(g t.Gomega) {
+		g.Expect(tc.K8sClient.Get(tc.Ctx, name, instance)).Should(t.Succeed())
+	}, tc.Timeout, tc.Interval).Should(t.Succeed())
+	return instance
+}

--- a/apis/topology/v1beta1/topology_types.go
+++ b/apis/topology/v1beta1/topology_types.go
@@ -266,8 +266,8 @@ func EnsureServiceTopology(
 	// 2. a topology reference is updated in the Service Component CR (tpRef != nil)
 	//    and the finalizer should be removed from the previously
 	//    referenced topology (tpRef.Name != lastAppliedTopology.Name)
-	if (tpRef == nil && lastAppliedTopology != nil) ||
-		(tpRef != nil && tpRef.Name != lastAppliedTopology.Name) {
+	if (lastAppliedTopology != nil) &&
+		(tpRef == nil || tpRef.Name != lastAppliedTopology.Name) {
 		_, err = EnsureDeletedTopologyRef(
 			ctx,
 			helper,

--- a/controllers/memcached/memcached_controller.go
+++ b/controllers/memcached/memcached_controller.go
@@ -412,7 +412,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 		ctx,
 		helper,
 		instance.Spec.TopologyRef,
-		instance.GetLastAppliedTopologyRef(),
+		instance.Status.LastAppliedTopology,
 		instance.Name,
 		labels.GetLabelSelector(serviceLabels),
 	)

--- a/controllers/network/dnsmasq_controller.go
+++ b/controllers/network/dnsmasq_controller.go
@@ -526,7 +526,7 @@ func (r *DNSMasqReconciler) reconcileNormal(ctx context.Context, instance *netwo
 		ctx,
 		helper,
 		instance.Spec.TopologyRef,
-		instance.GetLastAppliedTopologyRef(),
+		instance.Status.LastAppliedTopology,
 		instance.Name,
 		labels.GetLabelSelector(serviceLabels),
 	)

--- a/controllers/rabbitmq/rabbitmq_controller.go
+++ b/controllers/rabbitmq/rabbitmq_controller.go
@@ -303,7 +303,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 		ctx,
 		helper,
 		instance.Spec.TopologyRef,
-		instance.GetLastAppliedTopologyRef(),
+		instance.Status.LastAppliedTopology,
 		instance.Name,
 		labels.GetLabelSelector(
 			map[string]string{


### PR DESCRIPTION
As a follow up of [1] it is ok to simplify the service operators and blindly pass `instance.Status.LastAppliedTopology` to `EnsureServiceTopology` function provided by infra-operator.
The logic that removes the `finalizer` from an existing `TopologyRef` (only when `LastAppliedTopology != nil`) is now moved here, resulting in a simplification of the current operators logic.
This patch resolves yet another tech debt generated by the fact that we started with a different implementation of `LastAppliedTopology` (based on the `.Name` `string`), that later has been aligned with the existing `TopoRef` struct.

Jira: https://issues.redhat.com/browse/OSPRH-15072

[1] https://github.com/openstack-k8s-operators/placement-operator/pull/285#discussion_r1967176124