### PR TITLE
[golang] bump to golang 1.22

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: tools
   namespace: openstack-k8s-operators
-  tag: ci-build-root-golang-1.21-sdk-1.31
+  tag: ci-build-root-golang-1.22-sdk-1.31

--- a/.github/workflows/build-infra-operator.yaml
+++ b/.github/workflows/build-infra-operator.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/reusable-build-operator.yaml@main
     with:
       operator_name: infra
-      go_version: 1.21.x
+      go_version: 1.22.x
       operator_sdk_version: 1.31.0
     secrets:
       IMAGENAMESPACE: ${{ secrets.IMAGENAMESPACE }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
       exclude: ^vendor
 
 - repo: https://github.com/golangci/golangci-lint
-  rev: v1.59.1
+  rev: v1.63.4
   hooks:
     - id: golangci-lint-full
       args: ["-v"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOLANG_BUILDER=registry.access.redhat.com/ubi9/go-toolset:1.21
+ARG GOLANG_BUILDER=registry.access.redhat.com/ubi9/go-toolset:1.22
 ARG OPERATOR_BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Build the manager binary

--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ GINKGO ?= $(LOCALBIN)/ginkgo
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
-GOTOOLCHAIN_VERSION ?= go1.21.0
+GOTOOLCHAIN_VERSION ?= go1.22.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -1,6 +1,6 @@
 module github.com/openstack-k8s-operators/infra-operator/apis
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-logr/logr v1.4.2

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/onsi/gomega v1.34.1
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20250419062702-0acec6a591c8
 	github.com/rabbitmq/cluster-operator/v2 v2.9.0
-	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	k8s.io/api v0.29.15
 	k8s.io/apimachinery v0.29.15
 	k8s.io/client-go v0.29.15
@@ -53,6 +52,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
+	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/net v0.28.0 // indirect
 	golang.org/x/oauth2 v0.18.0 // indirect
 	golang.org/x/sys v0.23.0 // indirect

--- a/apis/network/v1beta1/ipset_webhook.go
+++ b/apis/network/v1beta1/ipset_webhook.go
@@ -19,9 +19,9 @@ package v1beta1
 import (
 	"fmt"
 	"net"
+	"slices"
 	"strings"
 
-	"golang.org/x/exp/slices"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/apis/network/v1beta1/netconfig_webhook.go
+++ b/apis/network/v1beta1/netconfig_webhook.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 	"net"
 	"regexp"
+	"slices"
 	"strconv"
 
-	"golang.org/x/exp/slices"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/controllers/instanceha/instanceha_controller.go
+++ b/controllers/instanceha/instanceha_controller.go
@@ -328,7 +328,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
-					fmt.Sprintf(condition.TLSInputReadyWaitingMessage, instance.Spec.CaBundleSecretName)))
+					condition.TLSInputReadyWaitingMessage, instance.Spec.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
 			instance.Status.Conditions.Set(condition.FalseCondition(

--- a/controllers/memcached/memcached_controller.go
+++ b/controllers/memcached/memcached_controller.go
@@ -258,7 +258,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
-					fmt.Sprintf(condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName)))
+					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
 			instance.Status.Conditions.Set(condition.FalseCondition(
@@ -284,7 +284,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
-					fmt.Sprintf(condition.TLSInputReadyWaitingMessage, err.Error())))
+					condition.TLSInputReadyWaitingMessage, err.Error()))
 				return ctrl.Result{}, nil
 			}
 			instance.Status.Conditions.Set(condition.FalseCondition(
@@ -308,7 +308,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 						memcachedv1.MTLSInputReadyCondition,
 						condition.RequestedReason,
 						condition.SeverityInfo,
-						fmt.Sprintf(condition.TLSInputReadyWaitingMessage, err.Error())))
+						condition.TLSInputReadyWaitingMessage, err.Error()))
 					return ctrl.Result{}, nil
 				}
 				instance.Status.Conditions.Set(condition.FalseCondition(
@@ -327,7 +327,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 				memcachedv1.MTLSInputReadyCondition,
 				condition.RequestedReason,
 				condition.SeverityInfo,
-				fmt.Sprintf(memcachedv1.MTLSInputReadyWaitingMessage)))
+				"%s", fmt.Sprintf(memcachedv1.MTLSInputReadyWaitingMessage)))
 			return ctrl.Result{}, nil
 		}
 	}

--- a/controllers/network/bgpconfiguration_controller.go
+++ b/controllers/network/bgpconfiguration_controller.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
-	"golang.org/x/exp/slices"
 	"k8s.io/apimachinery/pkg/api/equality"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/controllers/network/bgpconfiguration_controller.go
