### PR TITLE
Backport dnsmasq and rabbitmq patches to FR2

### DIFF
--- a/controllers/rabbitmq/rabbitmq_controller.go
+++ b/controllers/rabbitmq/rabbitmq_controller.go
@@ -216,50 +216,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 	// all cert input checks out so report InputReady
 	instance.Status.Conditions.MarkTrue(condition.TLSInputReadyCondition, condition.InputReadyMessage)
 
-	// RabbitMq config maps
-	cms := []util.Template{
-		{
-			Name:         fmt.Sprintf("%s-config-data", instance.Name),
-			Namespace:    instance.Namespace,
-			Type:         util.TemplateTypeConfig,
-			InstanceType: "rabbitmq",
-			Labels:       map[string]string{},
-			CustomData: map[string]string{
-				"inter_node_tls.config": `[
-  {server, [
-    {cacertfile,"/etc/rabbitmq-tls/ca.crt"},
-    {certfile,"/etc/rabbitmq-tls/tls.crt"},
-    {keyfile,"/etc/rabbitmq-tls/tls.key"},
-    {secure_renegotiate, true},
-    {fail_if_no_peer_cert, true},
-    {verify, verify_peer},
-    {versions, ['tlsv1.2','tlsv1.3']}
-  ]},
-  {client, [
-    {cacertfile,"/etc/rabbitmq-tls/ca.crt"},
-    {certfile,"/etc/rabbitmq-tls/tls.crt"},
-    {keyfile,"/etc/rabbitmq-tls/tls.key"},
-    {secure_renegotiate, true},
-    {verify, verify_peer},
-    {versions, ['tlsv1.2','tlsv1.3']}
-  ]}
-].
-`,
-			},
-		},
-	}
-
-	err = configmap.EnsureConfigMaps(ctx, helper, instance, cms, nil)
-	if err != nil {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.ServiceConfigReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.ServiceConfigReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{}, fmt.Errorf("error calculating configmap hash: %w", err)
-	}
-
 	IPv6Enabled, err := ocp.FirstClusterNetworkIsIPv6(ctx, helper)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
@@ -280,6 +236,59 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 			condition.ServiceConfigReadyErrorMessage,
 			err.Error()))
 		return ctrl.Result{}, fmt.Errorf("error getting cluster FIPS config: %w", err)
