### PR TITLE
[b/r] Add backup-restore CRD labels to infra-operator CRDs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,10 @@ WORKDIR $REMOTE_SOURCE_DIR/$REMOTE_SOURCE_SUBDIR
 USER root
 RUN mkdir -p ${DEST_ROOT}/usr/local/bin/
 
+# Remove go.work - not needed for the build and may reference a Go version
+# from the CI environment that is higher than the build image provides
+RUN rm -f go.work go.work.sum
+
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN if [ ! -f $CACHITO_ENV_FILE ]; then go mod download ; fi

--- a/apis/bases/instanceha.openstack.org_instancehas.yaml
+++ b/apis/bases/instanceha.openstack.org_instancehas.yaml
@@ -4,6 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    backup.openstack.org/category: controlplane
+    backup.openstack.org/restore: "true"
+    backup.openstack.org/restore-order: "20"
   name: instancehas.instanceha.openstack.org
 spec:
   group: instanceha.openstack.org

--- a/apis/bases/network.openstack.org_bgpconfigurations.yaml
+++ b/apis/bases/network.openstack.org_bgpconfigurations.yaml
@@ -4,6 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    backup.openstack.org/category: dataplane
+    backup.openstack.org/restore: "true"
+    backup.openstack.org/restore-order: "20"
   name: bgpconfigurations.network.openstack.org
 spec:
   group: network.openstack.org

--- a/apis/bases/network.openstack.org_dnsdata.yaml
+++ b/apis/bases/network.openstack.org_dnsdata.yaml
@@ -4,6 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    backup.openstack.org/category: dataplane
+    backup.openstack.org/restore: "true"
+    backup.openstack.org/restore-order: "20"
   name: dnsdata.network.openstack.org
 spec:
   group: network.openstack.org

--- a/apis/bases/network.openstack.org_ipsets.yaml
+++ b/apis/bases/network.openstack.org_ipsets.yaml
@@ -4,6 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    backup.openstack.org/category: dataplane
+    backup.openstack.org/restore: "true"
+    backup.openstack.org/restore-order: "40"
   name: ipsets.network.openstack.org
 spec:
   group: network.openstack.org

--- a/apis/bases/network.openstack.org_netconfigs.yaml
+++ b/apis/bases/network.openstack.org_netconfigs.yaml
@@ -4,6 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    backup.openstack.org/category: dataplane
+    backup.openstack.org/restore: "true"
+    backup.openstack.org/restore-order: "20"
   name: netconfigs.network.openstack.org
 spec:
   group: network.openstack.org

--- a/apis/bases/network.openstack.org_reservations.yaml
+++ b/apis/bases/network.openstack.org_reservations.yaml
@@ -4,6 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    backup.openstack.org/category: dataplane
+    backup.openstack.org/restore: "true"
+    backup.openstack.org/restore-order: "30"
   name: reservations.network.openstack.org
 spec:
   group: network.openstack.org

--- a/apis/bases/rabbitmq.openstack.org_rabbitmqpolicies.yaml
+++ b/apis/bases/rabbitmq.openstack.org_rabbitmqpolicies.yaml
@@ -4,6 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    backup.openstack.org/category: controlplane
+    backup.openstack.org/restore: "true"
+    backup.openstack.org/restore-order: "40"
   name: rabbitmqpolicies.rabbitmq.openstack.org
 spec:
   group: rabbitmq.openstack.org

--- a/apis/bases/rabbitmq.openstack.org_rabbitmqusers.yaml
+++ b/apis/bases/rabbitmq.openstack.org_rabbitmqusers.yaml
@@ -4,6 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    backup.openstack.org/category: controlplane
+    backup.openstack.org/restore: "true"
+    backup.openstack.org/restore-order: "40"
   name: rabbitmqusers.rabbitmq.openstack.org
 spec:
   group: rabbitmq.openstack.org

