### PR TITLE
Fix ip reassignment for ipset after scale-in

### DIFF
--- a/apis/network/v1beta1/ipset_webhook.go
+++ b/apis/network/v1beta1/ipset_webhook.go
@@ -82,7 +82,7 @@ func (r *IPSet) ValidateCreate() (admission.Warnings, error) {
 	basePath := field.NewPath("spec")
 
 	// validate requested networks exist in netcfg
-	allErrs = append(allErrs, valiateIPSetNetwork(r.Spec.Networks, basePath, &netcfg.Spec)...)
+	allErrs = append(allErrs, validateIPSetNetwork(r.Spec.Networks, basePath, &netcfg.Spec)...)
 
 	if len(allErrs) == 0 {
 		return nil, nil
@@ -132,10 +132,10 @@ func (r *IPSet) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
 		basePath := field.NewPath("spec")
 
 		// validate requested networks exist in
-		allErrs = append(allErrs, valiateIPSetNetwork(r.Spec.Networks, basePath, &netcfg.Spec)...)
+		allErrs = append(allErrs, validateIPSetNetwork(r.Spec.Networks, basePath, &netcfg.Spec)...)
 
 		// validate against the previous object only
-		allErrs = append(allErrs, valiateIPSetChanged(r.Spec.Networks, oldIPSet.Spec.Networks, basePath)...)
+		allErrs = append(allErrs, validateIPSetChanged(r.Spec.Networks, oldIPSet.Spec.Networks, basePath)...)
 	}
 
 	if len(allErrs) == 0 {
@@ -153,14 +153,14 @@ func (r *IPSet) ValidateDelete() (admission.Warnings, error) {
 	return nil, nil
 }
 
-// valiateIPSetNetwork
+// validateIPSetNetwork
 // - networks are uniq in the list
 // - networks and subnets exist in netcfg
 // - FixedIP is a valid IP address
 // - FixedIP has correct IP version of subnet
 // - FixedIP is in the subnet cidr
 // - Route is only specified on a single network per IPFamily
-func valiateIPSetNetwork(
+func validateIPSetNetwork(
 	networks []IPSetNetwork,
 	path *field.Path,
 	netCfgSpec *NetConfigSpec,
@@ -246,12 +246,12 @@ func valiateIPSetNetwork(
 	return allErrs
 }
 
-// valiateIPSetChanged
+// validateIPSetChanged
 // - if a previous requested network is still in the list
 // - if subnet changed within a network
 // - if fixedIP changed
 // - if defaultRoute changed
-func valiateIPSetChanged(
+func validateIPSetChanged(
 	networks []IPSetNetwork,
 	oldNetworks []IPSetNetwork,
 	path *field.Path,

--- a/apis/network/v1beta1/ipset_webhook_test.go
+++ b/apis/network/v1beta1/ipset_webhook_test.go
@@ -289,7 +289,7 @@ func TestIPSetValiateIPSetNetwork(t *testing.T) {
 			basePath := field.NewPath("spec")
 
 			var err error
-			allErrs := valiateIPSetNetwork(tt.c.Spec.Networks, basePath, &tt.n)
+			allErrs := validateIPSetNetwork(tt.c.Spec.Networks, basePath, &tt.n)
 			if len(allErrs) > 0 {
 				err = apierrors.NewInvalid(GroupVersion.WithKind("NetConfig").GroupKind(), tt.c.Name, allErrs)
 			}
@@ -477,12 +477,12 @@ func TestIPSetUpdateValidation(t *testing.T) {
 
 			var err error
 
-			allErrs := valiateIPSetNetwork(tt.newSpec.Networks, basePath, &tt.n)
+			allErrs := validateIPSetNetwork(tt.newSpec.Networks, basePath, &tt.n)
 			if len(allErrs) > 0 {
 				err = apierrors.NewInvalid(GroupVersion.WithKind("IPSet").GroupKind(), newCfg.Name, allErrs)
 			}
 
-			allErrs = valiateIPSetChanged(tt.newSpec.Networks, tt.oldSpec.Networks, basePath)
+			allErrs = validateIPSetChanged(tt.newSpec.Networks, tt.oldSpec.Networks, basePath)
 			if len(allErrs) > 0 {
 				err = apierrors.NewInvalid(GroupVersion.WithKind("IPSet").GroupKind(), newCfg.Name, allErrs)
 			}


### PR DESCRIPTION
After scale-in reserved ips are released back to the pool and if the ipset reconciles for some reason i.e update or infra-operator pod deleted, then the released ip would be assigned to the an exisitng ipset which already has a reservation.
This changes the logic to not try reserve for ipset/network combination which has a reserved ip.

jira: https://issues.redhat.com/browse/OSPRH-19871