### PR TITLE
Add Node RBAC permissions for MicroShift IPv6 detection

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -38,6 +38,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - delete

--- a/internal/controller/rabbitmq/rabbitmq_controller.go
+++ b/internal/controller/rabbitmq/rabbitmq_controller.go
@@ -127,6 +127,7 @@ type Reconciler struct {
 
 // Required to determine IPv6 and FIPS
 // +kubebuilder:rbac:groups=config.openshift.io,resources=networks,verbs=get;list;watch;
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list
 
 // Required to exec into pods
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete;


### PR DESCRIPTION
The RabbitMQ controller uses ocp.FirstClusterNetworkIsIPv6() from lib-common which falls back to checking Node PodCIDRs on MicroShift when the OpenShift Network CRD is not available. Add the necessary RBAC permissions to list Nodes at cluster scope.

Assisted-By: Claude (claude-sonnet-4.5)