### PR TITLE
Address TransportURL race condition and other fixes

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -235,6 +235,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - rabbitmq.com
+  resources:
+  - rabbitmqclusters/finalizers
+  verbs:
+  - update
+- apiGroups:
   - rabbitmq.openstack.org
   resources:
   - rabbitmqpolicies

--- a/internal/controller/rabbitmq/helpers.go
+++ b/internal/controller/rabbitmq/helpers.go
@@ -36,15 +36,9 @@ func getManagementURL(rabbit *rabbitmqclusterv2.RabbitmqCluster, rabbitSecret *c
 		managementPort = "15671"
 	}
 
-	// Check if secret has a custom port (for testing with mock servers)
-	// In production, the port field contains the AMQP port (5672/5671), not the management port
-	// But in tests with mock servers, we put the mock server's port in the port field
-	if portBytes, ok := rabbitSecret.Data["port"]; ok {
-		port := string(portBytes)
-		// If port is not a standard AMQP port, assume it's a custom management port (for tests)
-		if port != "5672" && port != "5671" {
-			managementPort = port
-		}
+	// Use explicit management-port field if present (for test mock servers)
+	if mgmtPortBytes, ok := rabbitSecret.Data["management-port"]; ok {
+		managementPort = string(mgmtPortBytes)
 	}
 
 	return fmt.Sprintf("%s://%s:%s", protocol, string(rabbitSecret.Data["host"]), managementPort)
@@ -67,4 +61,38 @@ func getTLSCACert(ctx context.Context, h *helper.Helper, rabbit *rabbitmqcluster
 	}
 
 	return caCert, nil
+}
+
+// ClusterReadinessError represents different types of cluster readiness failures
+type ClusterReadinessError struct {
+	ClusterName string
+	Reason      string
+	IsWaiting   bool // true if cluster is starting up, false if it's being deleted
+}
+
+func (e *ClusterReadinessError) Error() string {
+	return e.Reason
+}
+
+// checkClusterReadiness validates that a RabbitMQ cluster is ready for operations
+func checkClusterReadiness(rabbit *rabbitmqclusterv2.RabbitmqCluster) *ClusterReadinessError {
+	if !rabbit.DeletionTimestamp.IsZero() {
+		return &ClusterReadinessError{
+			ClusterName: rabbit.Name,
+			Reason:      fmt.Sprintf("RabbitMQ cluster %s is being deleted", rabbit.Name),
+			IsWaiting:   false,
+		}
+	}
+
+	if rabbit.Status.DefaultUser == nil ||
+		rabbit.Status.DefaultUser.SecretReference == nil ||
+		rabbit.Status.DefaultUser.SecretReference.Name == "" {
+		return &ClusterReadinessError{
+			ClusterName: rabbit.Name,
+			Reason:      fmt.Sprintf("RabbitMQ cluster %s", rabbit.Name),
+			IsWaiting:   true,
+		}
+	}
+
+	return nil
 }

--- a/internal/controller/rabbitmq/helpers.go
+++ b/internal/controller/rabbitmq/helpers.go
@@ -35,6 +35,18 @@ func getManagementURL(rabbit *rabbitmqclusterv2.RabbitmqCluster, rabbitSecret *c
 		protocol = "https"
 		managementPort = "15671"
 	}
+
+	// Check if secret has a custom port (for testing with mock servers)
+	// In production, the port field contains the AMQP port (5672/5671), not the management port
+	// But in tests with mock servers, we put the mock server's port in the port field
+	if portBytes, ok := rabbitSecret.Data["port"]; ok {
+		port := string(portBytes)
+		// If port is not a standard AMQP port, assume it's a custom management port (for tests)
+		if port != "5672" && port != "5671" {
+			managementPort = port
+		}
+	}
+
 	return fmt.Sprintf("%s://%s:%s", protocol, string(rabbitSecret.Data["host"]), managementPort)
 }
 

