### PR TITLE
[bgp] fix Makefile test target + add envtest test case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ PROC_CMD = --procs ${PROCS}
 test: manifests generate gowork fmt vet envtest ginkgo ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) -v debug --bin-dir $(LOCALBIN) use $(ENVTEST_K8S_VERSION) -p path)" \
 	OPERATOR_TEMPLATES="$(PWD)/templates" \
-	$(GINKGO) --trace --cover --coverpkg=../../pkg/dnsmasq,../../pkg/ipam,../../controllers,../../apis/network/v1beta1 --coverprofile cover.out --covermode=atomic ${PROC_CMD} $(GINKGO_ARGS) ./tests/... ./apis/network/...
+	$(GINKGO) --trace --cover --coverpkg=../../pkg/bgp,../../pkg/dnsmasq,../../pkg/ipam,../../controllers,../../apis/network/v1beta1 --coverprofile cover.out --covermode=atomic ${PROC_CMD} $(GINKGO_ARGS) ./tests/... ./apis/network/...
 
 ##@ Build
 


### PR DESCRIPTION
Adds bgp pkg to run functional tests with `make test`. Also adds an envtest to validate when BGPConfiguration CR is deleted, finalizer logic removes owned FRRConfiguration objects.