### PR TITLE
Optimize pkg/ipam

### DIFF
--- a/controllers/network/ipset_controller.go
+++ b/controllers/network/ipset_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/netip"
 	"sort"
 	"strings"
 
@@ -432,8 +433,11 @@ func (r *IPSetReconciler) ensureReservation(
 		}
 
 		if ipsetNet.FixedIP != nil {
-			ipDetails.FixedIP = net.ParseIP(string(*ipsetNet.FixedIP))
-			if ipDetails.FixedIP == nil {
+			ipDetails.FixedIP, err = netip.ParseAddr(string(*ipsetNet.FixedIP))
+			if err != nil {
+				return nil, fmt.Errorf("failed parse FixedIP %s", string(*ipsetNet.FixedIP))
+			}
+			if !ipDetails.FixedIP.IsValid() {
 				return nil, fmt.Errorf("failed parse FixedIP %s", string(*ipsetNet.FixedIP))
 			}
 		}

--- a/pkg/ipam/funcs.go
+++ b/pkg/ipam/funcs.go
@@ -2,11 +2,9 @@ package ipam
 
 import (
 	"fmt"
-	"net"
 	"net/netip"
 
 	networkv1 "github.com/openstack-k8s-operators/infra-operator/apis/network/v1beta1"
-	"golang.org/x/exp/slices"
 )
 
 // AssignIPDetails -
@@ -15,12 +13,58 @@ type AssignIPDetails struct {
 	NetName     string
 	SubNet      *networkv1.Subnet
 	Reservelist *networkv1.ReservationList
-	FixedIP     net.IP
+	FixedIP     netip.Addr
+	// internal use only
+	excluded map[netip.Addr]bool
+	reserved map[netip.Addr]string
+}
+
+func (a *AssignIPDetails) buildExcluded() error {
+	if a.excluded != nil {
+		return nil
+	}
+	a.excluded = make(map[netip.Addr]bool, len(a.SubNet.ExcludeAddresses))
+	for _, ipStr := range a.SubNet.ExcludeAddresses {
+		if ip, err := netip.ParseAddr(ipStr); err == nil {
+			a.excluded[ip] = true
+		} else {
+			return fmt.Errorf("failed to parse ExcludeAddresses %s: %w", ipStr, err)
+		}
+	}
+	return nil
+}
+
+func (a *AssignIPDetails) buildReserved() error {
+	if a.reserved != nil {
+		return nil
+	}
+	a.reserved = make(map[netip.Addr]string, len(a.Reservelist.Items))
+	for _, r := range a.Reservelist.Items {
+		if res, ok := r.Spec.Reservation[a.NetName]; ok {
+			if ip, err := netip.ParseAddr(res.Address); err == nil {
+				a.reserved[ip] = r.Spec.IPSetRef.Name
+			} else {
+				return fmt.Errorf("failed to parse reservation ip %s: %w", res.Address, err)
+			}
+		}
+	}
+	return nil
 }
 
 // AssignIP assigns an IP using a range and a reserve list.
 func (a *AssignIPDetails) AssignIP() (*networkv1.IPAddress, error) {
-	if a.FixedIP != nil {
+
+	err := a.buildExcluded()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build excluded IPs: %w", err)
+
+	}
+	err = a.buildReserved()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build reserved IPs: %w", err)
+	}
+
+	if a.FixedIP.IsValid() {
 		reservation, err := a.fixedIPExists()
 		if err != nil {
 			return nil, err
@@ -38,74 +82,67 @@ func (a *AssignIPDetails) AssignIP() (*networkv1.IPAddress, error) {
 }
 
 func (a *AssignIPDetails) fixedIPExists() (*networkv1.IPAddress, error) {
-	fixedIP := a.FixedIP.String()
-	if slices.Contains(a.SubNet.ExcludeAddresses, fixedIP) {
-		return nil, fmt.Errorf("FixedIP %s is in ExcludeAddresses", fixedIP)
+
+	if _, ok := a.excluded[a.FixedIP]; ok {
+		return nil, fmt.Errorf("FixedIP %s is in ExcludeAddresses", a.FixedIP.String())
 	}
 
-	// validate of nextip is already in a reservation and its not us
-	f := func(c networkv1.Reservation) bool {
-		return c.Spec.Reservation[a.NetName].Address == fixedIP
-	}
-	idx := slices.IndexFunc(a.Reservelist.Items, f)
-	if idx >= 0 && a.Reservelist.Items[idx].Spec.IPSetRef.Name != a.IPSet {
-		return nil, fmt.Errorf(fmt.Sprintf("%s already reserved for %s", fixedIP, a.Reservelist.Items[idx].Spec.IPSetRef.Name))
+	if reservedIPSet, ok := a.reserved[a.FixedIP]; ok && reservedIPSet != a.IPSet {
+		return nil, fmt.Errorf("%s already reserved for %s", a.FixedIP.String(), reservedIPSet)
 	}
 
 	return &networkv1.IPAddress{
 		Network: networkv1.NetNameStr(a.NetName),
 		Subnet:  a.SubNet.Name,
-		Address: fixedIP,
+		Address: a.FixedIP.String(),
 	}, nil
 }
 
-// IterateForAssignment iterates given an IP/IPNet and a list of reserved IPs
 func (a *AssignIPDetails) iterateForAssignment() (*networkv1.IPAddress, error) {
+
 	for _, allocRange := range a.SubNet.AllocationRanges {
 		firstip, err := netip.ParseAddr(allocRange.Start)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse AllocationRange.Start IP %s: %w", allocRange.Start, err)
+			return nil, fmt.Errorf("failed to parse allocation range start IP %s: %w", allocRange.Start, err)
 		}
 		lastip, err := netip.ParseAddr(allocRange.End)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse AllocationRange.End IP %s: %w", allocRange.End, err)
+			return nil, fmt.Errorf("failed to parse allocation range end IP %s: %w", allocRange.End, err)
 		}
 
-		// Iterate every IP address in the range
-		nextip, _ := netip.ParseAddr(firstip.String())
-		endip, _ := netip.ParseAddr(lastip.String())
-		for nextip.Compare(endip) < 1 {
-			// Skip addresses ending with 0
-			ipSlice := nextip.AsSlice()
-			if (nextip.Is4()) && (ipSlice[3] == 0) || (nextip.Is6() && (ipSlice[14] == 0) && (ipSlice[15] == 0)) {
-				nextip = nextip.Next()
+		for ip := firstip; ip.Compare(lastip) <= 0; ip = ip.Next() {
+
+			if ip.Is4() {
+				ip4 := ip.As4()
+				// Skip ipv4 addresses ending with 0
+				if ip4[3] == 0 {
+					continue
+				}
+			}
+
+			if ip.Is6() {
+				ip16 := ip.As16()
+				// Skip ipv6 addresses ending with 0
+				if ip16[14] == 0 && ip16[15] == 0 {
+					continue
+				}
+			}
+
+			// check if the IP is in the excluded or reserved sets
+			if _, ok := a.excluded[ip]; ok {
+				continue
+			}
+			if reservedIPSet, ok := a.reserved[ip]; ok && reservedIPSet != a.IPSet {
 				continue
 			}
 
-			// Skip if in ExcludeAddresses list
-			if slices.Contains(a.SubNet.ExcludeAddresses, nextip.String()) {
-				nextip = nextip.Next()
-				continue
-			}
-
-			// validate of nextip is already in a reservation and its not us
-			f := func(c networkv1.Reservation) bool {
-				return c.Spec.Reservation[a.NetName].Address == nextip.String()
-			}
-			idx := slices.IndexFunc(a.Reservelist.Items, f)
-			if idx >= 0 && a.Reservelist.Items[idx].Spec.IPSetRef.Name != a.IPSet {
-				nextip = nextip.Next()
-				continue
-			}
-
-			// Found a free IP
 			return &networkv1.IPAddress{
 				Network: networkv1.NetNameStr(a.NetName),
 				Subnet:  a.SubNet.Name,
-				Address: nextip.String(),
+				Address: ip.String(),
 			}, nil
 		}
 	}
 
-	return nil, fmt.Errorf(fmt.Sprintf("no ip address could be created for %s in subnet %s", a.IPSet, a.SubNet.Name))
+	return nil, fmt.Errorf("no ip address could be created for %s in subnet %s", a.IPSet, a.SubNet.Name)
 }


### PR DESCRIPTION
Significantly reduce net/netip.Addr.string4 allocations by

 * caching exclude and reservation IPs
 * reduce inner loop conversion to strings
 * reduce inner loop parsing of strings and comparison

Jira: [OSPRH-17235](https://issues.redhat.com//browse/OSPRH-17235)