### PR TITLE
[bgp] Mismatch between field name and JSON tag for NodeName.

### DIFF
--- a/apis/bases/network.openstack.org_bgpconfigurations.yaml
+++ b/apis/bases/network.openstack.org_bgpconfigurations.yaml
@@ -52,7 +52,7 @@ spec:
                 items:
                   description: FRRNodeConfigurationSelectorType -
                   properties:
-                    frrConfigurationNamespace:
+                    nodeName:
                       description: NodeName -  name of the node object as seen by
                         running the `oc get nodes` command
                       type: string

--- a/apis/network/v1beta1/bgpconfiguration_types.go
+++ b/apis/network/v1beta1/bgpconfiguration_types.go
@@ -25,7 +25,7 @@ import (
 type FRRNodeConfigurationSelectorType struct {
 	// +kubebuilder:validation:Optional
 	// NodeName -  name of the node object as seen by running the `oc get nodes` command
-	NodeName string `json:"frrConfigurationNamespace,omitempty"`
+	NodeName string `json:"nodeName,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// NodeSelector  to identify the correct FRRConfiguration from spec.nodeSelector

--- a/config/crd/bases/network.openstack.org_bgpconfigurations.yaml
+++ b/config/crd/bases/network.openstack.org_bgpconfigurations.yaml
@@ -52,7 +52,7 @@ spec:
                 items:
                   description: FRRNodeConfigurationSelectorType -
                   properties:
-                    frrConfigurationNamespace:
+                    nodeName:
                       description: NodeName -  name of the node object as seen by
                         running the `oc get nodes` command
                       type: string


### PR DESCRIPTION
Update the JSON tag from 'frrConfigurationNamespace' to 'nodeName' so it matches the field and avoids CRD decoding errors.
Jira: https://issues.redhat.com/browse/OSPRH-16550