--- a/internal/controller/rabbitmq/rabbitmq_controller.go
+++ b/internal/controller/rabbitmq/rabbitmq_controller.go
@@ -72,6 +72,10 @@ const (
 	serviceSecretNameField = ".spec.tls.SecretName"
 	caSecretNameField      = ".spec.tls.CASecretName"
 	topologyField          = ".spec.topologyRef.Name"
+
+	// rabbitmqClusterFinalizer is added to RabbitmqCluster to prevent direct deletion
+	// Only removed when parent RabbitMq CR is being deleted
+	rabbitmqClusterFinalizer = "rabbitmq.openstack.org/cluster-finalizer"
 )
 
 var rmqAllWatchFields = []string{
@@ -93,6 +97,7 @@ type Reconciler struct {
 // +kubebuilder:rbac:groups=rabbitmq.openstack.org,resources=rabbitmqs/finalizers,verbs=update
 
 // +kubebuilder:rbac:groups=rabbitmq.com,resources=rabbitmqclusters,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=rabbitmq.com,resources=rabbitmqclusters/finalizers,verbs=update
 
 // Required to determine IPv6 and FIPS
 // +kubebuilder:rbac:groups=config.openshift.io,resources=networks,verbs=get;list;watch;
@@ -193,6 +198,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 	if instance.Spec.TopologyRef != nil {
 		c := condition.UnknownCondition(condition.TopologyReadyCondition, condition.InitReason, condition.TopologyReadyInitMessage)
 		cl.Set(c)
+	}
+
+	// If we're not deleting this and the service object doesn't have our finalizer, add it.
+	if instance.DeletionTimestamp.IsZero() {
+		if controllerutil.AddFinalizer(instance, helper.GetFinalizer()) {
+			// Finalizer was added, will be persisted by defer PatchInstance
+			return ctrl.Result{}, nil
+		}
 	}
 
 	// Handle service delete
@@ -386,6 +399,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 		return rmqres, rmqerr
 	}
 	rabbitmqClusterInstance := rabbitmqImplCluster.GetRabbitMqCluster()
+
+	// Add finalizer to RabbitmqCluster to prevent direct deletion
+	// This ensures RabbitmqCluster can only be deleted when parent RabbitMq is deleted
+	// Need to fetch the cluster again to get a proper pointer for the client
+	clusterForFinalizer := &rabbitmqv2.RabbitmqCluster{}
+	if err := r.Get(ctx, types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, clusterForFinalizer); err == nil {
+		if controllerutil.AddFinalizer(clusterForFinalizer, rabbitmqClusterFinalizer) {
+			if err := r.Update(ctx, clusterForFinalizer); err != nil {
+				return ctrl.Result{}, err
+			}
+			// Finalizer was added, requeue to continue processing
+			return ctrl.Result{Requeue: true}, nil
+		}
+	}
 
 	clusterReady := false
 	if rabbitmqClusterInstance.Status.ObservedGeneration == rabbitmqClusterInstance.Generation {
@@ -713,6 +740,21 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, instance *rabbitmqv1be
 		return ctrl.Result{}, err
 	}
 
+	// Remove finalizer from RabbitmqCluster so it can be deleted
+	clusterInstance := &rabbitmqv2.RabbitmqCluster{}
+	err := r.Get(ctx, types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, clusterInstance)
+	if err == nil {
+		// Cluster exists - remove our finalizer
+		if controllerutil.RemoveFinalizer(clusterInstance, rabbitmqClusterFinalizer) {
+			if err := r.Update(ctx, clusterInstance); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+	} else if !k8s_errors.IsNotFound(err) {
+		// Error getting cluster (not NotFound) - return error
+		return ctrl.Result{}, err
+	}
+
 	rabbitmqCluster := impl.NewRabbitMqCluster(
 		&rabbitmqv2.RabbitmqCluster{
 			ObjectMeta: metav1.ObjectMeta{
@@ -722,7 +764,7 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, instance *rabbitmqv1be
 		},
 		5,
 	)
-	err := rabbitmqCluster.Delete(ctx, helper)
+	err = rabbitmqCluster.Delete(ctx, helper)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/rabbitmq/rabbitmqpolicy_controller.go
+++ b/internal/controller/rabbitmq/rabbitmqpolicy_controller.go
@@ -19,7 +19,6 @@ package rabbitmq
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -135,26 +134,26 @@ func (r *RabbitMQPolicyReconciler) reconcileNormal(ctx context.Context, instance
 		return ctrl.Result{}, err
 	}
 
-	// Check if cluster is being deleted
-	if !rabbit.DeletionTimestamp.IsZero() {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			rabbitmqv1.RabbitMQPolicyReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			rabbitmqv1.RabbitMQPolicyReadyErrorMessage,
-			fmt.Sprintf("RabbitMQ cluster %s is being deleted", instance.Spec.RabbitmqClusterName)))
-		return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
-	}
-
-	// Check if cluster is ready - need DefaultUser secret to proceed
-	if rabbit.Status.DefaultUser == nil || rabbit.Status.DefaultUser.SecretReference == nil || rabbit.Status.DefaultUser.SecretReference.Name == "" {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			rabbitmqv1.RabbitMQPolicyReadyCondition,
-			condition.RequestedReason,
-			condition.SeverityInfo,
-			"RabbitMQ policy waiting for dependencies %s",
-			fmt.Sprintf("RabbitMQ cluster %s", instance.Spec.RabbitmqClusterName)))
-		log.FromContext(ctx).Info("Waiting for RabbitMQ cluster to be ready", "cluster", instance.Spec.RabbitmqClusterName, "hasDefaultUser", rabbit.Status.DefaultUser != nil)
+	// Check if cluster is ready for operations
+	if readinessErr := checkClusterReadiness(rabbit); readinessErr != nil {
+		if readinessErr.IsWaiting {
+			// Cluster is starting up - set waiting condition
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				rabbitmqv1.RabbitMQPolicyReadyCondition,
+				condition.RequestedReason,
+				condition.SeverityInfo,
+				"RabbitMQ policy waiting for dependencies %s",
+				readinessErr.Reason))
+			log.FromContext(ctx).Info("Waiting for RabbitMQ cluster to be ready", "cluster", instance.Spec.RabbitmqClusterName)
+		} else {
+			// Cluster is being deleted - set error condition
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				rabbitmqv1.RabbitMQPolicyReadyCondition,
+				condition.ErrorReason,
+				condition.SeverityWarning,
+				rabbitmqv1.RabbitMQPolicyReadyErrorMessage,
+				readinessErr.Reason))
+		}
 		return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
 	}
 

