### PR TITLE
Add SKIP_SERVERS_WITH_NAME config to exclude VMs from evacuation

### DIFF
--- a/templates/instanceha/bin/instanceha.py
+++ b/templates/instanceha/bin/instanceha.py
@@ -476,6 +476,19 @@ class ConfigManager:
         logging.warning(f"Configuration {key} should be boolean, got {type(value).__name__}, using default: {default}")
         return default
 
+    def get_list(self, key: str, default: Optional[List] = None) -> List:
+        """Get a list configuration value with validation."""
+        if default is None:
+            default = []
+        value = self.config.get(key, default)
+        if isinstance(value, list):
+            return value
+        if isinstance(value, str):
+            return [v.strip() for v in value.split(',') if v.strip()]
+        logging.warning("Configuration key %s should be list, got %s, using default: %s",
+                       key, type(value).__name__, default)
+        return default
+
     # Configuration mapping with defaults and validation
     _config_map: Dict[str, ConfigItem] = {
         'EVACUABLE_TAG': ConfigItem('str', 'evacuable'),
@@ -499,9 +512,10 @@ class ConfigManager:
         'SSL_VERIFY': ConfigItem('bool', True),
         'FENCING_TIMEOUT': ConfigItem('int', 30, 5, 120),
         'HASH_INTERVAL': ConfigItem('int', 60, 30, 300),
+        'SKIP_SERVERS_WITH_NAME': ConfigItem('list', []),
     }
 
-    def get_config_value(self, key: str) -> Union[str, int, bool]:
+    def get_config_value(self, key: str) -> Union[str, int, bool, List]:
         """Get configuration value with automatic type handling and validation."""
         if key not in self._config_map:
             raise ValueError(f"Unknown configuration key: {key}")
@@ -520,6 +534,8 @@ class ConfigManager:
             return self.get_int(key, config_item.default, config_item.min_val, config_item.max_val)
         elif config_item.type == 'bool':
             return self.get_bool(key, config_item.default)
+        elif config_item.type == 'list':
+            return self.get_list(key, config_item.default)
 
         return config_item.default
 
@@ -1306,6 +1322,13 @@ def _update_service_disable_reason(connection, host, service_id=None) -> None:
         return False
 
 
+def _should_skip_server(server, skip_names) -> bool:
+    """Check if a server should be skipped based on name matching."""
+    if not skip_names or not hasattr(server, 'name') or not server.name:
+        return False
+    return any(pattern in server.name for pattern in skip_names)
+
+
 def _get_evacuable_servers(connection, host, service) -> List:
     """Get list of evacuable servers from a host."""
     images = service.get_evacuable_images(connection)
@@ -1313,6 +1336,15 @@ def _get_evacuable_servers(connection, host, service) -> List:
 
     servers = connection.servers.list(search_opts={'host': host, 'all_tenants': 1})
     servers = [s for s in servers if s.status in {'ACTIVE', 'ERROR', 'STOPPED'}]
+
+    skip_names = service.config.get_config_value('SKIP_SERVERS_WITH_NAME')
+    if skip_names:
+        skipped = [s for s in servers if _should_skip_server(s, skip_names)]
+        if skipped:
+            logging.info("Skipping %d server(s) matching name filter %s: %s",
+                        len(skipped), skip_names,
+                        ', '.join(s.id for s in skipped))
+        servers = [s for s in servers if not _should_skip_server(s, skip_names)]
 
     if flavors or images:
         logging.debug("Filtering images and flavors: %s %s", repr(flavors), repr(images))

--- a/test/instanceha/test_unit_core.py
+++ b/test/instanceha/test_unit_core.py
@@ -229,6 +229,55 @@ class TestConfigManager(unittest.TestCase):
         self.assertEqual(config_manager.get_config_value('DELTA'), 60)
         self.assertTrue(config_manager.get_config_value('SMART_EVACUATION'))
 