+++ b/controllers/network/bgpconfiguration_controller.go
@@ -496,7 +496,7 @@ func getPodNetworkDetails(
 
 				// verify the nodeName information is already present in the pod spec, otherwise report an error to reconcile
 				if pod.Spec.NodeName == "" {
-					return detailList, fmt.Errorf(fmt.Sprintf("empty spec.nodeName on pod %s", pod.Name))
+					return detailList, fmt.Errorf("empty spec.nodeName on pod %s", pod.Name)
 				}
 
 				detail := bgp.PodDetail{
@@ -513,8 +513,8 @@ func getPodNetworkDetails(
 				// reflect all requested networks. return with an error to reconcile if the length
 				// is <= the status. Note: the status also has the pod network
 				if len(netsStatus) <= len(netAttach) {
-					return detailList, fmt.Errorf(fmt.Sprintf("metadata.Annotations['k8s.ovn.org/pod-networks'] %s on pod %s, does not match requested networks %s",
-						pod.GetAnnotations()[k8s_networkv1.NetworkStatusAnnot], pod.Name, netAttachString))
+					return detailList, fmt.Errorf("metadata.Annotations['k8s.ovn.org/pod-networks'] %s on pod %s, does not match requested networks %s",
+						pod.GetAnnotations()[k8s_networkv1.NetworkStatusAnnot], pod.Name, netAttachString)
 				}
 
 				var netsStatusCopy = make([]k8s_networkv1.NetworkStatus, len(netsStatus))
@@ -550,7 +550,7 @@ func getPodNetworkDetails(
 
 					// verify there is IP information for the network, otherwise report an error to reconcile
 					if len(netStat.IPs) == 0 {
-						return detailList, fmt.Errorf(fmt.Sprintf("no IP information for network %s on pod %s", netStat.Name, pod.Name))
+						return detailList, fmt.Errorf("no IP information for network %s on pod %s", netStat.Name, pod.Name)
 					}
 				}
 

--- a/controllers/network/service_controller.go
+++ b/controllers/network/service_controller.go
@@ -130,7 +130,7 @@ func (r *ServiceReconciler) getServiceDNSData(
 					for _, ingr := range svc.Status.LoadBalancer.Ingress {
 						addr := net.ParseIP(ingr.IP)
 						if addr == nil {
-							return nil, fmt.Errorf(fmt.Sprintf("unrecognized address %s", ingr.IP))
+							return nil, fmt.Errorf("unrecognized address %s", ingr.IP)
 						}
 
 						if host, ok := svcDNSHosts[addr.String()]; !ok {

--- a/controllers/rabbitmq/rabbitmq_controller.go
+++ b/controllers/rabbitmq/rabbitmq_controller.go
@@ -195,7 +195,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
-					fmt.Sprintf(condition.TLSInputReadyWaitingMessage, err.Error())))
+					condition.TLSInputReadyWaitingMessage, err.Error()))
 				return ctrl.Result{}, nil
 			}
 			instance.Status.Conditions.Set(condition.FalseCondition(

--- a/controllers/redis/redis_controller.go
+++ b/controllers/redis/redis_controller.go
@@ -244,7 +244,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
-					fmt.Sprintf(condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName)))
+					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
 			instance.Status.Conditions.Set(condition.FalseCondition(
@@ -270,7 +270,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
-					fmt.Sprintf(condition.TLSInputReadyWaitingMessage, err.Error())))
+					condition.TLSInputReadyWaitingMessage, err.Error()))
 				return ctrl.Result{}, nil
 			}
 			instance.Status.Conditions.Set(condition.FalseCondition(

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openstack-k8s-operators/infra-operator
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-logr/logr v1.4.2

--- a/pkg/ipam/funcs.go
+++ b/pkg/ipam/funcs.go
@@ -49,7 +49,7 @@ func (a *AssignIPDetails) fixedIPExists() (*networkv1.IPAddress, error) {
 	}
 	idx := slices.IndexFunc(a.Reservelist.Items, f)
 	if idx >= 0 && a.Reservelist.Items[idx].Spec.IPSetRef.Name != a.IPSet {
-		return nil, fmt.Errorf(fmt.Sprintf("%s already reserved for %s", fixedIP, a.Reservelist.Items[idx].Spec.IPSetRef.Name))
+		return nil, fmt.Errorf("%s already reserved for %s", fixedIP, a.Reservelist.Items[idx].Spec.IPSetRef.Name)
 	}
 
 	return &networkv1.IPAddress{
@@ -107,5 +107,5 @@ func (a *AssignIPDetails) iterateForAssignment() (*networkv1.IPAddress, error) {
 		}
 	}
 
-	return nil, fmt.Errorf(fmt.Sprintf("no ip address could be created for %s in subnet %s", a.IPSet, a.SubNet.Name))
+	return nil, fmt.Errorf("no ip address could be created for %s in subnet %s", a.IPSet, a.SubNet.Name)
 }

--- a/pkg/ipam/funcs.go
+++ b/pkg/ipam/funcs.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"slices"
 
 	networkv1 "github.com/openstack-k8s-operators/infra-operator/apis/network/v1beta1"
-	"golang.org/x/exp/slices"
 )
 
 // AssignIPDetails -

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -7,5 +7,5 @@
       jobs:
         - openstack-k8s-operators-content-provider:
             vars:
-              cifmw_operator_build_golang_ct: "docker.io/library/golang:1.21"
-              cifmw_operator_build_golang_alt_ct: "quay.rdoproject.org/openstack-k8s-operators/golang:1.21"
+              cifmw_operator_build_golang_ct: "docker.io/library/golang:1.22"
+              cifmw_operator_build_golang_alt_ct: "quay.rdoproject.org/openstack-k8s-operators/golang:1.22"


### PR DESCRIPTION
* bump in go.mod (base and api)
* bump go-toolset in Dockerfile
* bump in github jobs ('.github/workflows')
* Bump the golangci-lint version in the .pre-commit-config.yaml to v1.63.4
* Bump build_root_image in .ci-operator.yaml to ci-build-root-golang-1.22-sdk-1.31 (if set)

To test on existing env:
* update golang to 1.22
* delete current `go.work*` files
* init go work files `go work init`

Jira: [OSPRH-12935](https://issues.redhat.com//browse/OSPRH-12935)