### PR TITLE
Make fencing details fetching agnostic to short vs fqdn hostname

### DIFF
--- a/templates/instanceha/bin/instanceha.py
+++ b/templates/instanceha/bin/instanceha.py
@@ -574,7 +574,7 @@ def _host_fence(host, action):
 
     try:
         # Collecting fencing data for the given host
-        fencing_data = [value for key, value in fencing.items() if key in host.split('.', 1)[0]][0]
+        fencing_data = [value for key, value in fencing.items() if host.split('.', 1)[0] in key][0]
 
     except:
         logging.error('No fencing data found for %s' % host)


### PR DESCRIPTION
By switching the comparison we make sure we match vs both short hostnames and fqdns when fetching fencing details from the secret.

Jira: https://issues.redhat.com/browse/OSPRH-18993