+    def test_get_list_from_yaml_list(self):
+        """Test list config value from YAML list."""
+        config_data = {
+            'config': {
+                'SKIP_SERVERS_WITH_NAME': ['amphora-', 'test-lb'],
+            }
+        }
+        with open(self.config_path, 'w') as f:
+            yaml.dump(config_data, f)
+
+        config_manager = instanceha.ConfigManager(self.config_path)
+        config_manager.clouds_path = self.clouds_path
+        config_manager.secure_path = self.secure_path
+        config_manager.fencing_path = self.fencing_path
+        config_manager.__init__(self.config_path)
+
+        result = config_manager.get_config_value('SKIP_SERVERS_WITH_NAME')
+        self.assertEqual(result, ['amphora-', 'test-lb'])
+
+    def test_get_list_from_comma_string(self):
+        """Test list config value from comma-separated string."""
+        config_data = {
+            'config': {
+                'SKIP_SERVERS_WITH_NAME': 'amphora-, test-lb',
+            }
+        }
+        with open(self.config_path, 'w') as f:
+            yaml.dump(config_data, f)
+
+        config_manager = instanceha.ConfigManager(self.config_path)
+        config_manager.clouds_path = self.clouds_path
+        config_manager.secure_path = self.secure_path
+        config_manager.fencing_path = self.fencing_path
+        config_manager.__init__(self.config_path)
+
+        result = config_manager.get_config_value('SKIP_SERVERS_WITH_NAME')
+        self.assertEqual(result, ['amphora-', 'test-lb'])
+
+    def test_get_list_default_empty(self):
+        """Test list config value defaults to empty list."""
+        config_manager = instanceha.ConfigManager(self.config_path)
+        config_manager.clouds_path = self.clouds_path
+        config_manager.secure_path = self.secure_path
+        config_manager.fencing_path = self.fencing_path
+        config_manager.__init__(self.config_path)
+
+        result = config_manager.get_config_value('SKIP_SERVERS_WITH_NAME')
+        self.assertEqual(result, [])
+
 
 class TestMetrics(unittest.TestCase):
     """Test the Metrics class functionality."""
@@ -892,6 +941,9 @@ class TestEvacuationFunctions(unittest.TestCase):
         mock_service.config.get_workers.return_value = 4
         mock_service.config.get_delay.return_value = 0
         mock_service.is_server_evacuable.return_value = True
+        mock_service.config.get_config_value.side_effect = lambda key: {
+            'SKIP_SERVERS_WITH_NAME': [], 'SMART_EVACUATION': True, 'WORKERS': 4, 'DELAY': 0,
+        }.get(key, False)
 
         # Mock servers
         mock_server1 = Mock()
@@ -945,6 +997,9 @@ class TestEvacuationFunctions(unittest.TestCase):
         mock_service.config.get_workers.return_value = 4
         mock_service.config.get_delay.return_value = 0
         mock_service.is_server_evacuable.return_value = True
+        mock_service.config.get_config_value.side_effect = lambda key: {
+            'SKIP_SERVERS_WITH_NAME': [], 'SMART_EVACUATION': True, 'WORKERS': 4, 'DELAY': 0,
+        }.get(key, False)
 
         # Mock servers
         mock_server1 = Mock()
@@ -1005,6 +1060,9 @@ class TestEvacuationFunctions(unittest.TestCase):
         mock_service.config.get_workers.return_value = 4
         mock_service.config.get_delay.return_value = 0
         mock_service.is_server_evacuable.return_value = True
+        mock_service.config.get_config_value.side_effect = lambda key: {
+            'SKIP_SERVERS_WITH_NAME': [], 'SMART_EVACUATION': True, 'WORKERS': 4, 'DELAY': 0,
+        }.get(key, False)
 
         # Mock servers
         mock_server1 = Mock()
