### PR TITLE
Fix RabbitMQ webhook to preserve QueueType during operator upgrades

### DIFF
--- a/apis/rabbitmq/v1beta1/rabbitmq_webhook.go
+++ b/apis/rabbitmq/v1beta1/rabbitmq_webhook.go
@@ -18,8 +18,10 @@ package v1beta1
 
 import (
 	"context"
+	"time"
 
 	common_webhook "github.com/openstack-k8s-operators/lib-common/modules/common/webhook"
+	rabbitmqv2 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -49,67 +51,139 @@ func SetupRabbitMqDefaults(defaults RabbitMqDefaults) {
 
 // Default sets default values for the RabbitMq using the provided Kubernetes client
 // to check if the cluster already exists
+//
+// NOTE: This function has a potential race condition (TOCTOU - Time Of Check Time Of Use).
+// Between reading the existing resources and applying defaults, the state could change.
+// We try to mitigate the risk by relying on the controller reconciliation loop and
+// by checking multiple sources (CR spec, status, cluster).
+// Complete prevention would require distributed locking, which is not practical for webhooks
 func (r *RabbitMq) Default(k8sClient client.Client) {
-	rabbitmqlog.Info("default", "name", r.Name)
+	rabbitmqlog.Info("default", "name", r.Name, "namespace", r.Namespace)
+
+	// Defensive checks - these should be guaranteed by the API server
+	if r.Name == "" || r.Namespace == "" {
+		rabbitmqlog.Error(nil, "invalid RabbitMq resource: name or namespace is empty",
+			"name", r.Name, "namespace", r.Namespace)
+		// Apply other defaults without QueueType logic
+		r.Spec.Default(false)
+		return
+	}
+
+	// shouldDefaultQueueType determines whether we should set QueueType to the default value (Quorum)
+	// false means: either the user set it explicitly, or we found an existing deployment and must preserve its state
+	shouldDefaultQueueType := true
 
 	if k8sClient != nil {
+		// Create a context with timeout to prevent hanging on slow API servers
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
 		// First, check if the user has explicitly set QueueType in the incoming request
 		// If so, preserve it and don't override with any default value
 		if r.Spec.QueueType != nil && *r.Spec.QueueType != "" {
 			rabbitmqlog.Info("preserving user-specified QueueType", "name", r.Name, "queueType", *r.Spec.QueueType)
+			shouldDefaultQueueType = false
 		} else {
 			// User didn't set QueueType - check if existing RabbitMq CR has it set
 			existingRabbitMq := &RabbitMq{}
-			err := k8sClient.Get(context.Background(), types.NamespacedName{
+			err := k8sClient.Get(ctx, types.NamespacedName{
 				Name: r.Name, Namespace: r.Namespace,
 			}, existingRabbitMq)
 
 			if err != nil && !apierrors.IsNotFound(err) {
-				rabbitmqlog.Error(err, "failed to get existing RabbitMq CR", "name", r.Name, "namespace", r.Namespace)
-				queueType := "Quorum"
-				r.Spec.QueueType = &queueType
-				r.Spec.Default(false)
+				// Error fetching existing RabbitMq CR (not a NotFound error)
+				// Fail safe: don't default QueueType to avoid breaking existing deployments
+				rabbitmqlog.Error(err, "failed to get existing RabbitMq CR, not defaulting QueueType for safety",
+					"name", r.Name, "namespace", r.Namespace)
+				shouldDefaultQueueType = false
+				r.Spec.Default(shouldDefaultQueueType)
 				return
 			}
 
-			if err == nil && existingRabbitMq.Spec.QueueType != nil && *existingRabbitMq.Spec.QueueType != "" {
-				// Existing CR has QueueType set - preserve it
-				r.Spec.QueueType = existingRabbitMq.Spec.QueueType
-				rabbitmqlog.Info("preserving QueueType from existing CR", "name", r.Name, "queueType", *r.Spec.QueueType)
-			} else {
-				// Either:
-				// - No existing RabbitMq CR (creation)
-				// - Existing RabbitMq CR without QueueType (needs defaulting)
-				// In both cases, default QueueType to Quorum.
-				// The CR's queueType should always be set based on desired state, not cluster state.
-				// Status.QueueType will reflect the actual cluster state after reconciliation.
-				if err == nil {
-					rabbitmqlog.Info("existing RabbitMq CR found without QueueType, will default to Quorum", "name", r.Name)
-				} else {
-					rabbitmqlog.Info("new RabbitMq CR, will default QueueType to Quorum", "name", r.Name)
+			// Check if we found an existing RabbitMq CR
+			rabbitMqCRExists := (err == nil)
+
+			if rabbitMqCRExists {
+				// Existing RabbitMq CR found - check if it has QueueType set
+				if existingRabbitMq.Spec.QueueType != nil && *existingRabbitMq.Spec.QueueType != "" {
+					// Existing CR has QueueType set in Spec - preserve it
+					// Create a new pointer to avoid aliasing
+					queueType := *existingRabbitMq.Spec.QueueType
+					r.Spec.QueueType = &queueType
+					rabbitmqlog.Info("preserving QueueType from existing CR spec", "name", r.Name, "queueType", queueType)
+					shouldDefaultQueueType = false
+				} else if existingRabbitMq.Status.QueueType != "" {
+					// Existing CR has QueueType set in Status but not in Spec
+					// This can happen when:
+					// - Old deployment where Spec.QueueType was never set (webhook didn't exist)
+					// - Status.QueueType was set by controller based on actual cluster state
+					// Preserve the Status.QueueType to avoid breaking existing deployments
+					// by changing queue type (which would cause PRECONDITION_FAILED errors)
+					statusQueueType := existingRabbitMq.Status.QueueType
+					r.Spec.QueueType = &statusQueueType
+					rabbitmqlog.Info("preserving QueueType from existing CR status (spec was empty)",
+						"name", r.Name,
+						"queueType", statusQueueType,
+						"reason", "preventing queue type change on existing deployment")
+					shouldDefaultQueueType = false
 				}
-				queueType := "Quorum"
-				r.Spec.QueueType = &queueType
+				// If we get here with rabbitMqCRExists=true but no QueueType, fall through to check RabbitmqCluster
+			}
+
+			// If we haven't set QueueType yet (either no RabbitMq CR, or it exists but has no QueueType),
+			// check if RabbitmqCluster exists (upgrade scenario)
+			if shouldDefaultQueueType {
+				rabbitmqlog.Info("checking for existing RabbitmqCluster to determine if this is an upgrade",
+					"name", r.Name, "namespace", r.Namespace, "rabbitMqCRExists", rabbitMqCRExists)
+				cluster := &rabbitmqv2.RabbitmqCluster{}
+				clusterErr := k8sClient.Get(ctx, types.NamespacedName{
+					Name: r.Name, Namespace: r.Namespace,
+				}, cluster)
+
+				if clusterErr != nil && !apierrors.IsNotFound(clusterErr) {
+					// Error fetching RabbitmqCluster (not a NotFound error)
+					// Fail safe: don't default QueueType to avoid breaking existing deployments
+					rabbitmqlog.Error(clusterErr, "error checking for existing RabbitMQCluster, not defaulting QueueType for safety",
+						"name", r.Name, "namespace", r.Namespace)
+					shouldDefaultQueueType = false
+				} else if clusterErr == nil && !cluster.CreationTimestamp.IsZero() {
+					// RabbitmqCluster exists - this is an existing deployment, don't default
+					shouldDefaultQueueType = false
+					rabbitmqlog.Info("found existing RabbitMQCluster, not defaulting QueueType",
+						"name", r.Name,
+						"clusterCreationTimestamp", cluster.CreationTimestamp.String(),
+						"reason", "existing rabbitmq clusters should never be touched")
+				} else {
+					// No existing RabbitmqCluster - this is truly a new deployment
+					// shouldDefaultQueueType stays true, will default to Quorum in spec.Default()
+					if clusterErr != nil {
+						rabbitmqlog.Info("no existing RabbitmqCluster found, will default QueueType to Quorum",
+							"name", r.Name, "namespace", r.Namespace, "error", clusterErr.Error())
+					} else {
+						rabbitmqlog.Info("new RabbitMq deployment, will default QueueType to Quorum", "name", r.Name)
+					}
+				}
 			}
 		}
 	}
 
 	// Apply other defaults (ContainerImage, etc.)
-	// Pass isNew=false to prevent overwriting the QueueType we just set
-	r.Spec.Default(false)
+	r.Spec.Default(shouldDefaultQueueType)
 }
 
 // Default - set defaults for this RabbitMq spec
-func (spec *RabbitMqSpec) Default(isNew bool) {
+// shouldDefaultQueueType: if true, sets QueueType to "Quorum" when not already set
+func (spec *RabbitMqSpec) Default(shouldDefaultQueueType bool) {
 	if spec.ContainerImage == "" {
 		spec.ContainerImage = rabbitMqDefaults.ContainerImageURL
 	}
-	spec.RabbitMqSpecCore.Default(isNew)
+	spec.RabbitMqSpecCore.Default(shouldDefaultQueueType)
 }
 
 // Default - set defaults for this RabbitMqSpecCore
-func (spec *RabbitMqSpecCore) Default(isNew bool) {
-	if isNew && (spec.QueueType == nil || *spec.QueueType == "") {
+// shouldDefaultQueueType: if true, sets QueueType to "Quorum" when not already set
+func (spec *RabbitMqSpecCore) Default(shouldDefaultQueueType bool) {
+	if shouldDefaultQueueType && (spec.QueueType == nil || *spec.QueueType == "") {
 		queueType := "Quorum"
 		spec.QueueType = &queueType
 	}


### PR DESCRIPTION
Restore RabbitmqCluster existence check (removed in 0021016) to prevent defaulting QueueType on existing deployments during operator upgrades. This fixes PRECONDITION_FAILED errors when services redeclare queues with mismatched queue types.

The webhook now checks in order: user-specified value, existing CR spec, existing CR status, RabbitmqCluster existence, then defaults to Quorum only for truly new deployments.

Tested:
- update from fr1 -> preserved queueType=nil
- update from fr3 -> preserved queueType=Mirrored
- new deployment -> queueType: Quorum