### PR TITLE
Force RabbitMQ to stick to TLSv1.2

### DIFF
--- a/controllers/rabbitmq/rabbitmq_controller.go
+++ b/controllers/rabbitmq/rabbitmq_controller.go
@@ -228,50 +228,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 	// all cert input checks out so report InputReady
 	instance.Status.Conditions.MarkTrue(condition.TLSInputReadyCondition, condition.InputReadyMessage)
 
-	// RabbitMq config maps
-	cms := []util.Template{
-		{
-			Name:         fmt.Sprintf("%s-config-data", instance.Name),
-			Namespace:    instance.Namespace,
-			Type:         util.TemplateTypeConfig,
-			InstanceType: "rabbitmq",
-			Labels:       map[string]string{},
-			CustomData: map[string]string{
-				"inter_node_tls.config": `[
-  {server, [
-    {cacertfile,"/etc/rabbitmq-tls/ca.crt"},
-    {certfile,"/etc/rabbitmq-tls/tls.crt"},
-    {keyfile,"/etc/rabbitmq-tls/tls.key"},
-    {secure_renegotiate, true},
-    {fail_if_no_peer_cert, true},
-    {verify, verify_peer},
-    {versions, ['tlsv1.2','tlsv1.3']}
-  ]},
-  {client, [
-    {cacertfile,"/etc/rabbitmq-tls/ca.crt"},
-    {certfile,"/etc/rabbitmq-tls/tls.crt"},
-    {keyfile,"/etc/rabbitmq-tls/tls.key"},
-    {secure_renegotiate, true},
-    {verify, verify_peer},
-    {versions, ['tlsv1.2','tlsv1.3']}
-  ]}
-].
-`,
-			},
-		},
-	}
-
-	err = configmap.EnsureConfigMaps(ctx, helper, instance, cms, nil)
-	if err != nil {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.ServiceConfigReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.ServiceConfigReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{}, fmt.Errorf("error calculating configmap hash: %w", err)
-	}
-
 	IPv6Enabled, err := ocp.FirstClusterNetworkIsIPv6(ctx, helper)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
@@ -292,6 +248,59 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 			condition.ServiceConfigReadyErrorMessage,
 			err.Error()))
 		return ctrl.Result{}, fmt.Errorf("error getting cluster FIPS config: %w", err)
+	}
+
+	// NOTE(dciabrin) OSPRH-20331 reported RabbitMQ partitionning during
+	// key update events, so until this can be resolved, revert to the
+	// same configuration scheme as OSP17 (see OSPRH-13633)
+	var tlsVersions string
+	if fipsEnabled {
+		tlsVersions = "['tlsv1.2','tlsv1.3']"
+	} else {
+		tlsVersions = "['tlsv1.2']"
+	}
+	// RabbitMq config maps
+	cms := []util.Template{
+		{
+			Name:         fmt.Sprintf("%s-config-data", instance.Name),
+			Namespace:    instance.Namespace,
+			Type:         util.TemplateTypeConfig,
+			InstanceType: "rabbitmq",
+			Labels:       map[string]string{},
+			CustomData: map[string]string{
+				"inter_node_tls.config": fmt.Sprintf(`[
+  {server, [
+    {cacertfile,"/etc/rabbitmq-tls/ca.crt"},
+    {certfile,"/etc/rabbitmq-tls/tls.crt"},
+    {keyfile,"/etc/rabbitmq-tls/tls.key"},
+    {secure_renegotiate, true},
+    {fail_if_no_peer_cert, true},
+    {verify, verify_peer},
+    {versions, %s}
+  ]},
+  {client, [
+    {cacertfile,"/etc/rabbitmq-tls/ca.crt"},
+    {certfile,"/etc/rabbitmq-tls/tls.crt"},
+    {keyfile,"/etc/rabbitmq-tls/tls.key"},
+    {secure_renegotiate, true},
+    {verify, verify_peer},
+    {versions, %s}
+  ]}
+].
+`, tlsVersions, tlsVersions),
+			},
+		},
+	}
+
+	err = configmap.EnsureConfigMaps(ctx, helper, instance, cms, nil)
+	if err != nil {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.ServiceConfigReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.ServiceConfigReadyErrorMessage,
+			err.Error()))
+		return ctrl.Result{}, fmt.Errorf("error calculating configmap hash: %w", err)
 	}
 
 	rabbitmqCluster := &rabbitmqv2.RabbitmqCluster{

--- a/tests/functional/rabbitmq_controller_test.go
+++ b/tests/functional/rabbitmq_controller_test.go
@@ -19,10 +19,12 @@ package functional_test
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
 	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 	rabbitmqv1 "github.com/openstack-k8s-operators/infra-operator/apis/rabbitmq/v1beta1"
+	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 
 	//revive:disable-next-line:dot-imports
 
@@ -121,6 +123,41 @@ var _ = Describe("RabbitMQ Controller", func() {
 			}, timeout, interval).Should(Succeed())
 		})
 
