### PR TITLE
Fix rabbitmqadmin breakage from default_user_tags in .rabbitmqadmin.conf

### DIFF
--- a/internal/controller/rabbitmq/rabbitmq_controller.go
+++ b/internal/controller/rabbitmq/rabbitmq_controller.go
@@ -606,7 +606,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 	}
 
 	// Ensure default user secret exists (optional, for initial setup)
-	err = r.ensureDefaultUser(ctx, instance, isMigration)
+	err = r.ensureDefaultUser(ctx, instance, isMigration, configVersion)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -1314,6 +1314,7 @@ func (r *Reconciler) ensureDefaultUser(
 	ctx context.Context,
 	instance *rabbitmqv1beta1.RabbitMq,
 	migrate bool,
+	configVersion string,
 ) error {
 	Log := r.GetLogger(ctx)
 	secretName := fmt.Sprintf("%s-default-user", instance.Name)
@@ -1343,7 +1344,7 @@ func (r *Reconciler) ensureDefaultUser(
 
 		// Only generate credentials on first creation
 		if len(secret.Data) == 0 {
-			generated, genErr := rabbitmq.GenerateDefaultUser(instance)
+			generated, genErr := rabbitmq.GenerateDefaultUser(instance, configVersion)
 			if genErr != nil {
 				return fmt.Errorf("failed to generate default user: %w", genErr)
 			}
@@ -1355,7 +1356,10 @@ func (r *Reconciler) ensureDefaultUser(
 		if _, ok := secret.Data["default_user.conf"]; !ok {
 			username := string(secret.Data["username"])
 			password := string(secret.Data["password"])
-			defaultUserConf := fmt.Sprintf("default_user = %s\ndefault_pass = %s\ndefault_user_tags.administrator = true\n", username, password)
+			defaultUserConf := fmt.Sprintf("default_user = %s\ndefault_pass = %s\n", username, password)
+			if !rabbitmq.IsVersion4OrLater(configVersion) {
+				defaultUserConf += "default_user_tags.administrator = true\n"
+			}
 			secret.Data["default_user.conf"] = []byte(defaultUserConf)
 		}
 

--- a/internal/rabbitmq/secret.go
+++ b/internal/rabbitmq/secret.go
@@ -37,7 +37,8 @@ func GenerateErlangCookie(r *rabbitmqv1.RabbitMq) (*corev1.Secret, error) {
 // GenerateDefaultUser generates a secret containing default user credentials.
 // The secret includes username, password, default_user.conf (for RabbitMQ config),
 // host (service DNS name), and port (AMQP or AMQPS based on TLS).
-func GenerateDefaultUser(r *rabbitmqv1.RabbitMq) (*corev1.Secret, error) {
+// configVersion is the effective RabbitMQ version used to determine config format.
+func GenerateDefaultUser(r *rabbitmqv1.RabbitMq, configVersion string) (*corev1.Secret, error) {
 	username := fmt.Sprintf("default_user_%s", r.Name)
 	password, err := util.GeneratePassword(24)
 	if err != nil {
@@ -45,10 +46,13 @@ func GenerateDefaultUser(r *rabbitmqv1.RabbitMq) (*corev1.Secret, error) {
 	}
 
 	// Generate default_user.conf content
-	defaultUserConf := fmt.Sprintf(`default_user = %s
-default_pass = %s
-default_user_tags.administrator = true
-`, username, password)
+	defaultUserConf := fmt.Sprintf("default_user = %s\ndefault_pass = %s\n", username, password)
+	// default_user_tags.administrator breaks rabbitmqadmin on RabbitMQ 4.x
+	// (the sed that builds .rabbitmqadmin.conf transforms it into an
+	// unrecognised key). Only include it for RabbitMQ 3.x.
+	if !IsVersion4OrLater(configVersion) {
+		defaultUserConf += "default_user_tags.administrator = true\n"
+	}
 
 	// Determine host and port
 	host := fmt.Sprintf("%s.%s.svc", r.Name, r.Namespace)

--- a/internal/rabbitmq/statefulset.go
+++ b/internal/rabbitmq/statefulset.go
@@ -422,7 +422,7 @@ cp /tmp/erlang-cookie-secret/.erlang.cookie /var/lib/rabbitmq/.erlang.cookie
 chmod 600 /var/lib/rabbitmq/.erlang.cookie
 cp /tmp/rabbitmq-plugins/enabled_plugins /operator/enabled_plugins
 echo '[default]' > /var/lib/rabbitmq/.rabbitmqadmin.conf
-sed -e 's/default_user/username/' -e 's/default_pass/password/' /tmp/default_user.conf >> /var/lib/rabbitmq/.rabbitmqadmin.conf
+sed -e 's/^default_user = /username = /' -e 's/^default_pass = /password = /' /tmp/default_user.conf >> /var/lib/rabbitmq/.rabbitmqadmin.conf
 chmod 600 /var/lib/rabbitmq/.rabbitmqadmin.conf
 # Allow time for multi-pod clusters to complete peer discovery
 sleep %d`, ptr.Deref(r.Spec.DelayStartSeconds, 30)),


### PR DESCRIPTION
Only include default_user_tags.administrator=true in default_user.conf for RabbitMQ 3.x. On 4.x the sed that builds .rabbitmqadmin.conf transformed it into the unrecognised key username_tags.administrator, causing rabbitmqadmin to crash with an AttributeError.

Also fix the sed patterns to anchor on the full key assignment (s/^default_user = /username = /) so other keys sharing the default_user prefix are never corrupted.