### PR TITLE
Expose Redis TLS status, sentinel endpoints, and client URL helpers

### DIFF
--- a/apis/bases/redis.openstack.org_redises.yaml
+++ b/apis/bases/redis.openstack.org_redises.yaml
@@ -285,6 +285,20 @@ spec:
                   the opentack-operator in the top-level CR (e.g. the ContainerImage)
                 format: int64
                 type: integer
+              sentinelHosts:
+                description: SentinelHosts - List of sentinel endpoints in host:port
+                  format
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: atomic
+              tlsSupport:
+                description: Whether TLS is supported by the Redis instance
+                enum:
+                - "True"
+                - "False"
+                - ""
+                type: string
             type: object
         type: object
     served: true

--- a/apis/redis/v1beta1/redis_types.go
+++ b/apis/redis/v1beta1/redis_types.go
@@ -17,12 +17,17 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
+	"fmt"
+
 	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -36,6 +41,13 @@ const (
 	// omit issue with statefulset pod label "controller-revision-hash": "<statefulset_name>-<hash>"
 	// Int32 is a 10 character + hyphen = 11
 	CrMaxLengthCorrection = 11
+
+	// SentinelPort is the port on which Redis Sentinel listens
+	SentinelPort = 26379
+
+	// SentinelMasterName is the name of the Redis master as known to Sentinel.
+	// This is hardcoded in the sentinel configuration templates.
+	SentinelMasterName = "redis"
 )
 
 // RedisSpec defines the desired state of Redis