+		It("should configure TLS 1.2 only for non-FIPS mode", func() {
+			SimulateRabbitMQClusterReady(rabbitmqName)
+			Eventually(func(g Gomega) {
+				// TLS settings for Erlang and RabbitMQ endpoints (AdvancedConfig)
+				// are in an Erlang data structure, so just parse the expected strings
+				// for application "rabbit", "rabbitmq_management", and erlang "client"
+				cluster := GetRabbitMQCluster(rabbitmqName)
+				advancedConfig := cluster.Spec.Rabbitmq.AdvancedConfig
+
+				g.Expect(advancedConfig).To(ContainSubstring("{rabbit, ["))
+				g.Expect(advancedConfig).To(ContainSubstring("{rabbitmq_management, ["))
+				g.Expect(advancedConfig).To(ContainSubstring("{client, ["))
+				g.Expect(strings.Count(advancedConfig, "{versions, ['tlsv1.2']}")).To(Equal(3))
+				// Ensure it doesn't use TLS1.3 (as FIPS still does for the time being)
+				g.Expect(strings.Count(advancedConfig, "'tlsv1.3'")).To(Equal(0))
+
+				// TLS settings for RabbitMQ cluster communication (inter-node-tls.config)
+				// should have a config for server and client. Those are in an Erlang
+				// data structure, so just parse the expected string
+				configMapName := types.NamespacedName{
+					Name:      fmt.Sprintf("%s-config-data", rabbitmqName.Name),
+					Namespace: rabbitmqName.Namespace,
+				}
+				cm := th.GetConfigMap(configMapName)
+				g.Expect(cm.Data).To(HaveKey("inter_node_tls.config"))
+				interNodeConfig := cm.Data["inter_node_tls.config"]
+
+				// Verify server and client configurations use TLS 1.2 only
+				g.Expect(interNodeConfig).To(ContainSubstring("{server, ["))
+				g.Expect(interNodeConfig).To(ContainSubstring("{client, ["))
+				g.Expect(strings.Count(interNodeConfig, "{versions, ['tlsv1.2']}")).To(Equal(2))
+				// Ensure it doesn't use TLS1.3 (as FIPS still does for the time being)
+				g.Expect(strings.Count(interNodeConfig, "'tlsv1.3'")).To(Equal(0))
+			}, timeout, interval).Should(Succeed())
+		})
 	})
 
 	When("RabbitMQ gets created with FIPS enabled", func() {
@@ -163,9 +200,78 @@ var _ = Describe("RabbitMQ Controller", func() {
 				g.Expect(rabbitmqServerAdditionalErlArgs).To(ContainSubstring("-crypto fips_mode true"))
 				g.Expect(rabbitmqServerAdditionalErlArgs).To(ContainSubstring("-proto_dist inet_tls"))
 				g.Expect(rabbitmqServerAdditionalErlArgs).To(ContainSubstring("-ssl_dist_optfile /etc/rabbitmq/inter-node-tls.config"))
-
 			}, timeout, interval).Should(Succeed())
+		})
 