--- a/internal/controller/rabbitmq/rabbitmquser_controller.go
+++ b/internal/controller/rabbitmq/rabbitmquser_controller.go
@@ -233,26 +233,26 @@ func (r *RabbitMQUserReconciler) reconcileNormal(ctx context.Context, instance *
 		return ctrl.Result{}, err
 	}
 
-	// Check if cluster is being deleted
-	if !rabbit.DeletionTimestamp.IsZero() {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			rabbitmqv1.RabbitMQUserReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			rabbitmqv1.RabbitMQUserReadyErrorMessage,
-			fmt.Sprintf("RabbitMQ cluster %s is being deleted", instance.Spec.RabbitmqClusterName)))
-		return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
-	}
-
-	// Check if cluster is ready - need DefaultUser secret to proceed
-	if rabbit.Status.DefaultUser == nil || rabbit.Status.DefaultUser.SecretReference == nil || rabbit.Status.DefaultUser.SecretReference.Name == "" {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			rabbitmqv1.RabbitMQUserReadyCondition,
-			condition.RequestedReason,
-			condition.SeverityInfo,
-			rabbitmqv1.RabbitMQUserReadyWaitingMessage,
-			fmt.Sprintf("RabbitMQ cluster %s", instance.Spec.RabbitmqClusterName)))
-		Log.Info("Waiting for RabbitMQ cluster to be ready", "cluster", instance.Spec.RabbitmqClusterName, "hasDefaultUser", rabbit.Status.DefaultUser != nil)
+	// Check if cluster is ready for operations
+	if readinessErr := checkClusterReadiness(rabbit); readinessErr != nil {
+		if readinessErr.IsWaiting {
+			// Cluster is starting up - set waiting condition
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				rabbitmqv1.RabbitMQUserReadyCondition,
+				condition.RequestedReason,
+				condition.SeverityInfo,
+				rabbitmqv1.RabbitMQUserReadyWaitingMessage,
+				readinessErr.Reason))
+			Log.Info("Waiting for RabbitMQ cluster to be ready", "cluster", instance.Spec.RabbitmqClusterName)
+		} else {
+			// Cluster is being deleted - set error condition
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				rabbitmqv1.RabbitMQUserReadyCondition,
+				condition.ErrorReason,
+				condition.SeverityWarning,
+				rabbitmqv1.RabbitMQUserReadyErrorMessage,
+				readinessErr.Reason))
+		}
 		return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
 	}
 

