### PR TITLE
Remove duplicate func GetLog

### DIFF
--- a/controllers/rabbitmq/transporturl_controller.go
+++ b/controllers/rabbitmq/transporturl_controller.go
@@ -55,11 +55,6 @@ func (r *TransportURLReconciler) GetKClient() kubernetes.Interface {
 	return r.Kclient
 }
 
-// GetLogger returns a logger object with a prefix of "controller.name" and additional controller context fields
-func GetLog(ctx context.Context) logr.Logger {
-	return log.FromContext(ctx).WithName("Controllers").WithName("TransportURL")
-}
-
 // GetScheme -
 func (r *TransportURLReconciler) GetScheme() *runtime.Scheme {
 	return r.Scheme


### PR DESCRIPTION
The rabbitmq/transporturl_controller implements two method 'GetLog' and 'GetLogger' for getting logger object and are duplicate methods.
This change removes 'GetLog' function as it is not used anywhere.