+	}
+
+	// NOTE(dciabrin) OSPRH-20331 reported RabbitMQ partitionning during
+	// key update events, so until this can be resolved, revert to the
+	// same configuration scheme as OSP17 (see OSPRH-13633)
+	var tlsVersions string
+	if fipsEnabled {
+		tlsVersions = "['tlsv1.2','tlsv1.3']"
+	} else {
+		tlsVersions = "['tlsv1.2']"
+	}
+	// RabbitMq config maps
+	cms := []util.Template{
+		{
+			Name:         fmt.Sprintf("%s-config-data", instance.Name),
+			Namespace:    instance.Namespace,
+			Type:         util.TemplateTypeConfig,
+			InstanceType: "rabbitmq",
+			Labels:       map[string]string{},
+			CustomData: map[string]string{
+				"inter_node_tls.config": fmt.Sprintf(`[
+  {server, [
+    {cacertfile,"/etc/rabbitmq-tls/ca.crt"},
+    {certfile,"/etc/rabbitmq-tls/tls.crt"},
+    {keyfile,"/etc/rabbitmq-tls/tls.key"},
+    {secure_renegotiate, true},
+    {fail_if_no_peer_cert, true},
+    {verify, verify_peer},
+    {versions, %s}
+  ]},
+  {client, [
+    {cacertfile,"/etc/rabbitmq-tls/ca.crt"},
+    {certfile,"/etc/rabbitmq-tls/tls.crt"},
+    {keyfile,"/etc/rabbitmq-tls/tls.key"},
+    {secure_renegotiate, true},
+    {verify, verify_peer},
+    {versions, %s}
+  ]}
+].
+`, tlsVersions, tlsVersions),
+			},
+		},
+	}
+
+	err = configmap.EnsureConfigMaps(ctx, helper, instance, cms, nil)
+	if err != nil {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.ServiceConfigReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.ServiceConfigReadyErrorMessage,
+			err.Error()))
+		return ctrl.Result{}, fmt.Errorf("error calculating configmap hash: %w", err)
 	}
 
 	rabbitmqCluster := &rabbitmqv2.RabbitmqCluster{

--- a/pkg/dnsmasq/deployment.go
+++ b/pkg/dnsmasq/deployment.go
@@ -71,7 +71,6 @@ func Deployment(
 	dnsmasqCmd = append(dnsmasqCmd, "--conf-dir=/etc/dnsmasq.d")
 	dnsmasqCmd = append(dnsmasqCmd, "--hostsdir=/etc/dnsmasq.d/hosts")
 	dnsmasqCmd = append(dnsmasqCmd, "--keep-in-foreground")
-	dnsmasqCmd = append(dnsmasqCmd, "--no-daemon")
 	dnsmasqCmd = append(dnsmasqCmd, "--log-debug")
 	dnsmasqCmd = append(dnsmasqCmd, "--bind-interfaces")
 	dnsmasqCmd = append(dnsmasqCmd, "--listen-address=$(POD_IP)")

--- a/pkg/rabbitmq/cluster.go
+++ b/pkg/rabbitmq/cluster.go
@@ -171,12 +171,21 @@ func ConfigureCluster(
 		}
 		// disable non tls listeners
 		cluster.Spec.TLS.DisableNonTLSListeners = true
+		// NOTE(dciabrin) OSPRH-20331 reported RabbitMQ partitionning during
+		// key update events, so until this can be resolved, revert to the
+		// same configuration scheme as OSP17 (see OSPRH-13633)
+		var tlsVersions string
+		if fipsEnabled {
+			tlsVersions = "['tlsv1.2','tlsv1.3']"
+		} else {
+			tlsVersions = "['tlsv1.2']"
+		}
 		// NOTE(dciabrin) RabbitMQ/Erlang needs a specific TLS configuration ordering
 		// in ssl_options.versions for TLS to work with FIPS. We cannot enforce the right
 		// ordering with AdditionalConfig, we have to pass a specific Erlang value via
 		// the AdvancedConfig field. We also add configuration flags which were known to
 		// work with FIPS in previous version of Openstack.
-		cluster.Spec.Rabbitmq.AdvancedConfig = `[
+		cluster.Spec.Rabbitmq.AdvancedConfig = fmt.Sprintf(`[
 {rabbit, [
 {ssl_options, [
   {cacertfile,"/etc/rabbitmq-tls/ca.crt"},
@@ -189,7 +198,7 @@ func ConfigureCluster(
   {honor_ecc_order,false},
   {verify,verify_none},
   {fail_if_no_peer_cert,false},
-  {versions, ['tlsv1.2','tlsv1.3']}
+  {versions, %s}
 ]}
 ]},
 {rabbitmq_management, [
@@ -205,17 +214,17 @@ func ConfigureCluster(
   {honor_ecc_order,false},
   {verify,verify_none},
   {fail_if_no_peer_cert,false},
-  {versions, ['tlsv1.2','tlsv1.3']}
+  {versions, %s}
 ]}
 ]},
 {client, [
 {cacertfile, "/etc/rabbitmq-tls/ca.crt"},
 {verify,verify_peer},
 {secure_renegotiate,true},
-{versions, ['tlsv1.2','tlsv1.3']}
+{versions, %s}
 ]}
 ].
-`
+`, tlsVersions, tlsVersions, tlsVersions)
 
 		cluster.Spec.Override.StatefulSet.Spec.Template.Spec.Volumes = append(
 			cluster.Spec.Override.StatefulSet.Spec.Template.Spec.Volumes,


### PR DESCRIPTION
Remove --no-daemon flag to improve TCP connection handling
Jira: [OSPRH-20039](https://issues.redhat.com//browse/OSPRH-20039)

Force RabbitMQ to stick to TLSv1.2
Jira: https://issues.redhat.com/browse/OSPRH-20331