--- a/internal/controller/rabbitmq/rabbitmqvhost_controller.go
+++ b/internal/controller/rabbitmq/rabbitmqvhost_controller.go
@@ -61,6 +61,7 @@ type RabbitMQVhostReconciler struct {
 //+kubebuilder:rbac:groups=rabbitmq.openstack.org,resources=rabbitmqvhosts/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=rabbitmq.openstack.org,resources=rabbitmqvhosts/finalizers,verbs=update
 //+kubebuilder:rbac:groups=rabbitmq.openstack.org,resources=rabbitmqusers,verbs=get;list;watch
+//+kubebuilder:rbac:groups=rabbitmq.openstack.org,resources=rabbitmqs,verbs=get;list;watch
 //+kubebuilder:rbac:groups=rabbitmq.com,resources=rabbitmqclusters,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
 
@@ -124,6 +125,29 @@ func (r *RabbitMQVhostReconciler) reconcileNormal(ctx context.Context, instance 
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(rabbitmqv1.RabbitMQVhostReadyCondition, condition.ErrorReason, condition.SeverityWarning, rabbitmqv1.RabbitMQVhostReadyErrorMessage, err.Error()))
 		return ctrl.Result{}, err
+	}
+
+	// Check if cluster is being deleted
+	if !rabbit.DeletionTimestamp.IsZero() {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			rabbitmqv1.RabbitMQVhostReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			rabbitmqv1.RabbitMQVhostReadyErrorMessage,
+			fmt.Sprintf("RabbitMQ cluster %s is being deleted", instance.Spec.RabbitmqClusterName)))
+		return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
+	}
+
+	// Check if cluster is ready - need DefaultUser secret to proceed
+	if rabbit.Status.DefaultUser == nil || rabbit.Status.DefaultUser.SecretReference == nil || rabbit.Status.DefaultUser.SecretReference.Name == "" {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			rabbitmqv1.RabbitMQVhostReadyCondition,
+			condition.RequestedReason,
+			condition.SeverityInfo,
+			"RabbitMQ vhost waiting for dependencies %s",
+			fmt.Sprintf("RabbitMQ cluster %s", instance.Spec.RabbitmqClusterName)))
+		log.FromContext(ctx).Info("Waiting for RabbitMQ cluster to be ready", "cluster", instance.Spec.RabbitmqClusterName, "hasDefaultUser", rabbit.Status.DefaultUser != nil)
+		return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
 	}
 
 	// Get admin credentials
@@ -350,6 +374,35 @@ func (r *RabbitMQVhostReconciler) transportURLToVhostMapFunc(_ context.Context, 
 	return requests
 }
 
+// clusterToVhostMapFunc maps RabbitMQ cluster changes to vhost reconciliation requests
+// This allows the vhost controller to react when a cluster is created, deleted,
+// or becomes ready, ensuring vhosts are created/updated when the cluster is available
+// Works with both RabbitmqCluster (cluster-operator) and RabbitMq CRs
+func (r *RabbitMQVhostReconciler) clusterToVhostMapFunc(ctx context.Context, obj client.Object) []reconcile.Request {
+	clusterName := obj.GetName()
+	clusterNamespace := obj.GetNamespace()
+
+	vhostList := &rabbitmqv1.RabbitMQVhostList{}
+	if err := r.List(ctx, vhostList, client.InNamespace(clusterNamespace)); err != nil {
+		log.FromContext(ctx).Error(err, "Failed to list vhosts for cluster watch", "cluster", clusterName)
+		return []reconcile.Request{}
+	}
+
+	requests := []reconcile.Request{}
+	for _, vhost := range vhostList.Items {
+		// Reconcile vhosts that reference this cluster
+		if vhost.Spec.RabbitmqClusterName == clusterName {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      vhost.Name,
+					Namespace: vhost.Namespace,
+				},
+			})
+		}
+	}
+	return requests
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *RabbitMQVhostReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Index RabbitMQUsers by username for efficient lookup
@@ -365,6 +418,10 @@ func (r *RabbitMQVhostReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&rabbitmqv1.RabbitMQVhost{}).
 		Watches(&rabbitmqv1.RabbitMQUser{},
 			handler.EnqueueRequestsFromMapFunc(r.userToVhostMapFunc)).
