### PR TITLE
Fix InstanceHA documentation inaccuracies and add MetalLB guide

### DIFF
--- a/config/samples/instanceha_v1beta1_instanceha.yaml
+++ b/config/samples/instanceha_v1beta1_instanceha.yaml
@@ -13,3 +13,4 @@ spec:
   #fencingSecret:
   #instanceHaConfigMap:
   #instanceHaKdumpPort:
+  #instanceHaHeartbeatPort:

--- a/docs/instanceha_architecture.md
+++ b/docs/instanceha_architecture.md
@@ -5,8 +5,6 @@
 InstanceHA is a high-availability service for OpenStack that automatically detects and evacuates instances from failed compute nodes.
 
 **Version**: 2.5
-**Code Size**: 3,645 lines
-**Test Suite**: 656 tests across 17 test suites
 
 ## Table of Contents
 
@@ -134,7 +132,7 @@ _config_map: Dict[str, ConfigItem] = {
     'HASH_INTERVAL': ConfigItem('int', 60, 30, 300),
     'ORCHESTRATED_RESTART': ConfigItem('bool', False),
     'SKIP_SERVERS_WITH_NAME': ConfigItem('list', []),
-    'EVACUATION_RETRIES': ConfigItem('int', 5, 1, 20),
+    'EVACUATION_RETRIES': ConfigItem('int', DEFAULT_EVACUATION_RETRIES, 1, 20),  # DEFAULT_EVACUATION_RETRIES = 5
 }
 ```
 
@@ -297,16 +295,22 @@ def track_host_processing(service: 'InstanceHAService', hostname: str):
 **UDP Socket Management**:
 ```python
 class UDPSocketManager:
-    """Context manager for UDP socket with proper resource cleanup."""
+    """Context manager for UDP socket with proper resource cleanup.
+    Supports IPv4, IPv6, and dual-stack (::) binding."""
     def __init__(self, udp_ip, udp_port, label='UDP'):
         self.udp_ip = udp_ip
         self.udp_port = udp_port
         self.label = label
+        self.socket = None
 
     def __enter__(self):
-        self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        info = socket.getaddrinfo(self.udp_ip or '::', self.udp_port,
+                                  type=socket.SOCK_DGRAM)[0]
+        self.socket = socket.socket(info[0], info[1])
+        if info[0] == socket.AF_INET6:
+            self.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
         self.socket.settimeout(1.0)
-        self.socket.bind((self.udp_ip, self.udp_port))
+        self.socket.bind(info[4])
         return self.socket
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -539,12 +543,12 @@ process_service(failed_service, reserved_hosts, resume, service)
     │             Called for kdump-fenced (not yet disabled)
     │
     ├─ 3. Manage Reserved Hosts
-    │   └─ _manage_reserved_hosts(conn, failed_service, reserved_hosts)
+    │   └─ _manage_reserved_hosts(conn, failed_service, reserved_hosts, service)
     │       ├─ Match by aggregate or zone
     │       └─ Enable matching reserved host
     │
     ├─ 4. Evacuate Servers
-    │   └─ _host_evacuate(connection, failed_service, service)
+    │   └─ _host_evacuate(connection, failed_service, service, target_host=None)
     │       ├─ Get evacuable images/flavors
     │       ├─ List servers on host
     │       ├─ Filter evacuable servers (ACTIVE, ERROR, SHUTOFF)
@@ -1082,7 +1086,7 @@ In addition, each event emission site also increments a corresponding Prometheus
 - `POD_NAMESPACE` environment variable set
 - `INSTANCEHA_CR_NAME` environment variable set to the InstanceHa CR name
 - `POD_NAME` environment variable set (used as `reportingInstance`)
-- RBAC: the operator ClusterRole must have `create` and `patch` permissions on `events`
+- RBAC: the pod's namespaced Role must have `create` and `patch` permissions on `events`
 
 ### Event Catalog
 
@@ -1649,6 +1653,12 @@ This ensures orphaned hosts are not left powered off indefinitely after a pod cr
 
 Emits `OrphanedHostRecovered` (Warning) for each recovered host.
 
