### PR TITLE
Reject RabbitMQUser when username matches cluster default user

### DIFF
--- a/apis/rabbitmq/v1beta1/rabbitmquser_webhook.go
+++ b/apis/rabbitmq/v1beta1/rabbitmquser_webhook.go
@@ -112,6 +112,11 @@ func (r *RabbitMQUser) ValidateCreate(k8sClient client.Client) (admission.Warnin
 		}
 	}
 
+	// Validate username doesn't conflict with the cluster's default user
+	if err := r.validateNotDefaultUser(k8sClient); err != nil {
+		return nil, err
+	}
+
 	return nil, r.validateUniqueUsername(k8sClient, r.Spec.Username)
 }
 
@@ -358,6 +363,40 @@ func (r *RabbitMQUser) validateUniqueUsername(k8sClient client.Client, username 
 				},
 			)
 		}
+	}
+
+	return nil
+}
+
+// validateNotDefaultUser checks that the username doesn't match the cluster's default user
+func (r *RabbitMQUser) validateNotDefaultUser(k8sClient client.Client) error {
+	secretName := fmt.Sprintf("%s-default-user", r.Spec.RabbitmqClusterName)
+	secret := &corev1.Secret{}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := k8sClient.Get(ctx,
+		client.ObjectKey{Name: secretName, Namespace: r.Namespace},
+		secret); err != nil {
+		// If the secret doesn't exist, the cluster may not be created yet - skip check
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return apierrors.NewInternalError(fmt.Errorf("failed to look up default user secret: %w", err))
+	}
+
+	defaultUsername := string(secret.Data["username"])
+	if r.Spec.Username == defaultUsername {
+		return apierrors.NewInvalid(
+			schema.GroupKind{Group: "rabbitmq.openstack.org", Kind: "RabbitMQUser"},
+			r.Name,
+			field.ErrorList{
+				field.Invalid(field.NewPath("spec", "username"), r.Spec.Username,
+					fmt.Sprintf("username %q conflicts with the default user of cluster %q",
+						r.Spec.Username, r.Spec.RabbitmqClusterName)),
+			},
+		)
 	}
 
 	return nil

--- a/internal/webhook/rabbitmq/v1beta1/rabbitmquser_webhook_test.go
+++ b/internal/webhook/rabbitmq/v1beta1/rabbitmquser_webhook_test.go
@@ -17,9 +17,12 @@ limitations under the License.
 package v1beta1
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
 	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 	rabbitmqv1beta1 "github.com/openstack-k8s-operators/infra-operator/apis/rabbitmq/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -125,6 +128,93 @@ var _ = Describe("RabbitMQUser webhook", func() {
 			_, err := user.ValidateCreate(k8sClient)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("invalid character"))
+		})
+
+		It("should reject username matching the cluster's default user", func() {
+			clusterName := "my-cluster"
+			defaultUsername := fmt.Sprintf("default_user_%s", clusterName)
+
+			// Create the default user secret that the cluster controller would create
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-default-user", clusterName),
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"username": []byte(defaultUsername),
+					"password": []byte("secret-password"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, secret)).To(Succeed())
+			})
+
+			user := &rabbitmqv1beta1.RabbitMQUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "conflicting-user",
+					Namespace: "default",
+				},
+				Spec: rabbitmqv1beta1.RabbitMQUserSpec{
+					RabbitmqClusterName: clusterName,
+					Username:            defaultUsername,
+				},
+			}
+
+			_, err := user.ValidateCreate(k8sClient)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("conflicts with the default user"))
+		})
+
+		It("should accept username not matching the cluster's default user", func() {
+			clusterName := "other-cluster"
+			defaultUsername := fmt.Sprintf("default_user_%s", clusterName)
+
+			// Create the default user secret
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-default-user", clusterName),
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"username": []byte(defaultUsername),
+					"password": []byte("secret-password"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, secret)).To(Succeed())
+			})
+
+			user := &rabbitmqv1beta1.RabbitMQUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "non-conflicting-user",
+					Namespace: "default",
+				},
+				Spec: rabbitmqv1beta1.RabbitMQUserSpec{
+					RabbitmqClusterName: clusterName,
+					Username:            "my-custom-user",
+				},
+			}
+
+			_, err := user.ValidateCreate(k8sClient)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should accept username when cluster default user secret does not exist", func() {
+			user := &rabbitmqv1beta1.RabbitMQUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "early-user",
+					Namespace: "default",
+				},
+				Spec: rabbitmqv1beta1.RabbitMQUserSpec{
+					RabbitmqClusterName: "nonexistent-cluster",
+					Username:            "default_user_nonexistent-cluster",
+				},
+			}
+
+			_, err := user.ValidateCreate(k8sClient)
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 


### PR DESCRIPTION
Add a validation webhook check that prevents creating a RabbitMQUser whose username conflicts with the default_user of the referenced RabbitMQ cluster. The check looks up the <cluster>-default-user secret and compares usernames, gracefully skipping if the cluster doesn't exist yet.