### PR TITLE
Add maxDescLen=0 in Makefile to avoid the issue of metadata.annotations too long

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,9 @@ SHELL = /usr/bin/env bash -o pipefail
 # Extra vars which will be passed to the Docker-build
 DOCKER_BUILD_ARGS ?=
 
+# To remove the description from CRDs and avoid too large error
+CRDDESC_OVERRIDE ?= :maxDescLen=0
+
 .PHONY: all
 all: build
 
@@ -95,7 +98,7 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: gowork controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd:maxDescLen=0 webhook paths="./..." output:crd:artifacts:config=config/crd/bases && \
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd$(CRDDESC_OVERRIDE) webhook paths="./..." output:crd:artifacts:config=config/crd/bases && \
 	rm -f apis/bases/* && cp -a config/crd/bases apis/
 
 .PHONY: generate


### PR DESCRIPTION
Add maxDescLen=0 in Makefile to avoid the following error while applying rabbitmq.openstack.org_rabbitmqs.yaml
```
# kubectl apply -f config/crd/bases/rabbitmq.openstack.org_rabbitmqs.yaml
The CustomResourceDefinition "rabbitmqs.rabbitmq.openstack.org" is invalid: metadata.annotations: Too long: may not be more than 262144 bytes
#
```