### PR TITLE
Force Erlang ssl application to stick to TLSv1.2

### DIFF
--- a/pkg/rabbitmq/cluster.go
+++ b/pkg/rabbitmq/cluster.go
@@ -197,6 +197,7 @@ func ConfigureCluster(
 		// the AdvancedConfig field. We also add configuration flags which were known to
 		// work with FIPS in previous version of Openstack.
 		cluster.Spec.Rabbitmq.AdvancedConfig = fmt.Sprintf(`[
+{ssl, [{protocol_version, %s}]},
 {rabbit, [
 {ssl_options, [
   {cacertfile,"/etc/rabbitmq-tls/ca.crt"},
@@ -235,7 +236,7 @@ func ConfigureCluster(
 {versions, %s}
 ]}
 ].
-`, tlsVersions, tlsVersions, tlsVersions)
+`, tlsVersions, tlsVersions, tlsVersions, tlsVersions)
 
 		cluster.Spec.Override.StatefulSet.Spec.Template.Spec.Volumes = append(
 			cluster.Spec.Override.StatefulSet.Spec.Template.Spec.Volumes,

--- a/tests/functional/rabbitmq_controller_test.go
+++ b/tests/functional/rabbitmq_controller_test.go
@@ -128,10 +128,11 @@ var _ = Describe("RabbitMQ Controller", func() {
 			Eventually(func(g Gomega) {
 				// TLS settings for Erlang and RabbitMQ endpoints (AdvancedConfig)
 				// are in an Erlang data structure, so just parse the expected strings
-				// for application "rabbit", "rabbitmq_management", and erlang "client"
+				// for application "rabbit", "rabbitmq_management", "client" and "ssl"
 				cluster := GetRabbitMQCluster(rabbitmqName)
 				advancedConfig := cluster.Spec.Rabbitmq.AdvancedConfig
 
+				g.Expect(advancedConfig).To(ContainSubstring("{ssl, [{protocol_version, ['tlsv1.2']}"))
 				g.Expect(advancedConfig).To(ContainSubstring("{rabbit, ["))
 				g.Expect(advancedConfig).To(ContainSubstring("{rabbitmq_management, ["))
 				g.Expect(advancedConfig).To(ContainSubstring("{client, ["))
@@ -208,10 +209,11 @@ var _ = Describe("RabbitMQ Controller", func() {
 			Eventually(func(g Gomega) {
 				// TLS settings for Erlang and RabbitMQ endpoints (AdvancedConfig)
 				// are in an Erlang data structure, so just parse the expected strings
-				// for application "rabbit", "rabbitmq_management", and erlang "client"
+				// for application "rabbit", "rabbitmq_management", "client" and "ssl"
 				cluster := GetRabbitMQCluster(rabbitmqName)
 				advancedConfig := cluster.Spec.Rabbitmq.AdvancedConfig
 
+				g.Expect(advancedConfig).To(ContainSubstring("{ssl, [{protocol_version, ['tlsv1.2','tlsv1.3']}"))
 				g.Expect(advancedConfig).To(ContainSubstring("{rabbit, ["))
 				g.Expect(advancedConfig).To(ContainSubstring("{rabbitmq_management, ["))
 				g.Expect(advancedConfig).To(ContainSubstring("{client, ["))


### PR DESCRIPTION
A follow up to [1] where RabbitMQ was forced to be configured with TLS1.2 to avoid disconnections/partitions in the RabbitMQ cluster during TLS key update.

In addition to [1], the ssl application that is part of the Erlang runtime should also be forced to use TLS1.2, so that other CLI tools like 'rabbitmqctl environment' reports correct TLS1.2 status.

[1] 7cb5eca42954e7fbbe7c575d38c9a76caaf97841

Jira: https://issues.redhat.com/browse/OSPRH-20331