### PR TITLE
Use hash-based naming for canonical RabbitMQ user/vhost CRs

### DIFF
--- a/apis/rabbitmq/v1beta1/canonical_names_test.go
+++ b/apis/rabbitmq/v1beta1/canonical_names_test.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCanonicalUserName(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterName string
+		vhostName   string
+		username    string
+	}{
+		{
+			name:        "short names",
+			clusterName: "rabbitmq",
+			vhostName:   "/",
+			username:    "nova",
+		},
+		{
+			name:        "with custom vhost",
+			clusterName: "rabbitmq",
+			vhostName:   "testvhost",
+			username:    "nova-user",
+		},
+		{
+			name:        "long names that broke with old convention",
+			clusterName: "rabbitmq-notifications",
+			vhostName:   "watcher-notifications",
+			username:    "watcher-notifications",
+		},
+		{
+			name:        "very long names",
+			clusterName: strings.Repeat("cluster", 5),
+			vhostName:   strings.Repeat("vhost", 5),
+			username:    "a-reasonable-username",
+		},
+		{
+			name:        "empty vhost treated as default",
+			clusterName: "rabbitmq",
+			vhostName:   "",
+			username:    "testuser",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CanonicalUserName(tt.clusterName, tt.vhostName, tt.username)
+
+			if len(got) > 63 {
+				t.Errorf("canonical user name %q is %d chars, exceeds 63-char label limit", got, len(got))
+			}
+
+			if !strings.HasPrefix(got, tt.username+"-") {
+				t.Errorf("canonical user name %q does not start with username prefix %q", got, tt.username+"-")
+			}
+
+			// Verify determinism
+			got2 := CanonicalUserName(tt.clusterName, tt.vhostName, tt.username)
+			if got != got2 {
+				t.Errorf("non-deterministic: got %q then %q", got, got2)
+			}
+		})
+	}
+}
+
+func TestCanonicalUserNameUniqueness(t *testing.T) {
+	// Same username on different clusters must produce different names
+	name1 := CanonicalUserName("rabbitmq", "/", "nova")
+	name2 := CanonicalUserName("rabbitmq-cell1", "/", "nova")
+	if name1 == name2 {
+		t.Errorf("same user on different clusters produced identical name: %q", name1)
+	}
+
+	// Same username on different vhosts must produce different names
+	name3 := CanonicalUserName("rabbitmq", "vhost-a", "nova")
+	name4 := CanonicalUserName("rabbitmq", "vhost-b", "nova")
+	if name3 == name4 {
+		t.Errorf("same user on different vhosts produced identical name: %q", name3)
+	}
+
+	// Different usernames on same cluster/vhost must produce different names
+	name5 := CanonicalUserName("rabbitmq", "/", "nova")
+	name6 := CanonicalUserName("rabbitmq", "/", "cinder")
+	if name5 == name6 {
+		t.Errorf("different users on same cluster produced identical name: %q", name5)
+	}
+}
+
+func TestCanonicalVhostName(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterName string
+		vhostName   string
+	}{
+		{
+			name:        "short names",
+			clusterName: "rabbitmq",
+			vhostName:   "testvhost",
+		},
+		{
+			name:        "long names that broke with old convention",
+			clusterName: "rabbitmq-notifications",
+			vhostName:   "watcher-notifications",
+		},
+		{
+			name:        "very long names",
+			clusterName: strings.Repeat("cluster", 5),
+			vhostName:   "a-reasonable-vhost",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CanonicalVhostName(tt.clusterName, tt.vhostName)
+
+			if len(got) > 63 {
+				t.Errorf("canonical vhost name %q is %d chars, exceeds 63-char label limit", got, len(got))
+			}
+
+			if !strings.HasPrefix(got, tt.vhostName+"-") {
+				t.Errorf("canonical vhost name %q does not start with vhost prefix %q", got, tt.vhostName+"-")
+			}
+
+			// Verify determinism
+			got2 := CanonicalVhostName(tt.clusterName, tt.vhostName)
+			if got != got2 {
+				t.Errorf("non-deterministic: got %q then %q", got, got2)
+			}
+		})
+	}
+}
+
+func TestCanonicalVhostNameUniqueness(t *testing.T) {
+	// Same vhost on different clusters must produce different names
+	name1 := CanonicalVhostName("rabbitmq", "testvhost")
+	name2 := CanonicalVhostName("rabbitmq-cell1", "testvhost")
+	if name1 == name2 {
+		t.Errorf("same vhost on different clusters produced identical name: %q", name1)
+	}
+}

--- a/apis/rabbitmq/v1beta1/rabbitmquser_types.go
+++ b/apis/rabbitmq/v1beta1/rabbitmquser_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"strings"
 
