### PR TITLE
Expose octavia HM IPs via BGP

### DIFF
--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -801,6 +801,15 @@ func CreateFRRConfiguration(name types.NamespacedName, spec map[string]interface
 	return th.CreateUnstructured(raw)
 }
 
+func GetOctaviaConfigMapData() map[string]interface{} {
+	return map[string]interface{}{
+		"hm_worker-0":      "172.23.0.103",
+		"hm_worker-1":      "172.23.0.105",
+		"rsyslog_worker-0": "172.23.0.104",
+		"rsyslog_worker-1": "172.23.0.106",
+	}
+}
+
 func GetMetalLBFRRConfigurationSpec(node string) map[string]interface{} {
 	return map[string]interface{}{
 		"bgp": map[string]interface{}{

--- a/tests/functional/bgpconfiguration_controller_test.go
+++ b/tests/functional/bgpconfiguration_controller_test.go
@@ -386,4 +386,86 @@ var _ = Describe("BGPConfiguration controller", func() {
 			}
 		})
 	})
+
+	When("octavia-hmport-map ConfigMap is present", func() {
+		var metallbNS *corev1.Namespace
+		var octaviaFrrName types.NamespacedName
+
+		BeforeEach(func() {
+			metallbNS = th.CreateNamespace(frrCfgNamespace + "-" + namespace)
+			// Create FRR configurations for workers
+			CreateFRRConfiguration(types.NamespacedName{Namespace: metallbNS.Name, Name: "worker-0"},
+				GetMetalLBFRRConfigurationSpec("worker-0"))
+			CreateFRRConfiguration(types.NamespacedName{Namespace: metallbNS.Name, Name: "worker-1"},
+				GetMetalLBFRRConfigurationSpec("worker-1"))
+
+			// Create a NAD config with gateway
+			nad := th.CreateNAD(types.NamespacedName{Namespace: namespace, Name: "internalapi"}, GetNADSpec())
+
+			// Create pods with NAD annotation on octavia workers
+			podName0 := types.NamespacedName{Namespace: namespace, Name: "octavia-pod-0"}
+			th.CreatePod(podName0, GetPodAnnotation(namespace), GetPodSpec("worker-0"))
+			th.SimulatePodPhaseRunning(podName0)
+
+			podName1 := types.NamespacedName{Namespace: namespace, Name: "octavia-pod-1"}
+			th.CreatePod(podName1, GetPodAnnotation(namespace), GetPodSpec("worker-1"))
+			th.SimulatePodPhaseRunning(podName1)
+
+			// Create octavia ConfigMap
+			th.CreateConfigMap(types.NamespacedName{Namespace: namespace, Name: "octavia-hmport-map"},
+				GetOctaviaConfigMapData())
+
+			bgpcfg := CreateBGPConfiguration(namespace, GetBGPConfigurationSpec(metallbNS.Name))
+			bgpcfgName.Name = bgpcfg.GetName()
+			bgpcfgName.Namespace = bgpcfg.GetNamespace()
+
+			octaviaFrrName = types.NamespacedName{
+				Name:      namespace + "-octavia-worker-0",
+				Namespace: metallbNS.Name,
+			}
+
+			DeferCleanup(th.DeleteInstance, bgpcfg)
+			DeferCleanup(th.DeleteInstance, nad)
+		})
+
+		It("should create FRRConfiguration for octavia workers", func() {
+			Eventually(func(g Gomega) {
+				frr := GetFRRConfiguration(octaviaFrrName)
+				g.Expect(frr).To(Not(BeNil()))
+				g.Expect(frr.Spec.BGP.Routers[0].Prefixes).To(ContainElements("172.23.0.103/32", "172.23.0.104/32"))
+			}, timeout, interval).Should(Succeed())
+		})
+
+		When("ConfigMap is updated", func() {
+			It("should update FRRConfigurations accordingly", func() {
+				// Update ConfigMap with different IPs
+				Eventually(func(g Gomega) {
+					cm := th.GetConfigMap(types.NamespacedName{Namespace: namespace, Name: "octavia-hmport-map"})
+					cm.Data["hm_worker-0"] = "172.23.0.203"
+					g.Expect(k8sClient.Update(ctx, cm)).Should(Succeed())
+				}, timeout, interval).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					frr := GetFRRConfiguration(octaviaFrrName)
+					g.Expect(frr.Spec.BGP.Routers[0].Prefixes).To(ContainElement("172.23.0.203/32"))
+				}, timeout, interval).Should(Succeed())
+			})
+		})
+
+		When("ConfigMap is deleted", func() {
+			It("should remove octavia FRRConfigurations", func() {
+				// Delete ConfigMap
+				Eventually(func(g Gomega) {
+					cm := th.GetConfigMap(types.NamespacedName{Namespace: namespace, Name: "octavia-hmport-map"})
+					g.Expect(k8sClient.Delete(ctx, cm)).Should(Succeed())
+				}, timeout, interval).Should(Succeed())
+
+				// Verify FRRConfiguration is deleted
+				frr := &frrk8sv1.FRRConfiguration{}
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, octaviaFrrName, frr)).Should(Not(Succeed()))
+				}, timeout, interval).Should(Succeed())
+			})
+		})
+	})
 })


### PR DESCRIPTION
Octavia has a special configmap storing ip addresses that are internally managed.

~~~
$ oc get configmaps octavia-hmport-map -o yaml
apiVersion: v1
data:
  hm_worker-0: 172.23.0.103
  hm_worker-1: 172.23.0.105
  hm_worker-2: 172.23.0.107
  rsyslog_worker-0: 172.23.0.104
  rsyslog_worker-1: 172.23.0.106
  rsyslog_worker-2: 172.23.0.108
kind: ConfigMap
metadata:
  name: octavia-hmport-map
  namespace: openstack
~~~

In order to have amphorae reach the controlplane and vice-versa we need these ips to be advertised when BGP is used.

Jira: https://issues.redhat.com/browse/OSPRH-20083

Assisted-by: claude-4-sonnet