### PR TITLE
Bump golangci-lint to 2.7.2 for infra

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
       exclude: ^vendor
 
 - repo: https://github.com/golangci/golangci-lint
-  rev: v2.4.0
+  rev: v2.7.2
   hooks:
     - id: golangci-lint-full
       args: ["-v"]


### PR DESCRIPTION
## Summary
-Bump golangci-lint to 2.7.2