### PR TITLE
[18.0-fr3] Remove --no-daemon flag to improve TCP connection handling

### DIFF
--- a/pkg/dnsmasq/deployment.go
+++ b/pkg/dnsmasq/deployment.go
@@ -71,7 +71,6 @@ func Deployment(
 	dnsmasqCmd = append(dnsmasqCmd, "--conf-dir=/etc/dnsmasq.d")
 	dnsmasqCmd = append(dnsmasqCmd, "--hostsdir=/etc/dnsmasq.d/hosts")
 	dnsmasqCmd = append(dnsmasqCmd, "--keep-in-foreground")
-	dnsmasqCmd = append(dnsmasqCmd, "--no-daemon")
 	dnsmasqCmd = append(dnsmasqCmd, "--log-debug")
 	dnsmasqCmd = append(dnsmasqCmd, "--bind-interfaces")
 	dnsmasqCmd = append(dnsmasqCmd, "--listen-address=$(POD_IP)")


### PR DESCRIPTION
Drop the --no-daemon flag while keeping --keep-in-foreground to allow DNSMasq to use its improved internal connection handling while still running as PID 1 in the container. This resolves issues where long-lived idle TCP connections block DNSMasq's event loop, causing liveness probe timeouts and pod restarts.

Each pod can then handle up to 20 TCP connections, which is the hard limit of dnsmasq 2.85.

The --keep-in-foreground flag ensures the process remains in the foreground for proper Kubernetes lifecycle management while allowing DNSMasq to use its more robust connection handling internally.

Fixes: Pod restarts when using long-lived TCP connections like 'nc -t'

Jira: [OSPRH-20039](https://issues.redhat.com//browse/OSPRH-20039)

Co-authored-by: Claude (Anthropic) claude@anthropic.com

(cherry picked from commit 76d40278eeb22d4000e294a06cd388ae8a1a3fac)