+		Watches(&rabbitmqclusterv2.RabbitmqCluster{},
+			handler.EnqueueRequestsFromMapFunc(r.clusterToVhostMapFunc)).
+		Watches(&rabbitmqv1.RabbitMq{},
+			handler.EnqueueRequestsFromMapFunc(r.clusterToVhostMapFunc)).
 		Watches(&rabbitmqv1.TransportURL{},
 			handler.EnqueueRequestsFromMapFunc(r.transportURLToVhostMapFunc)).
 		Complete(r)

--- a/internal/rabbitmq/cluster.go
+++ b/internal/rabbitmq/cluster.go
@@ -91,6 +91,13 @@ func ConfigureCluster(
 		Value: fmt.Sprintf("-proto_dist %s_%s %s", inetFamily, inetProtocol, tlsArgs),
 	})
 
+	initContainers := []corev1.Container{
+		{
+			Name:            "setup-container",
+			SecurityContext: &corev1.SecurityContext{},
+		},
+	}
+
 	defaultStatefulSet := rabbitmqv2.StatefulSet{
 		Spec: &rabbitmqv2.StatefulSetSpec{
 			Template: &rabbitmqv2.PodTemplateSpec{
@@ -111,10 +118,8 @@ func ConfigureCluster(
 							VolumeMounts: []corev1.VolumeMount{},
 						},
 					},
-					InitContainers: []corev1.Container{
-						{Name: "setup-container", SecurityContext: &corev1.SecurityContext{}},
-					},
-					Volumes: []corev1.Volume{},
+					InitContainers: initContainers,
+					Volumes:        []corev1.Volume{},
 				},
 			},
 		},

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -323,23 +323,21 @@ func CreateOrUpdateRabbitMQClusterSecret(name types.NamespacedName, mq *rabbitmq
 			},
 		}
 
-		// Use mock RabbitMQ API host/port if available, otherwise use fake service host
 		host := "host." + namespace + ".svc"
 		port := "5672"
 		if mockRabbitMQHost != "" {
 			host = mockRabbitMQHost
-			// For mock server, use management API port directly in secret
-			// getManagementURL will construct http://host:port where port is management port
-			// We need to override the management port to use our mock server's port
-			port = mockRabbitMQPort
 		}
 
-		// create rabbitmq-secret secret
 		secretData := map[string][]byte{
 			"host":     []byte(host),
 			"password": []byte("12345678"),
 			"username": []byte("user"),
 			"port":     []byte(port),
+		}
+
+		if mockRabbitMQHost != "" {
+			secretData["management-port"] = []byte(mockRabbitMQPort)
 		}
 
 		// if tls is enabled for rabbitmq cluster port will be 5671

--- a/test/functional/transporturl_controller_test.go
+++ b/test/functional/transporturl_controller_test.go
@@ -796,6 +796,10 @@ var _ = Describe("TransportURL controller", func() {
 				Namespace: namespace,
 			}
 
+			// Set up mock RabbitMQ Management API so controller can make API calls
+			SetupMockRabbitMQAPI()
+			DeferCleanup(StopMockRabbitMQAPI)
+
 			// Create RabbitMQCluster first
 			CreateRabbitMQCluster(rabbitmqName, GetDefaultRabbitMQClusterSpec(false))
 			DeferCleanup(DeleteRabbitMQCluster, rabbitmqName)
@@ -1704,6 +1708,57 @@ var _ = Describe("TransportURL controller", func() {
 					g.Expect(k8s_errors.IsNotFound(err)).To(BeTrue(), "Old user should be NotFound")
 				}
 			}, time.Second*45, interval).Should(Succeed())