+### Known Limitations
+
+**Lock reconciliation scope**: The VM unlock sweep at startup only checks servers on hosts that are `forced_down AND state='down'`. This covers the realistic crash scenario (pod dies mid-evacuation while the host is still fenced). However, if the pod crashes after evacuation succeeds and post-recovery clears `forced_down`, but before the `finally` block unlocks the VMs, the locked VMs on their new (healthy) hosts would not be found by the reconciliation. This window is extremely narrow — the `finally` block in `_server_evacuate_future` runs per-server immediately after each evacuation completes, so the crash would need to occur between the evacuation completing and the `finally` executing. In practice, a SIGKILL (OOM, node crash) during concurrent evacuation would leave VMs on hosts that are still `forced_down`, which the current reconciliation handles correctly.
+
+A broader scan (checking all servers with `locked_reason == LOCK_REASON_EVACUATION` regardless of host state) would close this theoretical gap but requires listing all servers in the cloud at startup, which may be expensive on large deployments.
+
 ---
 
 ## Graceful Shutdown
@@ -1826,10 +1836,6 @@ with concurrent.futures.ThreadPoolExecutor(max_workers=WORKERS) as executor:
 
 ## Testing
 
-### Test Statistics
-
-- **Total Tests**: 656 across 17 test suites
-
 ### Test Categories
 
 **1. Core Unit Tests** (`test_unit_core.py`):
@@ -1938,6 +1944,17 @@ Core unit tests covering:
 - Branching logic: `_host_evacuate` orchestrated/smart/traditional routing
 - Configuration: `ORCHESTRATED_RESTART` config key validation
 
+**18. Aggregate Threshold Tests** (`test_aggregate_threshold.py`):
+- Per-aggregate failure limit enforcement via `instanceha:max_failures` metadata
+- Multi-aggregate host membership and most-restrictive-limit selection
+- Interaction with global THRESHOLD percentage check
+
+**19. IPv6 UDP Tests** (`test_ipv6_udp.py`):
+- UDPSocketManager binding to IPv6 loopback, wildcard, and IPv4 addresses
+- Heartbeat reception over IPv6 (single, multiple, native byte order)
+- Kdump reception over IPv6 (single, multiple, invalid magic rejection)
+- Dual-stack (`::`) listener accepting both IPv4 and IPv6 packets
+
 ### Coverage by Component
 
 | Component | Coverage |
@@ -1978,24 +1995,75 @@ with patch('instanceha.time.sleep'):
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: instanceha
+  name: instanceha          # matches the InstanceHa CR .metadata.name
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   template:
     spec:
+      serviceAccountName: instanceha-instanceha
+      securityContext:
+        fsGroup: 42401
+      terminationGracePeriodSeconds: 30
       containers:
       - name: instanceha
-        image: quay.io/openstack-k8s-operators/instanceha:latest
+        image: <resolved from infra-instanceha-config ConfigMap or RELATED_IMAGE env var>
+        command: ["/usr/bin/python3", "-u", "/var/lib/instanceha/instanceha.py"]
+        securityContext:
+          runAsUser: 42401
+          runAsGroup: 42401
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
         env:
         - name: OS_CLOUD
-          value: overcloud
+          value: default                # from spec.openStackCloud
+        - name: CONFIG_HASH
+          value: <hash of all input configmaps/secrets>
+        - name: INSTANCEHA_DISABLED
+          value: "False"                # from spec.disabled
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCEHA_CR_NAME
+          value: instanceha             # the CR name
+        - name: HEARTBEAT_PORT          # only set when > 0
+          value: "7411"
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+          name: metrics
+        - containerPort: 7410
+          protocol: UDP
+          name: kdump
+        - containerPort: 7411
+          protocol: UDP
+          name: heartbeat
         volumeMounts:
-        - name: config
-          mountPath: /var/lib/instanceha
-        - name: clouds
-          mountPath: /home/cloud-admin/.config/openstack
-        - name: fencing
-          mountPath: /secrets
+        - name: openstack-config
+          mountPath: /home/cloud-admin/.config/openstack/clouds.yaml
+          subPath: clouds.yaml
+        - name: openstack-config-secret
+          mountPath: /home/cloud-admin/.config/openstack/secure.yaml
+          subPath: secure.yaml
+        - name: fencing-secret
+          mountPath: /secrets/fencing.yaml
+          subPath: fencing.yaml
+        - name: instanceha-script
+          mountPath: /var/lib/instanceha/instanceha.py
+          subPath: instanceha.py
+          readOnly: true
+        - name: instanceha-config
+          mountPath: /var/lib/instanceha/config.yaml
+          subPath: config.yaml
+          readOnly: true
         livenessProbe:
           httpGet:
             path: /
@@ -2011,15 +2079,24 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 10
       volumes:
-      - name: config
+      - name: openstack-config
         configMap:
-          name: instanceha-config
-      - name: clouds
+          name: openstack-config          # from spec.openStackConfigMap
+      - name: openstack-config-secret
         secret:
-          secretName: clouds-yaml
-      - name: fencing
+          secretName: openstack-config-secret  # from spec.openStackConfigSecret
+          defaultMode: 0440
+      - name: fencing-secret
         secret:
