### PR TITLE
Modernize using `gopls modernize tool`

### DIFF
--- a/controllers/memcached/memcached_controller.go
+++ b/controllers/memcached/memcached_controller.go
@@ -511,7 +511,7 @@ func (r *Reconciler) generateConfigMaps(
 		memcachedPort = fmt.Sprint(memcached.MemcachedPort)
 		instance.Status.TLSSupport = false
 	}
-	templateParameters := map[string]interface{}{
+	templateParameters := map[string]any{
 		"memcachedTLSListen":  memcachedTLSListen,
 		"memcachedTLSOptions": memcachedTLSOptions,
 		"memcachedPort":       memcachedPort,

--- a/controllers/rabbitmq/transporturl_controller.go
+++ b/controllers/rabbitmq/transporturl_controller.go
@@ -350,7 +350,7 @@ func (r *TransportURLReconciler) createTransportURLSecret(
 
 	// Create a new secret with the transport URL for this CR
 	data := map[string][]byte{
-		"transport_url": []byte(fmt.Sprintf("rabbit://%s:%s@%s:%s/%s", username, password, host, port, query)),
+		"transport_url": fmt.Appendf(nil, "rabbit://%s:%s@%s:%s/%s", username, password, host, port, query),
 	}
 	if quorum {
 		data["quorumqueues"] = []byte("true")

--- a/controllers/redis/redis_controller.go
+++ b/controllers/redis/redis_controller.go
@@ -447,7 +447,7 @@ func (r *Reconciler) generateConfigMaps(
 	instance *redisv1.Redis,
 	envVars *map[string]env.Setter,
 ) error {
-	templateParameters := make(map[string]interface{})
+	templateParameters := make(map[string]any)
 	customData := make(map[string]string)
 
 	cms := []util.Template{

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -60,13 +60,13 @@ const (
 	host1    = "host1"
 )
 
-func CreateDNSMasq(namespace string, spec map[string]interface{}) client.Object {
+func CreateDNSMasq(namespace string, spec map[string]any) client.Object {
 	name := uuid.New().String()
 
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "network.openstack.org/v1beta1",
 		"kind":       "DNSMasq",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name,
 			"namespace": namespace,
 		},
@@ -76,12 +76,12 @@ func CreateDNSMasq(namespace string, spec map[string]interface{}) client.Object 
 	return th.CreateUnstructured(raw)
 }
 
-func CreateDNSMasqWithName(name string, namespace string, spec map[string]interface{}) client.Object {
+func CreateDNSMasqWithName(name string, namespace string, spec map[string]any) client.Object {
 
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "network.openstack.org/v1beta1",
 		"kind":       "DNSMasq",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name,
 			"namespace": namespace,
 		},
@@ -90,11 +90,11 @@ func CreateDNSMasqWithName(name string, namespace string, spec map[string]interf
 
 	return th.CreateUnstructured(raw)
 }
-func GetDefaultDNSMasqSpec() map[string]interface{} {
-	spec := make(map[string]interface{})
+func GetDefaultDNSMasqSpec() map[string]any {
+	spec := make(map[string]any)
 	spec["containerImage"] = "test-dnsmasq-container-image"
 	spec["dnsDataLabelSelectorValue"] = "dnsdata"
-	spec["options"] = interface{}([]networkv1.DNSMasqOption{
+	spec["options"] = any([]networkv1.DNSMasqOption{
 		{
 			Key:    "server",
 			Values: []string{"1.1.1.1"},
@@ -105,7 +105,7 @@ func GetDefaultDNSMasqSpec() map[string]interface{} {
 		},
 	})
 
-	serviceOverride := interface{}(map[string]interface{}{
+	serviceOverride := any(map[string]any{
 		"metadata": map[string]map[string]string{
 			"annotations": {
 				"metallb.universe.tf/address-pool":    "ctlplane",
@@ -117,25 +117,25 @@ func GetDefaultDNSMasqSpec() map[string]interface{} {
 				"service": "dnsmasq",
 			},
 		},
-		"spec": map[string]interface{}{
+		"spec": map[string]any{
 			"type": "LoadBalancer",
 		},
 	})
 
-	spec["override"] = map[string]interface{}{
+	spec["override"] = map[string]any{
 		"service": serviceOverride,
 	}
 
 	return spec
 }
 
-func CreateDNSData(namespace string, spec map[string]interface{}) client.Object {
+func CreateDNSData(namespace string, spec map[string]any) client.Object {
 	name := uuid.New().String()
 
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "network.openstack.org/v1beta1",
 		"kind":       "DNSData",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name,
 			"namespace": namespace,
 		},
@@ -145,10 +145,10 @@ func CreateDNSData(namespace string, spec map[string]interface{}) client.Object 
 	return th.CreateUnstructured(raw)
 }
 
-func GetDefaultDNSDataSpec() map[string]interface{} {
-	spec := make(map[string]interface{})
+func GetDefaultDNSDataSpec() map[string]any {
+	spec := make(map[string]any)
 	spec["dnsDataLabelSelectorValue"] = "someselector"
-	spec["hosts"] = interface{}([]networkv1.DNSHost{
+	spec["hosts"] = any([]networkv1.DNSHost{
 		{
 			Hostnames: []string{host1},
 			IP:        "host-ip-1",
@@ -165,11 +165,11 @@ func GetDefaultDNSDataSpec() map[string]interface{} {
 	return spec
 }
 
-func CreateTransportURL(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	raw := map[string]interface{}{
+func CreateTransportURL(name types.NamespacedName, spec map[string]any) client.Object {
+	raw := map[string]any{
 		"apiVersion": "rabbitmq.openstack.org/v1beta1",
 		"kind":       "TransportURL",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -179,11 +179,11 @@ func CreateTransportURL(name types.NamespacedName, spec map[string]interface{}) 
 	return th.CreateUnstructured(raw)
 }
 
-func CreateRabbitMQCluster(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	raw := map[string]interface{}{
+func CreateRabbitMQCluster(name types.NamespacedName, spec map[string]any) client.Object {
+	raw := map[string]any{
 		"apiVersion": "rabbitmq.com/v1beta1",
 		"kind":       "RabbitmqCluster",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -211,12 +211,12 @@ func UpdateRabbitMQClusterToTLS(name types.NamespacedName) {
 	}, th.Timeout, th.Interval).Should(Succeed())
 }
 
-func GetDefaultRabbitMQClusterSpec(tlsEnabled bool) map[string]interface{} {
-	spec := make(map[string]interface{})
+func GetDefaultRabbitMQClusterSpec(tlsEnabled bool) map[string]any {
+	spec := make(map[string]any)
 	spec["delayStartSeconds"] = 30
 	spec["image"] = "quay.io/podified-antelope-centos9/openstack-rabbitmq:current-podified"
 	if tlsEnabled {
-		spec["tls"] = map[string]interface{}{
+		spec["tls"] = map[string]any{
 			"caSecretName":           "rootca-internal",
 			"disableNonTLSListeners": true,
 			"secretName":             "cert-rabbitmq-svc",
@@ -255,7 +255,7 @@ func CreateOrUpdateRabbitMQClusterSecret(name types.NamespacedName, mq *rabbitmq
 
 		// create rabbitmq-secret secret
 		secretData := map[string][]byte{
-			"host":     []byte(fmt.Sprintf("host.%s.svc", namespace)),
+			"host":     fmt.Appendf(nil, "host.%s.svc", namespace),
 			"password": []byte("12345678"),
 			"username": []byte("user"),
 			"port":     []byte("5672"),
@@ -292,19 +292,19 @@ func SimulateRabbitMQClusterReady(name types.NamespacedName) {
 		// create/update rabbitmq secret
 		CreateOrUpdateRabbitMQClusterSecret(secretName, mq)
 
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "rabbitmq.com/v1beta1",
 			"kind":       "RabbitmqCluster",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      name.Name,
 				"namespace": name.Namespace,
 			},
 		}
 
-		status := make(map[string]interface{})
+		status := make(map[string]any)
 
 		// add AllReplicasReady condition
-		statusCondition := []map[string]interface{}{
+		statusCondition := []map[string]any{
 			{
 				"reason": "AllPodsAreReady",
 				"status": "True",
@@ -319,16 +319,16 @@ func SimulateRabbitMQClusterReady(name types.NamespacedName) {
 
 		// add status.defaultUser which is used to get the
 		// secret holding username/password/host
-		statusDefaultUser := map[string]interface{}{
-			"secretReference": map[string]interface{}{
-				"keys": map[string]interface{}{
+		statusDefaultUser := map[string]any{
+			"secretReference": map[string]any{
+				"keys": map[string]any{
 					"password": "password",
 					"username": "username",
 				},
 				"name":      secretName.Name,
 				"namespace": name.Namespace,
 			},
-			"serviceReference": map[string]interface{}{
+			"serviceReference": map[string]any{
 				"name":      name.Name,
 				"namespace": name.Namespace,
 			},
@@ -472,13 +472,13 @@ func CreateLoadBalancerService(name types.NamespacedName, addDNSAnno bool) *core
 	return svc
 }
 
-func CreateNetConfig(namespace string, spec map[string]interface{}) client.Object {
+func CreateNetConfig(namespace string, spec map[string]any) client.Object {
 	name := uuid.New().String()
 
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "network.openstack.org/v1beta1",
 		"kind":       "NetConfig",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name,
 			"namespace": namespace,
 		},
@@ -488,13 +488,13 @@ func CreateNetConfig(namespace string, spec map[string]interface{}) client.Objec
 	return th.CreateUnstructured(raw)
 }
 
-func GetNetConfigSpec(nets ...networkv1.Network) map[string]interface{} {
-	spec := make(map[string]interface{})
+func GetNetConfigSpec(nets ...networkv1.Network) map[string]any {
+	spec := make(map[string]any)
 
 	netSpec := []networkv1.Network{}
 	netSpec = append(netSpec, nets...)
 
-	spec["networks"] = interface{}(netSpec)
+	spec["networks"] = any(netSpec)
 
 	return spec
 }
@@ -526,7 +526,7 @@ func GetNetCtlplaneSpec(name string, subnets ...networkv1.Subnet) networkv1.Netw
 	return net
 }
 
-func GetDefaultNetConfigSpec() map[string]interface{} {
+func GetDefaultNetConfigSpec() map[string]any {
 	net := GetNetSpec(net1, GetSubnet1(subnet1))
 	return GetNetConfigSpec(net)
 }
@@ -603,13 +603,13 @@ func GetSubnetWithWrongExcludeAddress() networkv1.Subnet {
 	}
 }
 
-func CreateIPSet(namespace string, spec map[string]interface{}) client.Object {
+func CreateIPSet(namespace string, spec map[string]any) client.Object {
 	name := uuid.New().String()
 
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "network.openstack.org/v1beta1",
 		"kind":       "IPSet",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name,
 			"namespace": namespace,
 		},
@@ -619,18 +619,18 @@ func CreateIPSet(namespace string, spec map[string]interface{}) client.Object {
 	return th.CreateUnstructured(raw)
 }
 
-func GetIPSetSpec(immutable bool, nets ...networkv1.IPSetNetwork) map[string]interface{} {
-	spec := make(map[string]interface{})
+func GetIPSetSpec(immutable bool, nets ...networkv1.IPSetNetwork) map[string]any {
+	spec := make(map[string]any)
 
 	networks := []networkv1.IPSetNetwork{}
 	networks = append(networks, nets...)
 	spec["immutable"] = immutable
-	spec["networks"] = interface{}(networks)
+	spec["networks"] = any(networks)
 
 	return spec
 }
 
-func GetDefaultIPSetSpec() map[string]interface{} {
+func GetDefaultIPSetSpec() map[string]any {
 	return GetIPSetSpec(false, GetIPSetNet1())
 }
 
@@ -698,12 +698,12 @@ func GetReservationFromNet(ipsetName types.NamespacedName, netName string) netwo
 	return res
 }
 
-func CreateMemcachedConfigWithName(name string, namespace string, spec map[string]interface{}) client.Object {
+func CreateMemcachedConfigWithName(name string, namespace string, spec map[string]any) client.Object {
 
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "memcached.openstack.org/v1beta1",
 		"kind":       "Memcached",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name,
 			"namespace": namespace,
 		},
@@ -712,17 +712,17 @@ func CreateMemcachedConfigWithName(name string, namespace string, spec map[strin
 
 	return th.CreateUnstructured(raw)
 }
-func CreateMemcachedConfig(namespace string, spec map[string]interface{}) client.Object {
+func CreateMemcachedConfig(namespace string, spec map[string]any) client.Object {
 	// name is set as a label on the statefulset and must not start with numbers
 	// "error": "Service \"6057811f-1ab3-4ebb-adaf-2\" is invalid: metadata.name: Invalid value: \"6057811f-1ab3-4ebb-adaf-2\":
 	// a DNS-1035 label must consist of lower case alphanumeric characters or '-',start with an alphabetic character, and end
 	// with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')"}
 	name := "memcached-" + uuid.New().String()[:25]
 
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "memcached.openstack.org/v1beta1",
 		"kind":       "Memcached",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name,
 			"namespace": namespace,
 		},
@@ -732,8 +732,8 @@ func CreateMemcachedConfig(namespace string, spec map[string]interface{}) client
 	return th.CreateUnstructured(raw)
 }
 
-func GetDefaultMemcachedSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultMemcachedSpec() map[string]any {
+	return map[string]any{
 		"replicas": 1,
 	}
 }
@@ -746,13 +746,13 @@ func GetMemcached(name types.NamespacedName) *memcachedv1.Memcached {
 	return instance
 }
 
-func CreateBGPConfiguration(namespace string, spec map[string]interface{}) client.Object {
+func CreateBGPConfiguration(namespace string, spec map[string]any) client.Object {
 	name := uuid.New().String()
 
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "network.openstack.org/v1beta1",
 		"kind":       "BGPConfiguration",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name,
 			"namespace": namespace,
 		},
@@ -770,13 +770,13 @@ func GetBGPConfiguration(name types.NamespacedName) *networkv1.BGPConfiguration 
 	return instance
 }
 
-func GetBGPConfigurationSpec(namespace string) map[string]interface{} {
+func GetBGPConfigurationSpec(namespace string) map[string]any {
 	if namespace != "" {
-		return map[string]interface{}{
+		return map[string]any{
 			"frrConfigurationNamespace": namespace,
 		}
 	}
-	return map[string]interface{}{}
+	return map[string]any{}
 }
 
 func GetFRRConfiguration(name types.NamespacedName) *frrk8sv1.FRRConfiguration {
@@ -787,11 +787,11 @@ func GetFRRConfiguration(name types.NamespacedName) *frrk8sv1.FRRConfiguration {
 	return instance
 }
 
-func CreateFRRConfiguration(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	raw := map[string]interface{}{
+func CreateFRRConfiguration(name types.NamespacedName, spec map[string]any) client.Object {
+	raw := map[string]any{
 		"apiVersion": "frrk8s.metallb.io/v1beta1",
 		"kind":       "FRRConfiguration",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -801,13 +801,13 @@ func CreateFRRConfiguration(name types.NamespacedName, spec map[string]interface
 	return th.CreateUnstructured(raw)
 }
 
-func GetMetalLBFRRConfigurationSpec(node string) map[string]interface{} {
-	return map[string]interface{}{
-		"bgp": map[string]interface{}{
-			"routers": []map[string]interface{}{
+func GetMetalLBFRRConfigurationSpec(node string) map[string]any {
+	return map[string]any{
+		"bgp": map[string]any{
+			"routers": []map[string]any{
 				{
 					"asn": 64999,
-					"neighbors": []map[string]interface{}{
+					"neighbors": []map[string]any{
 						{
 							"address":       "10.10.10.10",
 							"asn":           64999,
@@ -816,8 +816,8 @@ func GetMetalLBFRRConfigurationSpec(node string) map[string]interface{} {
 							"keepaliveTime": "30s",
 							"password":      "foo",
 							"port":          179,
-							"toAdvertise": map[string]interface{}{
-								"allowed": map[string]interface{}{
+							"toAdvertise": map[string]any{
+								"allowed": map[string]any{
 									"mode": "filtered",
 									"prefixes": []string{
 										"11.11.11.11/32",
@@ -825,8 +825,8 @@ func GetMetalLBFRRConfigurationSpec(node string) map[string]interface{} {
 									},
 								},
 							},
-							"toReceive": map[string]interface{}{
-								"allowed": map[string]interface{}{
+							"toReceive": map[string]any{
+								"allowed": map[string]any{
 									"mode": "filtered",
 								},
 							},
@@ -839,16 +839,16 @@ func GetMetalLBFRRConfigurationSpec(node string) map[string]interface{} {
 				},
 			},
 		},
-		"nodeSelector": map[string]interface{}{
-			"matchLabels": map[string]interface{}{
+		"nodeSelector": map[string]any{
+			"matchLabels": map[string]any{
 				"kubernetes.io/hostname": node,
 			},
 		},
 	}
 }
 
-func GetNADSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetNADSpec() map[string]any {
+	return map[string]any{
 		"config": `{
       "cniVersion": "0.3.1",
       "name": "internalapi",
@@ -870,13 +870,13 @@ func GetNADSpec() map[string]interface{} {
 	}
 }
 
-func GetPodSpec(node string) map[string]interface{} {
-	return map[string]interface{}{
-		"containers": []map[string]interface{}{
+func GetPodSpec(node string) map[string]any {
+	return map[string]any{
+		"containers": []map[string]any{
 			{
 				"name":  "foo",
 				"image": "foo:latest",
-				"ports": []map[string]interface{}{
+				"ports": []map[string]any{
 					{
 						"containerPort": 80,
 					},
@@ -923,16 +923,16 @@ func GetPodAnnotation(namespace string) map[string]string {
 // want to avoid by default
 // 2. Usually a topologySpreadConstraints is used to take care about
 // multi AZ, which is not applicable in this context
-func GetSampleTopologySpec(selector string) (map[string]interface{}, []corev1.TopologySpreadConstraint) {
+func GetSampleTopologySpec(selector string) (map[string]any, []corev1.TopologySpreadConstraint) {
 	// Build the topology Spec
-	topologySpec := map[string]interface{}{
-		"topologySpreadConstraints": []map[string]interface{}{
+	topologySpec := map[string]any{
+		"topologySpreadConstraints": []map[string]any{
 			{
 				"maxSkew":           1,
 				"topologyKey":       corev1.LabelHostname,
 				"whenUnsatisfiable": "ScheduleAnyway",
-				"labelSelector": map[string]interface{}{
-					"matchLabels": map[string]interface{}{
+				"labelSelector": map[string]any{
+					"matchLabels": map[string]any{
 						"service": selector,
 					},
 				},
@@ -958,12 +958,12 @@ func GetSampleTopologySpec(selector string) (map[string]interface{}, []corev1.To
 // CreateTopology - Creates a Topology CR based on the spec passed as input
 func CreateTopology(
 	topology types.NamespacedName,
-	spec map[string]interface{},
+	spec map[string]any,
 ) (client.Object, topologyv1.TopoRef) {
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "topology.openstack.org/v1beta1",
 		"kind":       "Topology",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      topology.Name,
 			"namespace": topology.Namespace,
 		},
@@ -1001,11 +1001,11 @@ func GetTopologyRef(name string, namespace string) []types.NamespacedName {
 	}
 }
 
-func CreateRabbitMQ(rabbitmq types.NamespacedName, spec map[string]interface{}) client.Object {
-	raw := map[string]interface{}{
+func CreateRabbitMQ(rabbitmq types.NamespacedName, spec map[string]any) client.Object {
+	raw := map[string]any{
 		"apiVersion": "rabbitmq.openstack.org/v1beta1",
 		"kind":       "RabbitMq",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      rabbitmq.Name,
 			"namespace": rabbitmq.Namespace,
 		},
@@ -1015,8 +1015,8 @@ func CreateRabbitMQ(rabbitmq types.NamespacedName, spec map[string]interface{}) 
 	return th.CreateUnstructured(raw)
 }
 
-func GetDefaultRabbitMQSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultRabbitMQSpec() map[string]any {
+	return map[string]any{
 		"replicas": 1,
 	}
 }

--- a/tests/functional/dnsmasq_controller_test.go
+++ b/tests/functional/dnsmasq_controller_test.go
@@ -75,7 +75,7 @@ var _ = Describe("DNSMasq controller", func() {
 				Name:      "some-dnsdata",
 			}
 
-			th.CreateConfigMap(dnsDataCM, map[string]interface{}{
+			th.CreateConfigMap(dnsDataCM, map[string]any{
 				dnsDataCM.Name: "172.20.0.80 keystone-internal.openstack.svc",
 			})
 			cm := th.GetConfigMap(dnsDataCM)
@@ -302,7 +302,7 @@ var _ = Describe("DNSMasq controller", func() {
 				Name:      "some-dnsdata",
 			}
 
-			th.CreateConfigMap(dnsDataCM, map[string]interface{}{
+			th.CreateConfigMap(dnsDataCM, map[string]any{
 				dnsDataCM.Name: "172.20.0.80 keystone-internal.openstack.svc",
 			})
 			cm := th.GetConfigMap(dnsDataCM)
@@ -390,7 +390,7 @@ var _ = Describe("DNSMasq controller", func() {
 	When("A DNSMasq is created with nodeSelector", func() {
 		BeforeEach(func() {
 			spec := GetDefaultDNSMasqSpec()
-			spec["nodeSelector"] = map[string]interface{}{
+			spec["nodeSelector"] = map[string]any{
 				"foo": "bar",
 			}
 			instance := CreateDNSMasq(namespace, spec)
@@ -420,7 +420,7 @@ var _ = Describe("DNSMasq controller", func() {
 				Name:      "some-dnsdata",
 			}
 
-			th.CreateConfigMap(dnsDataCM, map[string]interface{}{
+			th.CreateConfigMap(dnsDataCM, map[string]any{
 				dnsDataCM.Name: "172.20.0.80 keystone-internal.openstack.svc",
 			})
 			cm := th.GetConfigMap(dnsDataCM)
@@ -513,7 +513,7 @@ var _ = Describe("DNSMasq controller", func() {
 			}
 
 			spec := GetDefaultDNSMasqSpec()
-			spec["topologyRef"] = map[string]interface{}{
+			spec["topologyRef"] = map[string]any{
 				"name": topologyRef.Name,
 			}
 			instance := CreateDNSMasqWithName(dnsMasqDefaultName, namespace, spec)
@@ -543,7 +543,7 @@ var _ = Describe("DNSMasq controller", func() {
 				Name:      "some-dnsdata",
 			}
 
-			th.CreateConfigMap(dnsDataCM, map[string]interface{}{
+			th.CreateConfigMap(dnsDataCM, map[string]any{
 				dnsDataCM.Name: "172.20.0.80 keystone-internal.openstack.svc",
 			})
 			cm := th.GetConfigMap(dnsDataCM)

--- a/tests/functional/ipset_controller_test.go
+++ b/tests/functional/ipset_controller_test.go
@@ -42,10 +42,10 @@ var _ = Describe("IPSet controller", func() {
 	When("an IPSet gets created with no NetConfig available", func() {
 		It("it gets blocked by the webhook and fail", func() {
 
-			raw := map[string]interface{}{
+			raw := map[string]any{
 				"apiVersion": "network.openstack.org/v1beta1",
 				"kind":       "IPSet",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name":      "foo",
 					"namespace": namespace,
 				},

--- a/tests/functional/memcached_controller_test.go
+++ b/tests/functional/memcached_controller_test.go
@@ -137,7 +137,7 @@ var _ = Describe("Memcached Controller", func() {
 				Namespace: namespace,
 			}
 			//memcachedTopologies = GetTopologyRef(memcachefName.Name, memcachedName.Namespace)
-			spec["topologyRef"] = map[string]interface{}{
+			spec["topologyRef"] = map[string]any{
 				"name": topologyRef.Name,
 			}
 			memcached := CreateMemcachedConfigWithName(memcachedName.Name, namespace, spec)
@@ -244,10 +244,10 @@ var _ = Describe("Memcached Controller", func() {
 	When("a Memcached gets created with a name longer then 52 chars", func() {
 		It("gets blocked by the webhook and fail", func() {
 
-			raw := map[string]interface{}{
+			raw := map[string]any{
 				"apiVersion": "memcached.openstack.org/v1beta1",
 				"kind":       "Memcached",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name":      "foo-1234567890-1234567890-1234567890-1234567890-1234567890",
 					"namespace": namespace,
 				},
@@ -266,14 +266,14 @@ var _ = Describe("Memcached Controller", func() {
 
 			spec := GetDefaultMemcachedSpec()
 			// Reference a top-level topology
-			spec["topologyRef"] = map[string]interface{}{
+			spec["topologyRef"] = map[string]any{
 				"name":      "foo",
 				"namespace": "bar",
 			}
-			raw := map[string]interface{}{
+			raw := map[string]any{
 				"apiVersion": "memcached.openstack.org/v1beta1",
 				"kind":       "Memcached",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name":      memcachedDefaultName,
 					"namespace": namespace,
 				},

--- a/tests/functional/netconfig_webhook_test.go
+++ b/tests/functional/netconfig_webhook_test.go
@@ -47,10 +47,10 @@ var _ = Describe("NetConfig webhook", func() {
 		When("a second NetConfig gets created in the same namespace", func() {
 			It("gets blocked by the webhook and fail", func() {
 
-				raw := map[string]interface{}{
+				raw := map[string]any{
 					"apiVersion": "network.openstack.org/v1beta1",
 					"kind":       "NetConfig",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "foo",
 						"namespace": namespace,
 					},

--- a/tests/functional/rabbitmq_controller_test.go
+++ b/tests/functional/rabbitmq_controller_test.go
@@ -46,7 +46,7 @@ var _ = Describe("RabbitMQ Controller", func() {
 		clusterCm := types.NamespacedName{Name: "cluster-config-v1", Namespace: "kube-system"}
 		th.CreateConfigMap(
 			clusterCm,
-			map[string]interface{}{
+			map[string]any{
 				"install-config": "fips: false",
 			},
 		)
@@ -89,7 +89,7 @@ var _ = Describe("RabbitMQ Controller", func() {
 			certSecret = CreateCertSecret(rabbitmqName)
 			DeferCleanup(th.DeleteSecret, types.NamespacedName{Name: certSecret.Name, Namespace: namespace})
 			spec := GetDefaultRabbitMQSpec()
-			spec["tls"] = map[string]interface{}{
+			spec["tls"] = map[string]any{
 				"secretName": certSecret.Name,
 			}
 			rabbitmq := CreateRabbitMQ(rabbitmqName, spec)
@@ -134,7 +134,7 @@ var _ = Describe("RabbitMQ Controller", func() {
 			certSecret = CreateCertSecret(rabbitmqName)
 			DeferCleanup(th.DeleteSecret, types.NamespacedName{Name: certSecret.Name, Namespace: namespace})
 			spec := GetDefaultRabbitMQSpec()
-			spec["tls"] = map[string]interface{}{
+			spec["tls"] = map[string]any{
 				"secretName": certSecret.Name,
 			}
 			rabbitmq := CreateRabbitMQ(rabbitmqName, spec)
@@ -172,14 +172,14 @@ var _ = Describe("RabbitMQ Controller", func() {
 	When("RabbitMQ gets created with a complete statefulset override", func() {
 		BeforeEach(func() {
 			spec := GetDefaultRabbitMQSpec()
-			spec["override"] = map[string]interface{}{
-				"statefulSet": map[string]interface{}{
-					"spec": map[string]interface{}{
+			spec["override"] = map[string]any{
+				"statefulSet": map[string]any{
+					"spec": map[string]any{
 						"replicas": 3,
-						"template": map[string]interface{}{
-							"spec": map[string]interface{}{
-								"containers": []interface{}{
-									map[string]interface{}{
+						"template": map[string]any{
+							"spec": map[string]any{
+								"containers": []any{
+									map[string]any{
 										"name": "foobar",
 									},
 								},
@@ -207,9 +207,9 @@ var _ = Describe("RabbitMQ Controller", func() {
 	When("RabbitMQ gets created with a partial statefulset override", func() {
 		BeforeEach(func() {
 			spec := GetDefaultRabbitMQSpec()
-			spec["override"] = map[string]interface{}{
-				"statefulSet": map[string]interface{}{
-					"spec": map[string]interface{}{
+			spec["override"] = map[string]any{
+				"statefulSet": map[string]any{
+					"spec": map[string]any{
 						"replicas": 3,
 					},
 				},
@@ -233,9 +233,9 @@ var _ = Describe("RabbitMQ Controller", func() {
 	When("RabbitMQ gets updated with an invalid statefulset override", func() {
 		BeforeEach(func() {
 			spec := GetDefaultRabbitMQSpec()
-			spec["override"] = map[string]interface{}{
-				"statefulSet": map[string]interface{}{
-					"spec": map[string]interface{}{
+			spec["override"] = map[string]any{
+				"statefulSet": map[string]any{
+					"spec": map[string]any{
 						"replicas": 3,
 					},
 				},
@@ -249,7 +249,7 @@ var _ = Describe("RabbitMQ Controller", func() {
 
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, rabbitmqName, instance)).Should(Succeed())
-				data, _ := json.Marshal(map[string]interface{}{
+				data, _ := json.Marshal(map[string]any{
 					"wrong": "type",
 				})
 				instance.Spec.Override.StatefulSet.Raw = data
@@ -262,15 +262,15 @@ var _ = Describe("RabbitMQ Controller", func() {
 	When("RabbitMQ gets created with a service override", func() {
 		BeforeEach(func() {
 			spec := GetDefaultRabbitMQSpec()
-			spec["override"] = map[string]interface{}{
-				"service": map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"annotations": map[string]interface{}{
+			spec["override"] = map[string]any{
+				"service": map[string]any{
+					"metadata": map[string]any{
+						"annotations": map[string]any{
 							"metallb.universe.tf/address-pool":    "internalapi",
 							"metallb.universe.tf/loadBalancerIPs": "192.0.2.1",
 						},
 					},
-					"spec": map[string]interface{}{
+					"spec": map[string]any{
 						"type": "LoadBalancer",
 					},
 				},

--- a/tests/functional/transporturl_controller_test.go
+++ b/tests/functional/transporturl_controller_test.go
@@ -57,7 +57,7 @@ var _ = Describe("TransportURL controller", func() {
 			CreateRabbitMQCluster(rabbitmqClusterName, GetDefaultRabbitMQClusterSpec(false))
 			DeferCleanup(DeleteRabbitMQCluster, rabbitmqClusterName)
 
-			spec := map[string]interface{}{
+			spec := map[string]any{
 				"rabbitmqClusterName": rabbitmqClusterName.Name,
 			}
 			DeferCleanup(th.DeleteInstance, CreateTransportURL(transportURLName, spec))
@@ -89,7 +89,7 @@ var _ = Describe("TransportURL controller", func() {
 			Eventually(func(g Gomega) {
 				s := th.GetSecret(transportURLSecretName)
 				g.Expect(s.Data).To(HaveLen(1))
-				g.Expect(s.Data).To(HaveKeyWithValue("transport_url", []byte(fmt.Sprintf("rabbit://user:12345678@host.%s.svc:5672/?ssl=0", namespace))))
+				g.Expect(s.Data).To(HaveKeyWithValue("transport_url", fmt.Appendf(nil, "rabbit://user:12345678@host.%s.svc:5672/?ssl=0", namespace)))
 
 			}, timeout, interval).Should(Succeed())
 
@@ -111,7 +111,7 @@ var _ = Describe("TransportURL controller", func() {
 			CreateRabbitMQCluster(rabbitmqClusterName, GetDefaultRabbitMQClusterSpec(true))
 			DeferCleanup(DeleteRabbitMQCluster, rabbitmqClusterName)
 
-			spec := map[string]interface{}{
+			spec := map[string]any{
 				"rabbitmqClusterName": rabbitmqClusterName.Name,
 			}
 			DeferCleanup(th.DeleteInstance, CreateTransportURL(transportURLName, spec))
@@ -123,7 +123,7 @@ var _ = Describe("TransportURL controller", func() {
 			Eventually(func(g Gomega) {
 				s := th.GetSecret(transportURLSecretName)
 				g.Expect(s.Data).To(HaveLen(1))
-				g.Expect(s.Data).To(HaveKeyWithValue("transport_url", []byte(fmt.Sprintf("rabbit://user:12345678@host.%s.svc:5671/?ssl=1", namespace))))
+				g.Expect(s.Data).To(HaveKeyWithValue("transport_url", fmt.Appendf(nil, "rabbit://user:12345678@host.%s.svc:5671/?ssl=1", namespace)))
 
 			}, timeout, interval).Should(Succeed())
 
@@ -145,7 +145,7 @@ var _ = Describe("TransportURL controller", func() {
 			CreateRabbitMQCluster(rabbitmqClusterName, GetDefaultRabbitMQClusterSpec(false))
 			DeferCleanup(DeleteRabbitMQCluster, rabbitmqClusterName)
 
-			spec := map[string]interface{}{
+			spec := map[string]any{
 				"rabbitmqClusterName": rabbitmqClusterName.Name,
 			}
 			DeferCleanup(th.DeleteInstance, CreateTransportURL(transportURLName, spec))
@@ -158,7 +158,7 @@ var _ = Describe("TransportURL controller", func() {
 			Eventually(func(g Gomega) {
 				s := th.GetSecret(transportURLSecretName)
 				g.Expect(s.Data).To(HaveLen(1))
-				g.Expect(s.Data).To(HaveKeyWithValue("transport_url", []byte(fmt.Sprintf("rabbit://user:12345678@host.%s.svc:5672/?ssl=0", namespace))))
+				g.Expect(s.Data).To(HaveKeyWithValue("transport_url", fmt.Appendf(nil, "rabbit://user:12345678@host.%s.svc:5672/?ssl=0", namespace)))
 
 			}, timeout, interval).Should(Succeed())
 
@@ -169,7 +169,7 @@ var _ = Describe("TransportURL controller", func() {
 			Eventually(func(g Gomega) {
 				s := th.GetSecret(transportURLSecretName)
 				g.Expect(s.Data).To(HaveLen(1))
-				g.Expect(s.Data).To(HaveKeyWithValue("transport_url", []byte(fmt.Sprintf("rabbit://user:12345678@host.%s.svc:5671/?ssl=1", namespace))))
+				g.Expect(s.Data).To(HaveKeyWithValue("transport_url", fmt.Appendf(nil, "rabbit://user:12345678@host.%s.svc:5671/?ssl=1", namespace)))
 
 			}, timeout, interval).Should(Succeed())
 


### PR DESCRIPTION
Modernize using `gopls modernize tool` to update:

- Replace interface{} with any type alias (Go 1.18+)
- Update range loops to use idiomatic range syntax
- Replace fmt.Sprintf with fmt.Appendf where appropriate

These changes improve code readability and align with current Go best practices.

Co-Authored-By: Claude <noreply@anthropic.com>