+		})
+	})
+
+	When("TransportURL is created before RabbitMQ Status.QueueType is set (race condition)", func() {
+		BeforeEach(func() {
+			// Create RabbitMQ CR with Spec.QueueType=Quorum but without Status.QueueType
+			// This simulates the race condition during RabbitMQ 3.9->4.2 upgrade
+			spec := GetDefaultRabbitMQSpec()
+			spec["queueType"] = "Quorum"
+			rabbitmq := CreateRabbitMQ(rabbitmqClusterName, spec)
+			DeferCleanup(th.DeleteInstance, rabbitmq)
+
+			// Create RabbitMQCluster
+			CreateRabbitMQCluster(rabbitmqClusterName, GetDefaultRabbitMQClusterSpec(false))
+			DeferCleanup(DeleteRabbitMQCluster, rabbitmqClusterName)
+
+			// Create TransportURL
+			transportURLSpec := map[string]any{
+				"rabbitmqClusterName": rabbitmqClusterName.Name,
+			}
+			DeferCleanup(th.DeleteInstance, CreateTransportURL(transportURLName, transportURLSpec))
+		})
+
+		It("should read Spec.QueueType when Status.QueueType is not yet set", func() {
+			// Simulate RabbitMQCluster as ready
+			// Note: SimulateRabbitMQClusterReady does NOT set Status.QueueType
+			SimulateRabbitMQClusterReady(rabbitmqClusterName)
+
+			// Verify RabbitMQ CR has Spec.QueueType set to Quorum
+			Eventually(func(g Gomega) {
+				rabbitmq := GetRabbitMQ(rabbitmqClusterName)
+				g.Expect(rabbitmq.Spec.QueueType).ToNot(BeNil())
+				g.Expect(*rabbitmq.Spec.QueueType).To(Equal(rabbitmqv1.QueueTypeQuorum))
+			}, timeout, interval).Should(Succeed())
+
+			// Verify the TransportURL secret contains quorumqueues=true
+			// even though Status.QueueType is not set (race condition scenario)
+			Eventually(func(g Gomega) {
+				s := th.GetSecret(transportURLSecretName)
+				g.Expect(s.Data).To(HaveKey("transport_url"))
+				g.Expect(s.Data).To(HaveKeyWithValue("quorumqueues", []byte("true")),
+					"TransportURL should set quorumqueues=true based on Spec.QueueType even when Status.QueueType is not yet set")
+			}, timeout, interval).Should(Succeed())
+
+			// Verify TransportURL is ready
+			th.ExpectCondition(
+				transportURLName,
+				ConditionGetterFunc(TransportURLConditionGetter),
+				rabbitmqv1.TransportURLReadyCondition,
+				corev1.ConditionTrue,
+			)
 		})
 	})
 })


### PR DESCRIPTION
This fixes a number of things:

- User controller now always calls RabbitMQ API on every reconcile and not only on credential changes
- Added finalizer to RabbitmqCluster to prevent direct deletion. 
  Cluster can only be deleted when parent RabbitMq CR is deleted, 
  preventing accidental removal that would break management 
  (default user credentials will change on bootstrap)
- Fix webhook to preserve user-specified QueueType values. 
  The webhook now checks if QueueType is explicitly set in the 
  incoming request before attempting any defaulting logic

and most importantly we fix a TransportURL Race Condition:

Prioritize Spec.QueueType over Status.QueueType when determining quorum queue settings. This fixes a race condition where TransportURL reconciles before Status.QueueType is set during RabbitMQ cluster creation.

Previously, TransportURL would default to quorum=false during the window
between cluster creation and Status.QueueType update, causing services to
create classic queues on RabbitMQ clusters configured for quorum queues.
When services later reconnected with quorum=true, they would fail with
PRECONDITION_FAILED errors.

Jira: https://issues.redhat.com/browse/OSPRH-26770