### PR TITLE
[b/r][rabbitmq] Move RabbitMQVhost restore-order from 40 to 30

### DIFF
--- a/apis/bases/rabbitmq.openstack.org_rabbitmqvhosts.yaml
+++ b/apis/bases/rabbitmq.openstack.org_rabbitmqvhosts.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     backup.openstack.org/category: controlplane
     backup.openstack.org/restore: "true"
-    backup.openstack.org/restore-order: "40"
+    backup.openstack.org/restore-order: "30"
   name: rabbitmqvhosts.rabbitmq.openstack.org
 spec:
   group: rabbitmq.openstack.org

--- a/apis/rabbitmq/v1beta1/rabbitmqvhost_types.go
+++ b/apis/rabbitmq/v1beta1/rabbitmqvhost_types.go
@@ -52,7 +52,7 @@ type RabbitMQVhostStatus struct {
 //+kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[0].message"
 //+kubebuilder:metadata:labels=backup.openstack.org/restore=true
 //+kubebuilder:metadata:labels=backup.openstack.org/category=controlplane
-//+kubebuilder:metadata:labels=backup.openstack.org/restore-order=40
+//+kubebuilder:metadata:labels=backup.openstack.org/restore-order=30
 
 // RabbitMQVhost is the Schema for the rabbitmqvhosts API
 type RabbitMQVhost struct {

--- a/config/crd/bases/rabbitmq.openstack.org_rabbitmqvhosts.yaml
+++ b/config/crd/bases/rabbitmq.openstack.org_rabbitmqvhosts.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     backup.openstack.org/category: controlplane
     backup.openstack.org/restore: "true"
-    backup.openstack.org/restore-order: "40"
+    backup.openstack.org/restore-order: "30"
   name: rabbitmqvhosts.rabbitmq.openstack.org
 spec:
   group: rabbitmq.openstack.org


### PR DESCRIPTION
RabbitMQVhost and RabbitMQUser both had restore-order=40, causing Velero to restore them in the same step. Since Velero processes resources alphabetically, users were restored before vhosts, and the RabbitMQUser validating webhook rejected every user because the referenced vhost did not exist yet.

Moving RabbitMQVhost to restore-order=30 ensures vhosts are restored alongside the OpenStackControlPlane. The vhost webhook does not validate cluster existence, so the CR is accepted and the controller retries until the cluster is ready. By the time restore-order=40 runs, all vhosts exist and user validation succeeds.

Closes: [OSPRH-29606](https://redhat.atlassian.net/browse/OSPRH-29606)
Jira: [OSPRH-29646](https://redhat.atlassian.net/browse/OSPRH-29646)