### PR TITLE
Fix DNSMasq pod restarts caused by idle TCP connections

### DIFF
--- a/tests/functional/dnsmasq_controller_test.go
+++ b/tests/functional/dnsmasq_controller_test.go
@@ -162,7 +162,8 @@ var _ = Describe("DNSMasq controller", func() {
 
 			svc := th.GetService(types.NamespacedName{
 				Namespace: namespace,
-				Name:      fmt.Sprintf("dnsmasq-%s", dnsMasqName.Name)})
+				Name:      fmt.Sprintf("dnsmasq-%s", dnsMasqName.Name),
+			})
 			Expect(svc.Labels["service"]).To(Equal("dnsmasq"))
 		})
 
@@ -190,8 +191,10 @@ var _ = Describe("DNSMasq controller", func() {
 				g.Expect(container.VolumeMounts).To(HaveLen(3))
 				g.Expect(container.Image).To(Equal(containerImage))
 
-				g.Expect(container.LivenessProbe.TCPSocket.Port.IntVal).To(Equal(int32(5353)))
-				g.Expect(container.ReadinessProbe.TCPSocket.Port.IntVal).To(Equal(int32(5353)))
+				g.Expect(container.LivenessProbe.Exec).ToNot(BeNil())
+				g.Expect(container.LivenessProbe.Exec.Command).To(ContainElement(ContainSubstring("pgrep -f dnsmasq")))
+				g.Expect(container.ReadinessProbe.Exec).ToNot(BeNil())
+				g.Expect(container.ReadinessProbe.Exec.Command).To(ContainElement(ContainSubstring("pgrep -f dnsmasq")))
 			}, timeout, interval).Should(Succeed())
 		})
 


### PR DESCRIPTION
Replace TCP socket health probes with process/port checks to prevent conflicts with long-lived TCP connections. DNSMasq's single-threaded architecture can block when handling idle connections, causing liveness probe timeouts and unnecessary pod restarts.

Changes:
- Replace TCPSocket probes with Exec probes using pgrep + ss
- Add dns-loop-detect option for improved stability
- Remove unused intstr import

The new health checks verify both process state and port binding without establishing TCP connections that could interfere with DNSMasq's operation.

Fixes: Pod restarts when using 'nc -t <dnsmasq-ip> 5353'

Jira: [OSPRH-20039](https://issues.redhat.com//browse/OSPRH-20039)


Co-authored-by: Claude (Anthropic) claude@anthropic.com