### PR TITLE
Extend queueType to Quorum

### DIFF
--- a/apis/bases/rabbitmq.openstack.org_rabbitmqs.yaml
+++ b/apis/bases/rabbitmq.openstack.org_rabbitmqs.yaml
@@ -1361,11 +1361,12 @@ spec:
                 type: object
               queueType:
                 default: Mirrored
-                description: QueueType to eventually apply the ha-all policy to the
-                  cluster
+                description: QueueType to eventually apply the ha-all policy or configure
+                  default queue type for the cluster
                 enum:
                 - None
                 - Mirrored
+                - Quorum
                 type: string
               rabbitmq:
                 description: Configuration options for RabbitMQ Pods created in the

--- a/apis/bases/rabbitmq.openstack.org_transporturls.yaml
+++ b/apis/bases/rabbitmq.openstack.org_transporturls.yaml
@@ -108,6 +108,10 @@ spec:
                   the opentack-operator in the top-level CR (e.g. the ContainerImage)
                 format: int64
                 type: integer
+              queueType:
+                description: QueueType - the queue type from the associated RabbitMq
+                  instance
+                type: string
               secretName:
                 description: SecretName - name of the secret containing the rabbitmq
                   transport URL

--- a/apis/rabbitmq/v1beta1/rabbitmq_types.go
+++ b/apis/rabbitmq/v1beta1/rabbitmq_types.go
@@ -66,9 +66,9 @@ type RabbitMqSpecCore struct {
 	// by name
 	TopologyRef *topologyv1.TopoRef `json:"topologyRef,omitempty"`
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Enum=None;Mirrored
+	// +kubebuilder:validation:Enum=None;Mirrored;Quorum
 	// +kubebuilder:default=Mirrored
-	// QueueType to eventually apply the ha-all policy to the cluster
+	// QueueType to eventually apply the ha-all policy or configure default queue type for the cluster
 	QueueType string `json:"queueType"`
 }
 

--- a/apis/rabbitmq/v1beta1/transporturl_types.go
+++ b/apis/rabbitmq/v1beta1/transporturl_types.go
@@ -37,6 +37,9 @@ type TransportURLStatus struct {
 	// SecretName - name of the secret containing the rabbitmq transport URL
 	SecretName string `json:"secretName,omitempty"`
 
+	// QueueType - the queue type from the associated RabbitMq instance
+	QueueType string `json:"queueType,omitempty"`
+
 	// ObservedGeneration - the most recent generation observed for this
 	// service. If the observed generation is less than the spec generation,
 	// then the controller has not processed the latest changes injected by

--- a/config/crd/bases/rabbitmq.openstack.org_rabbitmqs.yaml
+++ b/config/crd/bases/rabbitmq.openstack.org_rabbitmqs.yaml
@@ -1361,11 +1361,12 @@ spec:
                 type: object
               queueType:
                 default: Mirrored
-                description: QueueType to eventually apply the ha-all policy to the
-                  cluster
+                description: QueueType to eventually apply the ha-all policy or configure
+                  default queue type for the cluster
                 enum:
                 - None
                 - Mirrored
+                - Quorum
                 type: string
               rabbitmq:
                 description: Configuration options for RabbitMQ Pods created in the

--- a/config/crd/bases/rabbitmq.openstack.org_transporturls.yaml
+++ b/config/crd/bases/rabbitmq.openstack.org_transporturls.yaml
@@ -108,6 +108,10 @@ spec:
                   the opentack-operator in the top-level CR (e.g. the ContainerImage)
                 format: int64
                 type: integer
+              queueType:
+                description: QueueType - the queue type from the associated RabbitMq
+                  instance
+                type: string
               secretName:
                 description: SecretName - name of the secret containing the rabbitmq
                   transport URL

--- a/controllers/rabbitmq/rabbitmq_controller.go
+++ b/controllers/rabbitmq/rabbitmq_controller.go
@@ -405,6 +405,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 				return ctrl.Result{}, err
 			}
 		}
+
+		// Update status for Quorum queue type
+		if instance.Spec.QueueType == "Quorum" && instance.Status.QueueType != "Quorum" {
+			Log.Info("Setting queue type status to quorum")
+		} else if instance.Spec.QueueType != "Quorum" && instance.Status.QueueType == "Quorum" {
+			Log.Info("Removing quorum queue type status")
+		}
+
 		instance.Status.QueueType = instance.Spec.QueueType
 	}
 


### PR DESCRIPTION
This commit adds Quorum as a valid option for QueueType.
We will switch from the previous default (Mirrored) over to this new value when all the operators will be ready.

The implementation works by adding a new key into the transportURL "quorumqueues"="true" if the rabbitmq instance has been configured for Quorum Queues, so that every operator could read this and configure the respective services to use quorum queues.
It also adds a queuetype status field to signal the secret change.

Jira: https://issues.redhat.com/browse/OSPRH-19160