### PR TITLE
Fix InstanceHA test mock configurations

### DIFF
--- a/test/instanceha/functional_test.py
+++ b/test/instanceha/functional_test.py
@@ -125,6 +125,11 @@ class MockServerManager:
             servers.append(server)
         return servers
 
+    def reset_state(self, server, state):
+        """Reset server state."""
+        if server in self.servers_data:
+            self.servers_data[server]['status'] = state.upper()
+
     def evacuate(self, server, host=None):
         """Evacuate a server.
 
@@ -156,6 +161,7 @@ class MockServerManager:
             'host': kwargs.get('host', 'compute-0'),
             'flavor': kwargs.get('flavor', {'id': 'flavor-1', 'extra_specs': {}}),
             'image': kwargs.get('image', {'id': 'image-1'}),
+            'OS-EXT-STS:task_state': kwargs.get('task_state', None),
         }
         self.servers_data[server_id] = server_data
         return server_id

--- a/test/instanceha/test_coverage_gaps.py
+++ b/test/instanceha/test_coverage_gaps.py
@@ -713,10 +713,13 @@ class TestMonitorEvacuation(unittest.TestCase):
         if monotonic_values is None:
             monotonic_values = [start_time + i for i in range(len(status_sequence) + 5)]
 
+        conn = Mock()
+        conn.servers.evacuate.return_value = (Mock(status_code=200, reason='OK'), {})
+
         with patch('instanceha.time.sleep'):
             with patch('instanceha.time.monotonic', side_effect=monotonic_values):
                 with patch('instanceha._server_evacuation_status', side_effect=status_sequence):
-                    return instanceha._monitor_evacuation(Mock(), 'srv-1', 'resp-1', start_time)
+                    return instanceha._monitor_evacuation(conn, 'srv-1', 'resp-1', start_time)
 
     def test_immediate_completion(self):
         status = Mock(completed=True, error=False)

--- a/test/instanceha/test_critical_error_paths.py
+++ b/test/instanceha/test_critical_error_paths.py
@@ -244,6 +244,7 @@ class TestEvacuationTimeouts(unittest.TestCase):
         mock_connection = Mock()
         mock_server = Mock()
         mock_server.id = 'server-123'
+        setattr(mock_server, 'OS-EXT-STS:task_state', None)
 
         # Mock evacuation to succeed
         mock_connection.servers.evacuate.return_value = (Mock(status_code=200, reason='OK'), {})
@@ -267,6 +268,7 @@ class TestEvacuationTimeouts(unittest.TestCase):
         mock_connection = Mock()
         mock_server = Mock()
         mock_server.id = 'server-123'
+        setattr(mock_server, 'OS-EXT-STS:task_state', None)
 
         # Mock evacuation to succeed
         mock_connection.servers.evacuate.return_value = (Mock(status_code=200, reason='OK'), {})

--- a/test/instanceha/test_unit_core.py
+++ b/test/instanceha/test_unit_core.py
@@ -1365,7 +1365,8 @@ class TestSecretExposure(unittest.TestCase):
                         'auth_url': 'http://keystone:5000/v3',
                         'user_domain_name': 'Default',
                         'project_domain_name': 'Default'
-                    }
+                    },
+                    'region_name': 'regionOne'
                 }
             }
         }
@@ -1462,6 +1463,7 @@ class TestSecretExposure(unittest.TestCase):
 
             self._assert_no_secrets_in_logs()
 
+    @patch.dict(os.environ, {'OS_CLOUD': 'testcloud'})
     def test_create_connection_exception_no_secret_exposure(self):
         """Test that create_connection exceptions don't expose passwords."""
         # Clear log capture
@@ -1609,6 +1611,7 @@ class TestSecretExposure(unittest.TestCase):
 
         self._assert_no_secrets_in_logs()
 
+    @patch.dict(os.environ, {'OS_CLOUD': 'testcloud'})
     def test_get_nova_connection_exception_no_secret_exposure(self):
         """Test that _get_nova_connection exceptions don't expose passwords."""
         # Clear log capture
@@ -1630,6 +1633,7 @@ class TestSecretExposure(unittest.TestCase):
 
             self._assert_no_secrets_in_logs()
 
+    @patch.dict(os.environ, {'OS_CLOUD': 'testcloud'})
     def test_establish_nova_connection_exception_no_secret_exposure(self):
         """Test that _establish_nova_connection exceptions don't expose passwords."""
         # Clear log capture
@@ -2691,6 +2695,7 @@ class TestFunctionalIntegration(unittest.TestCase):
         server1.name = 'test-server-1'
         server1.image = {'id': 'image-1'}
         server1.flavor = {'id': 'flavor-1'}
+        setattr(server1, 'OS-EXT-STS:task_state', None)
         nova_state['servers'].append(server1)
 
         # Create service and config
@@ -2757,6 +2762,7 @@ class TestFunctionalIntegration(unittest.TestCase):
             server.name = f'test-server-{i}'
             server.image = {'id': 'image-1'}
             server.flavor = {'id': 'flavor-1'}
+            setattr(server, 'OS-EXT-STS:task_state', None)
             nova_state['servers'].append(server)
 
         # Create service
@@ -2841,6 +2847,7 @@ class TestFunctionalIntegration(unittest.TestCase):
             server.host = f'compute-{i}.example.com'
             server.status = 'ACTIVE'
             server.name = f'test-server-{i}'
+            setattr(server, 'OS-EXT-STS:task_state', None)
             # First 3 have evacuable tag, last 2 don't
             if i < 3:
                 server.image = {'id': 'image-1'}
@@ -3204,6 +3211,7 @@ class TestAdvancedIntegration(unittest.TestCase):
         """Test smart evacuation tracks migration status to completion."""
         conn = Mock()
         server = Mock(id='server-123', status='ACTIVE', host='compute-01')
+        setattr(server, 'OS-EXT-STS:task_state', None)
 
         # Mock evacuation response
         response = Mock(status_code=200, reason='OK')
@@ -3229,6 +3237,7 @@ class TestAdvancedIntegration(unittest.TestCase):
         """Test smart evacuation handles timeout correctly."""
         conn = Mock()
         server = Mock(id='server-456', status='ACTIVE')
+        setattr(server, 'OS-EXT-STS:task_state', None)
 
         response = Mock(status_code=200, reason='OK')
         conn.servers.evacuate.return_value = (response, {})
@@ -3249,6 +3258,7 @@ class TestAdvancedIntegration(unittest.TestCase):
         """Test smart evacuation retries on errors."""
         conn = Mock()
         server = Mock(id='server-789', status='ACTIVE')
+        setattr(server, 'OS-EXT-STS:task_state', None)
 
         response = Mock(status_code=200, reason='OK')
         conn.servers.evacuate.return_value = (response, {})


### PR DESCRIPTION
Several tests were passing accidentally due to misconfigured mocks:

- TestSecretExposure: OS_CLOUD defaulted to 'overcloud' but fixtures defined 'testcloud', causing KeyError before nova_login was reached. Added @patch.dict for OS_CLOUD and region_name to clouds config.

- MockServerManager: Missing reset_state() method and OS-EXT-STS:task_state attribute, causing spurious "stuck task_state" warnings and AttributeError on every functional test evacuation.

- TestMonitorEvacuation: Connection mock returned bare Mock() from evacuate() instead of (response, {}) tuple, causing "cannot unpack non-iterable Mock" on every retry attempt.

- Multiple test files: Server mocks created without OS-EXT-STS:task_state attribute, triggering false stuck-task-state detection on every evacuation call.