-          secretName: fencing-credentials
+          secretName: fencing-secret       # from spec.fencingSecret
+          defaultMode: 0440
+      - name: instanceha-script
+        configMap:
+          name: instanceha-sh              # auto-generated: <cr-name>-sh
+          defaultMode: 0644
+      - name: instanceha-config
+        configMap:
+          name: instanceha-config          # from spec.instanceHaConfigMap
 ```
 
 ---
@@ -2148,8 +2225,8 @@ config:
 ```
 
 **Notes**:
-- Value of `0` disables threshold checking
-- Value of `100` blocks all evacuations
+- Value of `0` blocks all evacuations (any failure percentage exceeds 0%)
+- Value of `100` disables threshold checking (nothing can exceed 100%)
 - Aggregate-aware calculation uses only evacuable hosts as denominator
 
 ---
@@ -3004,8 +3081,8 @@ config:
 
 ## References
 
-- **Code**: `instanceha.py` (3,572 lines)
-- **Tests**: 656 tests across 17 test suites
+- **Code**: `instanceha.py`
+- **Tests**:
   - `test_unit_core.py` (core unit tests)
   - `test_fencing_agents.py` (fencing agent tests)
   - `test_kdump_detection.py` (kdump detection tests)
@@ -3023,6 +3100,8 @@ config:
   - `test_orchestrated_evacuation.py` (orchestrated evacuation tests)
   - `test_heartbeat_detection.py` (heartbeat detection tests)
   - `test_heartbeat_scale.py` (heartbeat scale tests)
+  - `test_aggregate_threshold.py` (per-aggregate failure threshold tests)
+  - `test_ipv6_udp.py` (IPv6 UDP listener tests)
 - **Documentation**:
   - This file (instanceha_architecture.md)
   - [instanceha_guide.md](instanceha_guide.md) — Operator deployment and configuration guide

--- a/docs/instanceha_guide.md
+++ b/docs/instanceha_guide.md
@@ -250,7 +250,7 @@ spec:
   # UDP port for kdump messages (default: 7410)
   instanceHaKdumpPort: 7410
 
-  # UDP port for heartbeat messages (default: 7411, set 0 to disable)
+  # UDP port for heartbeat messages (default: 7411)
   instanceHaHeartbeatPort: 7411
 
   # Optional: Application Credential authentication (see Authentication section)
@@ -274,7 +274,7 @@ spec:
 
 ### Network Attachments
 
-The `networkAttachments` field lists Multus NetworkAttachmentDefinition CRs to attach to the InstanceHA pod. Each entry adds an additional network interface. The UDP listeners (kdump and heartbeat) bind to `0.0.0.0`, so they accept packets on any attached interface.
+The `networkAttachments` field lists Multus NetworkAttachmentDefinition CRs to attach to the InstanceHA pod. Each entry adds an additional network interface. The UDP listeners (kdump and heartbeat) bind to `::` (dual-stack), so they accept both IPv4 and IPv6 packets on any attached interface.
 
 A common pattern is to separate heartbeat traffic from the API network. Heartbeat packets are small and frequent — putting them on the same network as the Nova API can add noise, and a congested API network could delay heartbeats enough to trigger false positives. Using a dedicated network for heartbeat avoids both problems:
 
@@ -312,6 +312,43 @@ spec:
 Compute nodes then send their heartbeat packets to the InstanceHA pod's IP on the `heartbeat-net` network (e.g., `172.20.0.x:7411`), while the Nova API traffic flows through `internalapi` as usual.
 
 When only a single `networkAttachments` entry is provided (the typical case), all traffic — Nova API, kdump, and heartbeat — shares that interface.