@@ -187,9 +188,10 @@ func IsInternalFinalizer(finalizer string) bool {
 }
 
 // CanonicalUserName returns the deterministic CR name for a shared user singleton.
+// The name is kept short by hashing the cluster+vhost context into 8 hex chars,
+// keeping the human-readable username as a prefix for kubectl readability.
+// Full cluster/vhost/username metadata is available in the CR spec.
 func CanonicalUserName(clusterName, vhostName, username string) string {
-	if vhostName == "/" || vhostName == "" {
-		return fmt.Sprintf("%s-user-%s", clusterName, username)
-	}
-	return fmt.Sprintf("%s-%s-user-%s", clusterName, vhostName, username)
+	hash := sha256.Sum256([]byte(clusterName + "/" + vhostName))
+	return fmt.Sprintf("%s-%x", username, hash[:4])
 }

--- a/apis/rabbitmq/v1beta1/rabbitmqvhost_types.go
+++ b/apis/rabbitmq/v1beta1/rabbitmqvhost_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"crypto/sha256"
 	"fmt"
 
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
@@ -116,6 +117,10 @@ const (
 )
 
 // CanonicalVhostName returns the deterministic CR name for a shared vhost singleton.
+// The name is kept short by hashing the cluster name into 8 hex chars,
+// keeping the human-readable vhost name as a prefix for kubectl readability.
+// Full cluster/vhost metadata is available in the CR spec.
 func CanonicalVhostName(clusterName, vhostName string) string {
-	return fmt.Sprintf("%s-vhost-%s", clusterName, vhostName)
+	hash := sha256.Sum256([]byte(clusterName))
+	return fmt.Sprintf("%s-%x", vhostName, hash[:4])
 }

--- a/test/functional/transporturl_controller_test.go
+++ b/test/functional/transporturl_controller_test.go
@@ -1966,4 +1966,72 @@ var _ = Describe("TransportURL controller", func() {
 			)
 		})
 	})
+
+	When("TransportURL is created with long cluster, user, and vhost names", func() {
+		var rabbitmqName types.NamespacedName
+		longVhost := "watcher-notifications"
+		longUsername := "watcher-notifications"
+
+		BeforeEach(func() {
+			rabbitmqName = types.NamespacedName{
+				Name:      "rabbitmq-notifications",
+				Namespace: namespace,
+			}
+
+			CreateRabbitMQCluster(rabbitmqName, GetDefaultRabbitMQClusterSpec(false))
+			DeferCleanup(DeleteRabbitMQCluster, rabbitmqName)
+
+			spec := GetDefaultRabbitMQSpec()
+			rabbitmq := CreateRabbitMQ(rabbitmqName, spec)
+			DeferCleanup(th.DeleteInstance, rabbitmq)
+
+			tuSpec := map[string]any{
+				"rabbitmqClusterName": rabbitmqName.Name,
+				"username":            longUsername,
+				"vhost":               longVhost,
+			}
+			DeferCleanup(th.DeleteInstance, CreateTransportURL(transportURLName, tuSpec))
+		})
+
+		It("should create user and vhost CRs with names under the 63-char label limit", func() {
+			SimulateRabbitMQClusterReady(rabbitmqName)
+
+			vhostCRName := types.NamespacedName{
+				Name:      rabbitmqv1.CanonicalVhostName(rabbitmqName.Name, longVhost),
+				Namespace: namespace,
+			}
+			Expect(len(vhostCRName.Name)).To(BeNumerically("<=", 63),
+				"Vhost CR name %q is %d chars, must be <= 63", vhostCRName.Name, len(vhostCRName.Name))
+
+			Eventually(func(g Gomega) {
+				vhost := &rabbitmqv1.RabbitMQVhost{}
+				g.Expect(k8sClient.Get(ctx, vhostCRName, vhost)).Should(Succeed())
+				g.Expect(vhost.Spec.Name).To(Equal(longVhost))
+				g.Expect(vhost.Spec.RabbitmqClusterName).To(Equal(rabbitmqName.Name))
+			}, timeout, interval).Should(Succeed())
+			SimulateRabbitMQVhostReady(vhostCRName)
+
+			userCRName := types.NamespacedName{
+				Name:      rabbitmqv1.CanonicalUserName(rabbitmqName.Name, longVhost, longUsername),
+				Namespace: namespace,
+			}
+			Expect(len(userCRName.Name)).To(BeNumerically("<=", 63),
+				"User CR name %q is %d chars, must be <= 63", userCRName.Name, len(userCRName.Name))
+
+			Eventually(func(g Gomega) {
+				user := &rabbitmqv1.RabbitMQUser{}
+				g.Expect(k8sClient.Get(ctx, userCRName, user)).Should(Succeed())
+				g.Expect(user.Spec.Username).To(Equal(longUsername))
+				g.Expect(user.Spec.RabbitmqClusterName).To(Equal(rabbitmqName.Name))
+			}, timeout, interval).Should(Succeed())
+			SimulateRabbitMQUserReady(userCRName, longVhost)
+
+			th.ExpectCondition(
+				transportURLName,
+				ConditionGetterFunc(TransportURLConditionGetter),
+				rabbitmqv1.TransportURLReadyCondition,
+				corev1.ConditionTrue,
+			)
+		})
+	})
 })