@@ -79,6 +91,14 @@ type RedisStatus struct {
 	// Conditions
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`
 
+	// +kubebuilder:validation:Enum=True;False;""
+	// Whether TLS is supported by the Redis instance
+	TLSSupport string `json:"tlsSupport,omitempty"`
+
+	// SentinelHosts - List of sentinel endpoints in host:port format
+	// +listType=atomic
+	SentinelHosts []string `json:"sentinelHosts,omitempty" optional:"true"`
+
 	// ObservedGeneration - the most recent generation observed for this
 	// service. If the observed generation is less than the spec generation,
 	// then the controller has not processed the latest changes injected by
@@ -120,6 +140,71 @@ func init() {
 // IsReady - returns true if service is ready to serve requests
 func (instance Redis) IsReady() bool {
 	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
+}
+
+// GetRedisTLSSupport - return the TLS support of the Redis instance
+func (instance *Redis) GetRedisTLSSupport() bool {
+	return instance.Status.TLSSupport == "True"
+}
+
+// GetRedisClientURL - return the connection URL for Redis clients
+func (instance *Redis) GetRedisClientURL() string {
+	url := fmt.Sprintf("redis://%s:%d/", instance.Name, 6379)
+	if instance.GetRedisTLSSupport() {
+		url += "?ssl=true"
+	}
+	return url
+}
+
+// GetSentinelMasterName - return the name of the Redis master as configured in Sentinel
+func (instance *Redis) GetSentinelMasterName() string {
+	return SentinelMasterName
+}
+
+// GetSentinelHosts - return the list of sentinel host:port endpoints
+func (instance *Redis) GetSentinelHosts() []string {
+	return instance.Status.SentinelHosts
+}
+
+// GetRedisSentinelURL - return a connection URL for Redis Sentinel clients.
+// The URL format follows the tooz/oslo.cache convention:
+//
+//	redis://<sentinel host>:<sentinel port>?sentinel=<master name>&sentinel_fallback=<host2>:<port>&sentinel_fallback=<host3>:<port>
+//
+// When TLS is enabled, ssl, sentinel_ssl, and ssl_ca_certs parameters are appended.
+func (instance *Redis) GetRedisSentinelURL() string {
+	if len(instance.Status.SentinelHosts) == 0 {
+		return ""
+	}
+	url := fmt.Sprintf("redis://%s?sentinel=%s", instance.Status.SentinelHosts[0], SentinelMasterName)
+	for _, fallback := range instance.Status.SentinelHosts[1:] {
+		url += "&sentinel_fallback=" + fallback
+	}
+	if instance.GetRedisTLSSupport() {
+		url += "&ssl=true&sentinel_ssl=true&ssl_ca_certs=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+	}
+	return url
+}
+
+// GetRedisByName - gets the Redis instance by name
+func GetRedisByName(
+	ctx context.Context,
+	h *helper.Helper,
+	name string,
+	namespace string,
+) (*Redis, error) {
+	redis := &Redis{}
+	err := h.GetClient().Get(
+		ctx,
+		types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		},
+		redis)
+	if err != nil {
+		return nil, err
+	}
+	return redis, err
 }
 
 // RbacConditionsSet - set the conditions for the rbac object

--- a/apis/redis/v1beta1/zz_generated.deepcopy.go
+++ b/apis/redis/v1beta1/zz_generated.deepcopy.go
@@ -172,6 +172,11 @@ func (in *RedisStatus) DeepCopyInto(out *RedisStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.SentinelHosts != nil {
+		in, out := &in.SentinelHosts, &out.SentinelHosts
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.LastAppliedTopology != nil {
 		in, out := &in.LastAppliedTopology, &out.LastAppliedTopology
 		*out = new(topologyv1beta1.TopoRef)

--- a/apis/test/helpers/redis.go
+++ b/apis/test/helpers/redis.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2023 Red Hat
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"fmt"
+
+	t "github.com/onsi/gomega"
+	redisv1 "github.com/openstack-k8s-operators/infra-operator/apis/redis/v1beta1"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+)
+
+// CreateRedis creates a new Redis instance with the specified namespace in the Kubernetes cluster.
+func (tc *TestHelper) CreateRedis(namespace string, redisName string, spec redisv1.RedisSpec) types.NamespacedName {
+	name := types.NamespacedName{
+		Name:      redisName,
+		Namespace: namespace,
+	}
+
+	r := &redisv1.Redis{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "redis.openstack.org/v1beta1",
+			Kind:       "Redis",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      redisName,
+			Namespace: namespace,
+		},
+		Spec: spec,
+	}
+
+	t.Expect(tc.K8sClient.Create(tc.Ctx, r)).Should(t.Succeed())
+
+	return name
+}
+
+// GetRedis waits for and retrieves a Redis instance from the Kubernetes cluster
+func (tc *TestHelper) GetRedis(name types.NamespacedName) *redisv1.Redis {
+	r := &redisv1.Redis{}
+	t.Eventually(func(g t.Gomega) {
+		g.Expect(tc.K8sClient.Get(tc.Ctx, name, r)).Should(t.Succeed())
+	}, tc.Timeout, tc.Interval).Should(t.Succeed())
+	return r
+}
+
+// SimulateRedisReady simulates a ready state for a Redis instance in a Kubernetes cluster.
+func (tc *TestHelper) SimulateRedisReady(name types.NamespacedName) {
+	t.Eventually(func(g t.Gomega) {
+		r := tc.GetRedis(name)
+		r.Status.ObservedGeneration = r.Generation
+		r.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
+
+		replicas := int32(1)
+		if r.Spec.Replicas != nil {
+			replicas = *r.Spec.Replicas
+		}
+
+		headlessServiceName := r.Name + "-redis"
+		sentinelHosts := make([]string, 0, replicas)
+		for i := int32(0); i < replicas; i++ {
+			sentinelHosts = append(sentinelHosts,
+				fmt.Sprintf("%s-%d.%s.%s.svc:%d",
+					headlessServiceName, i,
+					headlessServiceName,
+					r.Namespace,
+					redisv1.SentinelPort,
+				))
+		}
+		r.Status.SentinelHosts = sentinelHosts
+
+		// This can return conflict so we have the t.Eventually block to retry
+		g.Expect(tc.K8sClient.Status().Update(tc.Ctx, r)).To(t.Succeed())
+
+	}, tc.Timeout, tc.Interval).Should(t.Succeed())
+
+	tc.Logger.Info("Simulated redis ready", "on", name)
+}
+
+// GetDefaultRedisSpec returns redisv1.RedisSpec for test-helpers
+func (tc *TestHelper) GetDefaultRedisSpec() redisv1.RedisSpec {
+	return redisv1.RedisSpec{
+		RedisSpecCore: redisv1.RedisSpecCore{
+			Replicas: ptr.To(int32(3)),
+		},
+	}
+}

--- a/config/crd/bases/redis.openstack.org_redises.yaml
+++ b/config/crd/bases/redis.openstack.org_redises.yaml
@@ -285,6 +285,20 @@ spec:
                   the opentack-operator in the top-level CR (e.g. the ContainerImage)
                 format: int64
                 type: integer
+              sentinelHosts:
+                description: SentinelHosts - List of sentinel endpoints in host:port
+                  format
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: atomic
+              tlsSupport:
+                description: Whether TLS is supported by the Redis instance
+                enum:
+                - "True"
+                - "False"
+                - ""
+                type: string
             type: object
         type: object
     served: true

--- a/internal/controller/redis/redis_controller.go
+++ b/internal/controller/redis/redis_controller.go
@@ -55,6 +55,7 @@ import (
 	redis "github.com/openstack-k8s-operators/infra-operator/internal/redis"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 
+	"github.com/openstack-k8s-operators/lib-common/modules/common/clusterdns"
 	common_rbac "github.com/openstack-k8s-operators/lib-common/modules/common/rbac"
 	commonservice "github.com/openstack-k8s-operators/lib-common/modules/common/service"
 	commonstatefulset "github.com/openstack-k8s-operators/lib-common/modules/common/statefulset"
@@ -291,6 +292,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 	}
 	// all cert input checks out so report InputReady
 	instance.Status.Conditions.MarkTrue(condition.TLSInputReadyCondition, condition.InputReadyMessage)
+	if instance.Spec.TLS.Enabled() {
+		instance.Status.TLSSupport = "True"
+	} else {
+		instance.Status.TLSSupport = "False"
+	}
 
 	// Redis config maps
 	err = r.generateConfigMaps(ctx, helper, instance, &inputHashEnv)
@@ -348,6 +354,26 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 			err.Error()))
 		return hlres, hlerr
 	}
+
+	// Build sentinel host list from statefulset pod DNS names
+	headlessServiceName := instance.GetName() + "-redis"
+	clusterDomain := clusterdns.GetDNSClusterDomain()
+	replicas := int32(1)
+	if instance.Spec.Replicas != nil {
+		replicas = *instance.Spec.Replicas
+	}
+	sentinelHosts := make([]string, 0, int(replicas))
+	for i := int32(0); i < replicas; i++ {
+		host := fmt.Sprintf("%s-%d.%s.%s.svc.%s:%d",
+			headlessServiceName, i,
+			headlessServiceName,
+			instance.Namespace,
+			clusterDomain,
+			redisv1.SentinelPort,
+		)
+		sentinelHosts = append(sentinelHosts, host)
+	}
+	instance.Status.SentinelHosts = sentinelHosts
 
 	// Service to expose Redis pods
 	commonsvc, err := commonservice.NewService(redis.Service(instance), time.Duration(5)*time.Second, nil)

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -43,6 +43,7 @@ import (
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	networkv1 "github.com/openstack-k8s-operators/infra-operator/apis/network/v1beta1"
 	rabbitmqv1 "github.com/openstack-k8s-operators/infra-operator/apis/rabbitmq/v1beta1"
+	redisv1 "github.com/openstack-k8s-operators/infra-operator/apis/redis/v1beta1"
 	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	appsv1 "k8s.io/api/apps/v1"
@@ -930,6 +931,41 @@ func GetMemcached(name types.NamespacedName) *memcachedv1.Memcached {
 		g.Expect(k8sClient.Get(ctx, name, instance)).Should(Succeed())
 	}, timeout, interval).Should(Succeed())
 	return instance
+}
+
+func CreateRedisConfig(namespace string, spec map[string]any) client.Object {
+	name := "redis-" + uuid.New().String()[:25]
+
+	raw := map[string]any{
+		"apiVersion": "redis.openstack.org/v1beta1",
+		"kind":       "Redis",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+		},
+		"spec": spec,
+	}
+
+	return th.CreateUnstructured(raw)
+}
+
+func GetDefaultRedisSpec() map[string]any {
+	return map[string]any{
+		"replicas": 3,
+	}
+}
+
+func GetRedis(name types.NamespacedName) *redisv1.Redis {
+	instance := &redisv1.Redis{}
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, name, instance)).Should(Succeed())
+	}, timeout, interval).Should(Succeed())
+	return instance
+}
+
+func RedisConditionGetter(name types.NamespacedName) condition.Conditions {
+	instance := GetRedis(name)
+	return instance.Status.Conditions
 }
 
 func CreateBGPConfiguration(namespace string, spec map[string]any) client.Object {

--- a/test/functional/redis_controller_test.go
+++ b/test/functional/redis_controller_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package functional_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
+
+	//revive:disable-next-line:dot-imports
+	redisv1 "github.com/openstack-k8s-operators/infra-operator/apis/redis/v1beta1"
+	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Redis Controller", func() {
+	var redisName types.NamespacedName
+
+	When("a default Redis gets created", func() {
+		BeforeEach(func() {
+			redis := CreateRedisConfig(namespace, GetDefaultRedisSpec())
+			redisName.Name = redis.GetName()
+			redisName.Namespace = redis.GetNamespace()
+			DeferCleanup(th.DeleteInstance, redis)
+		})
+
+		It("should have created a Redis", func() {
+			Eventually(func(_ Gomega) {
+				GetRedis(redisName)
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	When("Deployment rollout is progressing", func() {
+		BeforeEach(func() {
+			redis := CreateRedisConfig(namespace, GetDefaultRedisSpec())
+			redisName.Name = redis.GetName()
+			redisName.Namespace = redis.GetNamespace()
+			DeferCleanup(th.DeleteInstance, redis)
+
+			stsName := types.NamespacedName{
+				Name:      redisName.Name + "-redis",
+				Namespace: redisName.Namespace,
+			}
+			th.SimulateStatefulSetProgressing(stsName)
+		})
+
+		It("reaches Ready when deployment rollout finished", func() {
+			stsName := types.NamespacedName{
+				Name:      redisName.Name + "-redis",
+				Namespace: redisName.Namespace,
+			}
+
+			th.ExpectCondition(
+				redisName,
+				ConditionGetterFunc(RedisConditionGetter),
+				condition.DeploymentReadyCondition,
+				corev1.ConditionFalse,
+			)
+
+			th.SimulateStatefulSetReplicaReady(stsName)
+
+			th.ExpectCondition(
+				redisName,
+				ConditionGetterFunc(RedisConditionGetter),
+				condition.DeploymentReadyCondition,
+				corev1.ConditionTrue,
+			)
+		})
+	})
+
+	When("Redis reaches Ready state", func() {
+		BeforeEach(func() {
+			redis := CreateRedisConfig(namespace, GetDefaultRedisSpec())
+			redisName.Name = redis.GetName()
+			redisName.Namespace = redis.GetNamespace()
+			DeferCleanup(th.DeleteInstance, redis)
+
+			stsName := types.NamespacedName{
+				Name:      redisName.Name + "-redis",
+				Namespace: redisName.Namespace,
+			}
+			th.SimulateStatefulSetReplicaReady(stsName)
+		})
+
+		It("populates SentinelHosts in status", func() {
+			Eventually(func(g Gomega) {
+				instance := GetRedis(redisName)
+				g.Expect(instance.Status.SentinelHosts).To(HaveLen(3))
+				headlessServiceName := redisName.Name + "-redis"
+				for i := 0; i < 3; i++ {
+					expectedHost := fmt.Sprintf("%s-%d.%s.%s.svc.cluster.local:%d",
+						headlessServiceName, i,
+						headlessServiceName,
+						redisName.Namespace,
+						redisv1.SentinelPort,
+					)
+					g.Expect(instance.Status.SentinelHosts[i]).To(Equal(expectedHost))
+				}
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("returns correct sentinel URL from GetRedisSentinelURL", func() {
+			Eventually(func(g Gomega) {
+				instance := GetRedis(redisName)
+				g.Expect(instance.Status.SentinelHosts).To(HaveLen(3))
+
+				sentinelURL := instance.GetRedisSentinelURL()
+				headlessServiceName := redisName.Name + "-redis"
+				expectedPrimary := fmt.Sprintf("%s-0.%s.%s.svc.cluster.local:%d",
+					headlessServiceName,
+					headlessServiceName,
+					redisName.Namespace,
+					redisv1.SentinelPort,
+				)
+				g.Expect(sentinelURL).To(HavePrefix("redis://" + expectedPrimary))
+				g.Expect(sentinelURL).To(ContainSubstring("sentinel=redis"))
+				for i := 1; i < 3; i++ {
+					fallback := fmt.Sprintf("%s-%d.%s.%s.svc.cluster.local:%d",
+						headlessServiceName, i,
+						headlessServiceName,
+						redisName.Namespace,
+						redisv1.SentinelPort,
+					)
+					g.Expect(sentinelURL).To(ContainSubstring("sentinel_fallback=" + fallback))
+				}
+				g.Expect(sentinelURL).NotTo(ContainSubstring("ssl=true"))
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("returns correct master name from GetSentinelMasterName", func() {
+			instance := GetRedis(redisName)
+			Expect(instance.GetSentinelMasterName()).To(Equal("redis"))
+		})
+
+		It("returns correct client URL from GetRedisClientURL", func() {
+			instance := GetRedis(redisName)
+			clientURL := instance.GetRedisClientURL()
+			Expect(clientURL).To(Equal(fmt.Sprintf("redis://%s:6379/", redisName.Name)))
+			Expect(clientURL).NotTo(ContainSubstring("ssl=true"))
+		})
+
+		It("sets TLSSupport to False when TLS is not configured", func() {
+			Eventually(func(g Gomega) {
+				instance := GetRedis(redisName)
+				g.Expect(instance.Status.TLSSupport).To(Equal("False"))
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+})

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -46,14 +46,17 @@ import (
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	networkv1 "github.com/openstack-k8s-operators/infra-operator/apis/network/v1beta1"
 	rabbitmqv1 "github.com/openstack-k8s-operators/infra-operator/apis/rabbitmq/v1beta1"
+	redisv1 "github.com/openstack-k8s-operators/infra-operator/apis/redis/v1beta1"
 
 	memcached_ctrl "github.com/openstack-k8s-operators/infra-operator/internal/controller/memcached"
 	network_ctrl "github.com/openstack-k8s-operators/infra-operator/internal/controller/network"
 	rabbitmq_ctrl "github.com/openstack-k8s-operators/infra-operator/internal/controller/rabbitmq"
+	redis_ctrl "github.com/openstack-k8s-operators/infra-operator/internal/controller/redis"
 
 	webhookmemcachedv1beta1 "github.com/openstack-k8s-operators/infra-operator/internal/webhook/memcached/v1beta1"
 	webhooknetworkv1beta1 "github.com/openstack-k8s-operators/infra-operator/internal/webhook/network/v1beta1"
 	webhookrabbitmqv1beta1 "github.com/openstack-k8s-operators/infra-operator/internal/webhook/rabbitmq/v1beta1"
+	webhookredisv1beta1 "github.com/openstack-k8s-operators/infra-operator/internal/webhook/redis/v1beta1"
 
 	ocp_configv1 "github.com/openshift/api/config/v1"
 	infra_test "github.com/openstack-k8s-operators/infra-operator/apis/test/helpers"
@@ -150,6 +153,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	err = memcachedv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
+	err = redisv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
 	err = k8s_networkv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 	err = frrk8sv1.AddToScheme(scheme.Scheme)
@@ -210,6 +215,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	err = webhookmemcachedv1beta1.SetupMemcachedWebhookWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
+	err = webhookredisv1beta1.SetupRedisWebhookWithManager(k8sManager)
+	Expect(err).NotTo(HaveOccurred())
 	err = webhookrabbitmqv1beta1.SetupRabbitMqWebhookWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 	err = webhookrabbitmqv1beta1.SetupRabbitMQUserWebhookWithManager(k8sManager)
@@ -262,6 +269,13 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&memcached_ctrl.Reconciler{
+		Client:  k8sManager.GetClient(),
+		Scheme:  k8sManager.GetScheme(),
+		Kclient: kclient,
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = (&redis_ctrl.Reconciler{
 		Client:  k8sManager.GetClient(),
 		Scheme:  k8sManager.GetScheme(),
 		Kclient: kclient,


### PR DESCRIPTION
Add TLSSupport and SentinelHosts fields to RedisStatus, populated by
the controller from the TLS spec and statefulset pod DNS names. Expose
helper methods on the Redis API type for consumers:

- GetRedisTLSSupport / GetRedisClientURL: direct Redis connection URL 
- GetSentinelHosts / GetRedisSentinelURL: tooz-compatible sentinel URL 
  with sentinel_fallback, ssl, sentinel_ssl and ssl_ca_certs support
- GetRedisByName: fetch a Redis CR by name/namespace

TLSSupport uses a string enum (True/False/"") instead of bool to comply
with the NoBools CRD validation policy. SentinelHosts carries the 
x-kubernetes-list-type=atomic marker required by the CRD schema checker.

Includes functional tests covering TLS status, sentinel host population,
and client/sentinel URL generation, plus shared test helpers.