### PR TITLE
Remove redundant _host_fence() call before result check

### DIFF
--- a/templates/instanceha/bin/instanceha.py
+++ b/templates/instanceha/bin/instanceha.py
@@ -692,7 +692,6 @@ def process_service(service, reserved_hosts, resume):
     if not resume:
         try:
             logging.info('Fencing %s' % service.host)
-            _host_fence(service.host, 'off')
             fence_result = _host_fence(service.host, 'off')
             if not fence_result:
                 logging.error('Fencing failed for %s, skipping evacuation' % service.host)


### PR DESCRIPTION
This commit:

1. Removes a duplicate call to `_host_fence()` in the `process_service` function. The function was being called once without using the return value, and immediately after with error handling.

Co-authored-by: Luca Miccini <lmiccini@redhat.com>