--- a/apis/bases/rabbitmq.openstack.org_rabbitmqvhosts.yaml
+++ b/apis/bases/rabbitmq.openstack.org_rabbitmqvhosts.yaml
@@ -4,6 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    backup.openstack.org/category: controlplane
+    backup.openstack.org/restore: "true"
+    backup.openstack.org/restore-order: "40"
   name: rabbitmqvhosts.rabbitmq.openstack.org
 spec:
   group: rabbitmq.openstack.org

--- a/apis/bases/topology.openstack.org_topologies.yaml
+++ b/apis/bases/topology.openstack.org_topologies.yaml
@@ -4,6 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    backup.openstack.org/category: dataplane
+    backup.openstack.org/restore: "true"
+    backup.openstack.org/restore-order: "20"
   name: topologies.topology.openstack.org
 spec:
   group: topology.openstack.org

--- a/apis/instanceha/v1beta1/instanceha_types.go
+++ b/apis/instanceha/v1beta1/instanceha_types.go
@@ -118,6 +118,9 @@ type InstanceHaStatus struct {
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[0].status",description="Status"
 //+kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[0].message",description="Message"
+//+kubebuilder:metadata:labels=backup.openstack.org/restore=true
+//+kubebuilder:metadata:labels=backup.openstack.org/category=controlplane
+//+kubebuilder:metadata:labels=backup.openstack.org/restore-order=20
 
 // InstanceHa is the Schema for the instancehas API
 type InstanceHa struct {

--- a/apis/network/v1beta1/bgpconfiguration_types.go
+++ b/apis/network/v1beta1/bgpconfiguration_types.go
@@ -54,6 +54,9 @@ type BGPConfigurationStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:metadata:labels=backup.openstack.org/restore=true
+//+kubebuilder:metadata:labels=backup.openstack.org/category=dataplane
+//+kubebuilder:metadata:labels=backup.openstack.org/restore-order=20
 
 // BGPConfiguration is the Schema for the bgpconfigurations API
 type BGPConfiguration struct {

--- a/apis/network/v1beta1/dnsdata_types.go
+++ b/apis/network/v1beta1/dnsdata_types.go
@@ -63,6 +63,9 @@ type DNSDataStatus struct {
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[0].status",description="Ready"
 //+kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[0].message",description="Message"
+//+kubebuilder:metadata:labels=backup.openstack.org/restore=true
+//+kubebuilder:metadata:labels=backup.openstack.org/category=dataplane
+//+kubebuilder:metadata:labels=backup.openstack.org/restore-order=20
 
 // DNSData is the Schema for the dnsdata API
 type DNSData struct {

--- a/apis/network/v1beta1/ipset_types.go
+++ b/apis/network/v1beta1/ipset_types.go
@@ -108,6 +108,9 @@ type IPSetStatus struct {
 //+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[0].status",description="Ready"
 //+kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[0].message",description="Message"
 //+kubebuilder:printcolumn:name="Reservation",type="string",JSONPath=".status.reservation",description="Reservation"
+//+kubebuilder:metadata:labels=backup.openstack.org/restore=true
+//+kubebuilder:metadata:labels=backup.openstack.org/category=dataplane
+//+kubebuilder:metadata:labels=backup.openstack.org/restore-order=40
 
 // IPSet is the Schema for the ipsets API
 type IPSet struct {

--- a/apis/network/v1beta1/netconfig_types.go
+++ b/apis/network/v1beta1/netconfig_types.go
@@ -136,6 +136,9 @@ type NetConfigStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:shortName=netcfg;netscfg
+//+kubebuilder:metadata:labels=backup.openstack.org/restore=true
+//+kubebuilder:metadata:labels=backup.openstack.org/category=dataplane
+//+kubebuilder:metadata:labels=backup.openstack.org/restore-order=20
 
 // NetConfig is the Schema for the netconfigs API
 type NetConfig struct {

--- a/apis/network/v1beta1/reservation_types.go
+++ b/apis/network/v1beta1/reservation_types.go
@@ -50,6 +50,9 @@ type ReservationStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="Reservation",type="string",JSONPath=".spec.reservation",description="Reservation"
+//+kubebuilder:metadata:labels=backup.openstack.org/restore=true
+//+kubebuilder:metadata:labels=backup.openstack.org/category=dataplane
+//+kubebuilder:metadata:labels=backup.openstack.org/restore-order=30
 
 // Reservation is the Schema for the reservations API
 type Reservation struct {

--- a/apis/rabbitmq/v1beta1/rabbitmqpolicy_types.go
+++ b/apis/rabbitmq/v1beta1/rabbitmqpolicy_types.go
@@ -75,6 +75,9 @@ type RabbitMQPolicyStatus struct {
 //+kubebuilder:printcolumn:name="Pattern",type="string",JSONPath=".spec.pattern"
 //+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[0].status"
 //+kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[0].message"
+//+kubebuilder:metadata:labels=backup.openstack.org/restore=true
+//+kubebuilder:metadata:labels=backup.openstack.org/category=controlplane
+//+kubebuilder:metadata:labels=backup.openstack.org/restore-order=40
 
 // RabbitMQPolicy is the Schema for the rabbitmqpolicies API
 type RabbitMQPolicy struct {

--- a/apis/rabbitmq/v1beta1/rabbitmquser_types.go
+++ b/apis/rabbitmq/v1beta1/rabbitmquser_types.go
@@ -118,6 +118,9 @@ type RabbitMQUserStatus struct {
 //+kubebuilder:printcolumn:name="Vhost",type="string",JSONPath=".status.vhost"
 //+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[0].status"
 //+kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[0].message"
+//+kubebuilder:metadata:labels=backup.openstack.org/restore=true
+//+kubebuilder:metadata:labels=backup.openstack.org/category=controlplane
+//+kubebuilder:metadata:labels=backup.openstack.org/restore-order=40
 
 // RabbitMQUser is the Schema for the rabbitmqusers API
 type RabbitMQUser struct {

--- a/apis/rabbitmq/v1beta1/rabbitmqvhost_types.go
+++ b/apis/rabbitmq/v1beta1/rabbitmqvhost_types.go
@@ -50,6 +50,9 @@ type RabbitMQVhostStatus struct {
 //+kubebuilder:printcolumn:name="Vhost",type="string",JSONPath=".spec.name"
 //+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[0].status"
 //+kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[0].message"
+//+kubebuilder:metadata:labels=backup.openstack.org/restore=true
+//+kubebuilder:metadata:labels=backup.openstack.org/category=controlplane
+//+kubebuilder:metadata:labels=backup.openstack.org/restore-order=40
 
 // RabbitMQVhost is the Schema for the rabbitmqvhosts API
 type RabbitMQVhost struct {

--- a/apis/topology/v1beta1/topology_types.go
+++ b/apis/topology/v1beta1/topology_types.go
@@ -51,6 +51,9 @@ type TopologyStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:metadata:labels=backup.openstack.org/restore=true
+//+kubebuilder:metadata:labels=backup.openstack.org/category=dataplane
+//+kubebuilder:metadata:labels=backup.openstack.org/restore-order=20
 
 // Topology is the Schema for the topologies API
 type Topology struct {

--- a/config/crd/bases/instanceha.openstack.org_instancehas.yaml
+++ b/config/crd/bases/instanceha.openstack.org_instancehas.yaml
@@ -4,6 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    backup.openstack.org/category: controlplane
+    backup.openstack.org/restore: "true"
+    backup.openstack.org/restore-order: "20"
   name: instancehas.instanceha.openstack.org
 spec:
   group: instanceha.openstack.org

--- a/config/crd/bases/network.openstack.org_bgpconfigurations.yaml
+++ b/config/crd/bases/network.openstack.org_bgpconfigurations.yaml
@@ -4,6 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    backup.openstack.org/category: dataplane
+    backup.openstack.org/restore: "true"
+    backup.openstack.org/restore-order: "20"
   name: bgpconfigurations.network.openstack.org
 spec:
   group: network.openstack.org

--- a/config/crd/bases/network.openstack.org_dnsdata.yaml
+++ b/config/crd/bases/network.openstack.org_dnsdata.yaml
@@ -4,6 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    backup.openstack.org/category: dataplane
+    backup.openstack.org/restore: "true"
+    backup.openstack.org/restore-order: "20"
   name: dnsdata.network.openstack.org
 spec:
   group: network.openstack.org

--- a/config/crd/bases/network.openstack.org_ipsets.yaml
+++ b/config/crd/bases/network.openstack.org_ipsets.yaml
@@ -4,6 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    backup.openstack.org/category: dataplane
+    backup.openstack.org/restore: "true"
+    backup.openstack.org/restore-order: "40"
   name: ipsets.network.openstack.org
 spec:
   group: network.openstack.org

--- a/config/crd/bases/network.openstack.org_netconfigs.yaml
+++ b/config/crd/bases/network.openstack.org_netconfigs.yaml
@@ -4,6 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    backup.openstack.org/category: dataplane
+    backup.openstack.org/restore: "true"
+    backup.openstack.org/restore-order: "20"
   name: netconfigs.network.openstack.org
 spec:
   group: network.openstack.org

--- a/config/crd/bases/network.openstack.org_reservations.yaml
+++ b/config/crd/bases/network.openstack.org_reservations.yaml
@@ -4,6 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    backup.openstack.org/category: dataplane
+    backup.openstack.org/restore: "true"
+    backup.openstack.org/restore-order: "30"
   name: reservations.network.openstack.org
 spec:
   group: network.openstack.org

--- a/config/crd/bases/rabbitmq.openstack.org_rabbitmqpolicies.yaml
+++ b/config/crd/bases/rabbitmq.openstack.org_rabbitmqpolicies.yaml
@@ -4,6 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    backup.openstack.org/category: controlplane
+    backup.openstack.org/restore: "true"
+    backup.openstack.org/restore-order: "40"
   name: rabbitmqpolicies.rabbitmq.openstack.org
 spec:
   group: rabbitmq.openstack.org

--- a/config/crd/bases/rabbitmq.openstack.org_rabbitmqusers.yaml
+++ b/config/crd/bases/rabbitmq.openstack.org_rabbitmqusers.yaml
@@ -4,6 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    backup.openstack.org/category: controlplane
+    backup.openstack.org/restore: "true"
+    backup.openstack.org/restore-order: "40"
   name: rabbitmqusers.rabbitmq.openstack.org
 spec:
   group: rabbitmq.openstack.org

--- a/config/crd/bases/rabbitmq.openstack.org_rabbitmqvhosts.yaml
+++ b/config/crd/bases/rabbitmq.openstack.org_rabbitmqvhosts.yaml
@@ -4,6 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    backup.openstack.org/category: controlplane
+    backup.openstack.org/restore: "true"
+    backup.openstack.org/restore-order: "40"
   name: rabbitmqvhosts.rabbitmq.openstack.org
 spec:
   group: rabbitmq.openstack.org

--- a/config/crd/bases/topology.openstack.org_topologies.yaml
+++ b/config/crd/bases/topology.openstack.org_topologies.yaml
@@ -4,6 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    backup.openstack.org/category: dataplane
+    backup.openstack.org/restore: "true"
+    backup.openstack.org/restore-order: "20"
   name: topologies.topology.openstack.org
 spec:
   group: topology.openstack.org


### PR DESCRIPTION
Add backup-restore labels to infra-operator CRDs for backup and restore:
- NetConfig, Topology, BGPConfiguration, DNSData (order 20, dataplane)
- Reservation (order 30, dataplane) - requires NetConfig
- IPSet (order 40, dataplane) - requires Reservation
- InstanceHa (order 20, controlplane) - restored with spec.disabled=True via resource restore modifier to prevent fencing before EDPM reconnects

Jira: [OSPRH-22912](https://redhat.atlassian.net/browse/OSPRH-22912)
Jira: [OSPRH-22913](https://redhat.atlassian.net/browse/OSPRH-22913)
Jira: [OSPRH-26645](https://redhat.atlassian.net/browse/OSPRH-26645)

Depends-on: https://github.com/openstack-k8s-operators/install_yamls/pull/1144