+		It("should configure TLS 1.2 and 1.3 for FIPS mode", func() {
+			SimulateRabbitMQClusterReady(rabbitmqName)
+			Eventually(func(g Gomega) {
+				// TLS settings for Erlang and RabbitMQ endpoints (AdvancedConfig)
+				// are in an Erlang data structure, so just parse the expected strings
+				// for application "rabbit", "rabbitmq_management", and erlang "client"
+				cluster := GetRabbitMQCluster(rabbitmqName)
+				advancedConfig := cluster.Spec.Rabbitmq.AdvancedConfig
+
+				g.Expect(advancedConfig).To(ContainSubstring("{rabbit, ["))
+				g.Expect(advancedConfig).To(ContainSubstring("{rabbitmq_management, ["))
+				g.Expect(advancedConfig).To(ContainSubstring("{client, ["))
+				g.Expect(strings.Count(advancedConfig, "{versions, ['tlsv1.2','tlsv1.3']}")).To(Equal(3))
+
+				// TLS settings for RabbitMQ cluster communication (inter-node-tls.config)
+				// should have a config for server and client. Those are in an Erlang
+				// data structure, so just parse the expected string
+				configMapName := types.NamespacedName{
+					Name:      fmt.Sprintf("%s-config-data", rabbitmqName.Name),
+					Namespace: rabbitmqName.Namespace,
+				}
+				cm := th.GetConfigMap(configMapName)
+				g.Expect(cm.Data).To(HaveKey("inter_node_tls.config"))
+				interNodeConfig := cm.Data["inter_node_tls.config"]
+
+				// Verify server and client configurations use TLS 1.2 only
+				g.Expect(interNodeConfig).To(ContainSubstring("{server, ["))
+				g.Expect(interNodeConfig).To(ContainSubstring("{client, ["))
+				g.Expect(strings.Count(interNodeConfig, "{versions, ['tlsv1.2','tlsv1.3']}")).To(Equal(2))
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	When("RabbitMQ TLS input validation", func() {
+		It("should set TLSInputReadyCondition to true when valid TLS secret is provided", func() {
+			certSecret := CreateCertSecret(rabbitmqName)
+			DeferCleanup(th.DeleteSecret, types.NamespacedName{Name: certSecret.Name, Namespace: namespace})
+
+			spec := GetDefaultRabbitMQSpec()
+			spec["tls"] = map[string]any{
+				"secretName": certSecret.Name,
+			}
+			rabbitmq := CreateRabbitMQ(rabbitmqName, spec)
+			DeferCleanup(th.DeleteInstance, rabbitmq)
+
+			Eventually(func(g Gomega) {
+				instance := GetRabbitMQ(rabbitmqName)
+				g.Expect(instance.Status.Conditions.Has(condition.TLSInputReadyCondition)).To(BeTrue())
+				tlsCondition := instance.Status.Conditions.Get(condition.TLSInputReadyCondition)
+				g.Expect(tlsCondition.Status).To(Equal(corev1.ConditionTrue))
+				g.Expect(tlsCondition.Message).To(Equal(condition.InputReadyMessage))
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("should set TLSInputReadyCondition to false when TLS secret is missing", func() {
+			spec := GetDefaultRabbitMQSpec()
+			spec["tls"] = map[string]any{
+				"secretName": "non-existent-secret",
+			}
+			rabbitmq := CreateRabbitMQ(rabbitmqName, spec)
+			DeferCleanup(th.DeleteInstance, rabbitmq)
+
+			Eventually(func(g Gomega) {
+				instance := GetRabbitMQ(rabbitmqName)
+				g.Expect(instance.Status.Conditions.Has(condition.TLSInputReadyCondition)).To(BeTrue())
+				tlsCondition := instance.Status.Conditions.Get(condition.TLSInputReadyCondition)
+				g.Expect(tlsCondition.Status).To(Equal(corev1.ConditionFalse))
+				g.Expect(string(tlsCondition.Reason)).To(Equal(string(condition.RequestedReason)))
+			}, timeout, interval).Should(Succeed())
 		})
 	})
 


### PR DESCRIPTION
The combination of RabbitMQ/Erlang currently in use has issues with TLS1.3, which can cause disconnections/partitions in the rabbitmq cluster during TLS key update.

In order to mitigate this issue until the underlying issue is addressed, force RabbitMQ to use TLS1.2 for connections, in the same way as we did for OSP17 (see [OSPRH-15346](https://issues.redhat.com//browse/OSPRH-15346)).

Jira: https://issues.redhat.com/browse/OSPRH-20331