@@ -1203,6 +1261,89 @@ class TestEvacuationFunctions(unittest.TestCase):
 
                     # Assert ThreadPoolExecutor was called with the expected max_workers
                     mock_executor_class.assert_called_once_with(max_workers=workers_value)
+
+
+class TestSkipServersByName(unittest.TestCase):
+    """Test name-based server skip filtering."""
+
+    def test_should_skip_server_matching_pattern(self):
+        server = Mock()
+        server.name = 'amphora-abc123'
+        self.assertTrue(instanceha._should_skip_server(server, ['amphora-']))
+
+    def test_should_skip_server_substring_match(self):
+        server = Mock()
+        server.name = 'my-amphora-vm-01'
+        self.assertTrue(instanceha._should_skip_server(server, ['amphora']))
+
+    def test_should_skip_server_no_match(self):
+        server = Mock()
+        server.name = 'my-web-server'
+        self.assertFalse(instanceha._should_skip_server(server, ['amphora-']))
+
+    def test_should_skip_server_multiple_patterns(self):
+        server = Mock()
+        server.name = 'test-lb-vm'
+        self.assertTrue(instanceha._should_skip_server(server, ['amphora-', 'test-lb']))
+
+    def test_should_skip_server_empty_patterns(self):
+        server = Mock()
+        server.name = 'amphora-abc123'
+        self.assertFalse(instanceha._should_skip_server(server, []))
+
+    def test_should_skip_server_no_name(self):
+        server = Mock()
+        server.name = None
+        self.assertFalse(instanceha._should_skip_server(server, ['amphora-']))
+
+    def test_get_evacuable_servers_skips_matching_names(self):
+        mock_conn = Mock()
+        mock_service = Mock()
+
+        active_server = Mock()
+        active_server.status = 'ACTIVE'
+        active_server.name = 'my-web-server'
+        active_server.id = 'server-1'
+
+        amphora_server = Mock()
+        amphora_server.status = 'ACTIVE'
+        amphora_server.name = 'amphora-abc123'
+        amphora_server.id = 'server-2'
+
+        mock_conn.servers.list.return_value = [active_server, amphora_server]
+        mock_service.get_evacuable_images.return_value = []
+        mock_service.get_evacuable_flavors.return_value = []
+        mock_service.config.get_config_value.side_effect = lambda key: {
+            'SKIP_SERVERS_WITH_NAME': ['amphora-'],
+        }.get(key, False)
+
+        result = instanceha._get_evacuable_servers(mock_conn, 'test-host', mock_service)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].name, 'my-web-server')
+
+    def test_get_evacuable_servers_no_skip_when_empty(self):
+        mock_conn = Mock()
+        mock_service = Mock()
+
+        server1 = Mock()
+        server1.status = 'ACTIVE'
+        server1.name = 'amphora-abc123'
+        server1.id = 'server-1'
+
+        server2 = Mock()
+        server2.status = 'ACTIVE'
+        server2.name = 'my-web-server'
+        server2.id = 'server-2'
+
+        mock_conn.servers.list.return_value = [server1, server2]
+        mock_service.get_evacuable_images.return_value = []
+        mock_service.get_evacuable_flavors.return_value = []
+        mock_service.config.get_config_value.side_effect = lambda key: {
+            'SKIP_SERVERS_WITH_NAME': [],
+        }.get(key, False)
+
+        result = instanceha._get_evacuable_servers(mock_conn, 'test-host', mock_service)
+        self.assertEqual(len(result), 2)
 
 
 class TestSecretExposure(unittest.TestCase):


### PR DESCRIPTION
Allow users to specify a list of name patterns (substrings) to skip during evacuation. Servers whose name contains any of the configured patterns will be excluded. This is useful for skipping Octavia amphora VMs or other infrastructure instances that should not be evacuated.

The option accepts a comma-separated string in the ConfigMap:
  SKIP_SERVERS_WITH_NAME: "amphora-,octavia-lb"