--- a/test/kuttl/tests/rabbitmq-credential-rotation/01-assert.yaml
+++ b/test/kuttl/tests/rabbitmq-credential-rotation/01-assert.yaml
@@ -25,13 +25,13 @@ commands:
       echo "PASS: Transport URL contains nova username"
   - script: |
       set -e
-      # Verify the RabbitMQUser was created (canonical naming: <cluster>-user-<username>)
-      READY=$(oc get rabbitmquser -n $NAMESPACE rabbitmq-cred-rot-user-nova -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+      # Verify the RabbitMQUser was created (canonical naming: <username>-<sha8>)
+      READY=$(oc get rabbitmquser -n $NAMESPACE nova-b562b443 -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
       if [ "$READY" != "True" ]; then
         echo "FAIL: RabbitMQUser not ready"
         exit 1
       fi
-      USERNAME=$(oc get rabbitmquser -n $NAMESPACE rabbitmq-cred-rot-user-nova -o jsonpath='{.status.username}')
+      USERNAME=$(oc get rabbitmquser -n $NAMESPACE nova-b562b443 -o jsonpath='{.status.username}')
       if [ "$USERNAME" != "nova" ]; then
         echo "FAIL: Expected username 'nova', got: '$USERNAME'"
         exit 1

--- a/test/kuttl/tests/rabbitmq-credential-rotation/02-assert.yaml
+++ b/test/kuttl/tests/rabbitmq-credential-rotation/02-assert.yaml
@@ -43,12 +43,12 @@ commands:
   - script: |
       set -e
       # Old user CR should be auto-deleted (no NodeSets means credentials are safe to remove)
-      if oc get rabbitmquser -n $NAMESPACE rabbitmq-cred-rot-user-nova 2>/dev/null; then
-        echo "FAIL: Old user CR rabbitmq-cred-rot-user-nova still exists"
-        oc get rabbitmquser -n $NAMESPACE rabbitmq-cred-rot-user-nova -o yaml
+      if oc get rabbitmquser -n $NAMESPACE nova-b562b443 2>/dev/null; then
+        echo "FAIL: Old user CR nova-b562b443 still exists"
+        oc get rabbitmquser -n $NAMESPACE nova-b562b443 -o yaml
         exit 1
       fi
-      echo "PASS: Old user CR rabbitmq-cred-rot-user-nova auto-deleted"
+      echo "PASS: Old user CR nova-b562b443 auto-deleted"
   - script: |
       set -e
       # Verify old user was deleted from RabbitMQ

--- a/test/kuttl/tests/rabbitmq-credential-rotation/03-cleanup.yaml
+++ b/test/kuttl/tests/rabbitmq-credential-rotation/03-cleanup.yaml
@@ -6,8 +6,8 @@ commands:
     oc delete rabbitmquser -n $NAMESPACE -l app.kubernetes.io/managed-by=transporturl --ignore-not-found
     oc delete rabbitmqvhost -n $NAMESPACE -l app.kubernetes.io/managed-by=transporturl --ignore-not-found
     # Clean up canonical CRs created by the shared singleton model
-    oc delete rabbitmquser rabbitmq-cred-rot-user-nova -n $NAMESPACE --ignore-not-found
-    oc delete rabbitmquser rabbitmq-cred-rot-user-glance -n $NAMESPACE --ignore-not-found
+    oc delete rabbitmquser nova-b562b443 -n $NAMESPACE --ignore-not-found
+    oc delete rabbitmquser glance-b562b443 -n $NAMESPACE --ignore-not-found
     oc delete rabbitmq.rabbitmq.openstack.org rabbitmq-cred-rot -n $NAMESPACE --ignore-not-found
     oc delete pvc -n $NAMESPACE -l app.kubernetes.io/name=rabbitmq-cred-rot --ignore-not-found
     # Clean up Released PVs to avoid stale data on re-runs


### PR DESCRIPTION
The old naming convention (<cluster>-<vhost>-user-<username>) could exceed the 63-char Kubernetes label limit with long component names (e.g. rabbitmq-notifications + watcher-notifications = 71 chars).

Switch to <username>-<sha8(cluster+vhost)> for users and <vhostname>-<sha8(cluster)> for vhosts. The human-readable part comes first for kubectl readability; the SHA256 hash disambiguates the cluster/vhost combination. Full metadata remains in the CR spec/status.