+
+### Stable IP for UDP Listeners
+
+By default, the InstanceHA pod receives a dynamic IP from the Multus IPAM pool. If the pod restarts, it may get a different IP, and compute nodes sending kdump or heartbeat packets to the old address will fail until reconfigured.
+
+To provide a stable IP that survives pod restarts, create a MetalLB-backed LoadBalancer Service that fronts the InstanceHA UDP ports. Compute nodes send packets to the Service's external IP, and MetalLB routes them to the pod regardless of its current address.
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: instanceha-udp
+  namespace: openstack
+  annotations:
+    metallb.universe.tf/address-pool: internalapi
+    metallb.universe.tf/allow-shared-ip: internalapi
+    metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+spec:
+  type: LoadBalancer
+  selector:
+    service: instanceha
+  ports:
+  - name: kdump
+    port: 7410
+    targetPort: 7410
+    protocol: UDP
+  - name: heartbeat
+    port: 7411
+    targetPort: 7411
+    protocol: UDP
+```
+
+Replace `172.17.0.80` with an IP from your `internalapi` MetalLB address pool. The `allow-shared-ip` annotation lets this Service share the same IP with other OpenStack services (e.g., keystone, nova, cinder) that already use the `internalapi` pool — since the InstanceHA ports (7410/UDP, 7411/UDP) don't conflict with any existing service ports, sharing is safe and avoids consuming an additional IP. If you prefer a dedicated IP, pick an unused address and remove the `allow-shared-ip` annotation.
+
+> **Note:** The `address-pool` value must match the actual MetalLB IPAddressPool name. In a standard openstack-k8s-operators deployment this is `internalapi`. You can verify the pool name with `oc get ipaddresspools -n metallb-system`.
+
+Then configure compute nodes to send kdump and heartbeat packets to that IP instead of the pod IP.
 
 ### Required Secrets and ConfigMaps
 
@@ -463,7 +500,7 @@ compute-1:
   uuid: System.Embedded.1  # Redfish system ID
 ```
 
-Redfish operations retry up to 3 times with per-request timeout of `FENCING_TIMEOUT` (clamped to 5–300 seconds). All URLs are validated to prevent SSRF attacks (localhost and link-local addresses are blocked).
+Redfish operations attempt up to 3 times with per-request timeout of `FENCING_TIMEOUT` (configurable range: 5–120 seconds). All URLs are validated to prevent SSRF attacks (localhost and link-local addresses are blocked).
 
 ### Metal3 (BMH) Configuration
 
@@ -525,7 +562,7 @@ config:
 | false | false | true | Only instances on hosts in tagged aggregates |
 | true | true | true | Tagged flavor OR tagged image, AND host must be in tagged aggregate |
 
-When all three filters are enabled but no resources carry the tag, all instances are evacuated (fail-open behavior ensures evacuation works out of the box before tagging is configured).
+When `TAGGED_FLAVORS` and/or `TAGGED_IMAGES` are enabled but no flavors or images carry the tag, all instances pass the flavor/image filter. This fail-open behavior ensures evacuation works out of the box before tagging is configured. However, `TAGGED_AGGREGATES` is fail-closed: if no aggregates carry the evacuable tag, no hosts pass the aggregate filter and no evacuations occur.
 
 ---
 
@@ -598,6 +635,53 @@ config:
 
 Each compute node must run a heartbeat sender that periodically sends a UDP packet to the InstanceHA pod. The packet format is a 4-byte magic number (`0x48425631`) followed by the hostname. See `docs/instanceha_heartbeat_performance.md` for a reference sender script and scalability benchmarks (tested to 1000 nodes).
 
