### PR TITLE
Remove required on inline RabbitmqClusterSpecCore

### DIFF
--- a/apis/rabbitmq/v1beta1/rabbitmq_types.go
+++ b/apis/rabbitmq/v1beta1/rabbitmq_types.go
@@ -54,7 +54,6 @@ type RabbitMqSpec struct {
 
 // RabbitMqSpecCore - this version is used by the OpenStackControlplane CR (no container images)
 type RabbitMqSpecCore struct {
-	// +kubebuilder:validation:Required
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// Overrides to use when creating the Rabbitmq clusters
 	rabbitmqv2.RabbitmqClusterSpecCore `json:",inline"`


### PR DESCRIPTION
This is a pre-step to upgrade to controller-tools. When updating to controller-tools v0.18.0 the required tag results getting an empty string added to the required list:

```
                 type: object
             required:
+            - ""
             - containerImage
             type: object
           status:
```

Lets remove the tag as it should not be needed when inline the RabbitmqClusterSpecCore.

Related: [OSPRH-12935](https://issues.redhat.com//browse/OSPRH-12935)