### PR TITLE
Skip RDO jobs for InstanceHA-only changes on all dependent jobs

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -6,10 +6,14 @@
     github-check:
       jobs:
         - openstack-k8s-operators-content-provider:
-            irrelevant-files:
+            irrelevant-files: &iha_irrelevant_files
               - ^templates/instanceha/.*$
               - ^test/instanceha/.*$
             vars:
               cifmw_install_yamls_sdk_version: v1.41.1
               cifmw_operator_build_golang_ct: "docker.io/library/golang:1.24"
               cifmw_operator_build_golang_alt_ct: "quay.rdoproject.org/openstack-k8s-operators/golang:1.24"
+        - podified-multinode-edpm-deployment-crc:
+            irrelevant-files: *iha_irrelevant_files
+        - cifmw-crc-podified-edpm-baremetal:
+            irrelevant-files: *iha_irrelevant_files


### PR DESCRIPTION
Adding irrelevant-files only to the content-provider job caused dependent jobs (podified-multinode-edpm-deployment-crc and cifmw-crc-podified-edpm-baremetal) to fail because their skipped dependency was treated as unsatisfied by Zuul.