+The recommended way to deploy the heartbeat sender is via the `instanceha-monitoring` EDPM service:
+
+**1. Create an OpenStackDataPlaneService CR:**
+
+```yaml
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: instanceha-monitoring
+spec:
+  playbook: osp.edpm.instanceha_monitoring
+```
+
+**2. Add the service to your OpenStackDataPlaneNodeSet:**
+
+```yaml
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneNodeSet
+metadata:
+  name: openstack-edpm
+spec:
+  services:
+    - download-cache
+    - bootstrap
+    - configure-network
+    # ... existing services ...
+    - nova
+    - instanceha-monitoring
+```
+
+**3. Set the required variables:**
+
+Pass the variables via `nodeTemplate.ansible.ansibleVars` or per-node overrides in the nodeset:
+
+```yaml
+spec:
+  nodeTemplate:
+    ansible:
+      ansibleVars:
+        edpm_instanceha_monitoring_heartbeat_enabled: true
+        edpm_instanceha_monitoring_heartbeat_ip: "<instanceha-ip>"
+        edpm_instanceha_monitoring_heartbeat_port: 7411
+        edpm_instanceha_monitoring_heartbeat_interval: 30
+```
+
+The `edpm_instanceha_monitoring_heartbeat_ip` must be the InstanceHA pod's IP on the heartbeat network. To ensure this IP remains stable across pod restarts, expose the heartbeat port via a MetalLB LoadBalancer Service and use the Service's external IP here. See [Stable IP for UDP Listeners](#stable-ip-for-udp-listeners).
+
 For large deployments, consider placing heartbeat traffic on a dedicated network attachment to isolate it from Nova API traffic. See [Network Attachments](#network-attachments) for an example.
 
 ---
@@ -622,6 +706,8 @@ Each compute node needs `fence_kdump` configured in `/etc/kdump.conf`:
 fence_kdump_nodes <instanceha-pod-ip>
 fence_kdump_args -p 7410
 ```
+
+To ensure this IP remains stable across pod restarts, expose the kdump port via a MetalLB LoadBalancer Service. See [Stable IP for UDP Listeners](#stable-ip-for-udp-listeners).
 
 ### InstanceHA Configuration
 
@@ -719,7 +805,7 @@ Each instance is fully independent — no cross-region communication or coordina
 | `fencingSecret` | string | `"fencing-secret"` | Secret with `fencing.yaml` |
 | `instanceHaConfigMap` | string | `"instanceha-config"` | ConfigMap with `config.yaml` |
 | `instanceHaKdumpPort` | int32 | `7410` | UDP port for kdump messages |
-| `instanceHaHeartbeatPort` | int32 | `7411` | UDP port for heartbeat messages (0 to disable) |
+| `instanceHaHeartbeatPort` | int32 | `7411` | UDP port for heartbeat messages |
 | `auth.applicationCredentialSecret` | string | none | Secret with `AC_ID` and `AC_SECRET` keys |
 | `nodeSelector` | map | none | Kubernetes node placement constraints |
 | `networkAttachments` | []string | none | Additional Multus network attachments |
@@ -755,7 +841,7 @@ All values are strings in the ConfigMap. The agent converts and validates them a
 | `TAGGED_IMAGES` | bool | true | Filter by image tag |
 | `TAGGED_FLAVORS` | bool | true | Filter by flavor tag |
 | `TAGGED_AGGREGATES` | bool | true | Filter by aggregate tag (also affects threshold calculation and reserved host matching) |
-| `SKIP_SERVERS_WITH_NAME` | list | `""` (empty) | Server name glob patterns (comma-separated) to exclude from evacuation |
+| `SKIP_SERVERS_WITH_NAME` | list | `[]` (empty) | Server name glob patterns (comma-separated) to exclude from evacuation |
 | `EVACUATION_RETRIES` | int | 5 (range: 1–20) | Max per-instance evacuation retry attempts before giving up |
 
 #### Host Recovery
@@ -851,11 +937,11 @@ The agent exposes three HTTP endpoints on port 8080:
 oc get pods -n openstack -l service=instanceha
 
 # View agent logs
-oc logs -n openstack deployment/instanceha-instanceha
+oc logs -n openstack deployment/instanceha
 
 # View K8s events
 oc describe instanceha instanceha -n openstack
 
 # Scrape Prometheus metrics
-oc exec deployment/instanceha-instanceha -- curl -s http://localhost:8080/metrics
+oc exec deployment/instanceha -- curl -s http://localhost:8080/metrics
 ```

--- a/docs/instanceha_heartbeat_performance.md
+++ b/docs/instanceha_heartbeat_performance.md
@@ -44,7 +44,7 @@ tens of MiB range.
 
 ## UDP Listener Throughput
 
-The listener is a single-threaded blocking `recvmsg` loop. It processes
+The listener is a single-threaded blocking `recvfrom` loop. It processes
 incoming heartbeat packets serially: validate magic number, decode
 hostname from the payload, and write the timestamp under the lock.
 Throughput is independent of THRESHOLD since the listener processes all

--- a/internal/controller/instanceha/instanceha_controller.go
+++ b/internal/controller/instanceha/instanceha_controller.go
@@ -128,7 +128,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 	// when a condition's state doesn't change.
 	savedConditions := instance.Status.Conditions.DeepCopy()
 
-	// Always patch the instance status when exiting this function so we can persist any changes.
+	// Patch the instance status when exiting this function so we can persist any changes,
+	// unless a panic occurred during reconciliation.
 	defer func() {
 		if panicVal := recover(); panicVal != nil {
 			Log.Error(fmt.Errorf("panic: %v", panicVal), "panic during reconcile, not updating status")


### PR DESCRIPTION
Architecture doc:
- THRESHOLD 0/100 behavior was backwards
- Deployment YAML rewritten to match actual code
- UDPSocketManager snippet updated to IPv6 dual-stack
- RBAC changed from ClusterRole to namespaced Role
- EVACUATION_RETRIES uses DEFAULT_EVACUATION_RETRIES constant

Guide doc:
- Clarified aggregate filtering is fail-closed
- Fixed FENCING_TIMEOUT range from 5-300 to 5-120
- Added stable IP for UDP listeners via MetalLB LoadBalancer Service

Other:
- Controller comment fix per PR #584 review (status not patched on panic)
- Heartbeat perf doc: recvmsg -> recvfrom
- CRD sample: added instanceHaHeartbeatPort comment