### PR TITLE
Switch to Quorum Queues by default

### DIFF
--- a/apis/bases/rabbitmq.openstack.org_rabbitmqs.yaml
+++ b/apis/bases/rabbitmq.openstack.org_rabbitmqs.yaml
@@ -1360,7 +1360,7 @@ spec:
                     type: string
                 type: object
               queueType:
-                default: Mirrored
+                default: Quorum
                 description: QueueType to eventually apply the ha-all policy or configure
                   default queue type for the cluster
                 enum:

--- a/apis/rabbitmq/v1beta1/rabbitmq_types.go
+++ b/apis/rabbitmq/v1beta1/rabbitmq_types.go
@@ -67,7 +67,7 @@ type RabbitMqSpecCore struct {
 	TopologyRef *topologyv1.TopoRef `json:"topologyRef,omitempty"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Enum=None;Mirrored;Quorum
-	// +kubebuilder:default=Mirrored
+	// +kubebuilder:default=Quorum
 	// QueueType to eventually apply the ha-all policy or configure default queue type for the cluster
 	QueueType string `json:"queueType"`
 }

--- a/config/crd/bases/rabbitmq.openstack.org_rabbitmqs.yaml
+++ b/config/crd/bases/rabbitmq.openstack.org_rabbitmqs.yaml
@@ -1360,7 +1360,7 @@ spec:
                     type: string
                 type: object
               queueType:
-                default: Mirrored
+                default: Quorum
                 description: QueueType to eventually apply the ha-all policy or configure
                   default queue type for the cluster
                 enum:


### PR DESCRIPTION
This should wait until all the other operators patches are merged + bumps.

Related: https://issues.redhat.com/browse/OSPRH-19160