### PR TITLE
Fix FRR old namespace cleanup error handling in reconcileDelete

### DIFF
--- a/internal/controller/network/bgpconfiguration_controller.go
+++ b/internal/controller/network/bgpconfiguration_controller.go
@@ -384,7 +384,7 @@ func (r *BGPConfigurationReconciler) reconcileDelete(ctx context.Context, instan
 
 	if frrNamespace != instance.Spec.FRRConfigurationNamespace {
 		if err := r.cleanupOldNamespaceFRRConfigurations(ctx, instance, instance.Spec.FRRConfigurationNamespace); err != nil {
-			Log.Error(err, "Failed to cleanup FRRConfigurations from old namespace", "namespace", instance.Spec.FRRConfigurationNamespace)
+			return ctrl.Result{}, fmt.Errorf("error cleaning up FRRConfigurations from old namespace %s: %w", instance.Spec.FRRConfigurationNamespace, err)
 		}
 	}
 


### PR DESCRIPTION
- Return the error from `cleanupOldNamespaceFRRConfigurations` in `reconcileDelete` instead of just logging it
- Without this fix, if the cleanup fails, the finalizer is still removed and the CR is garbage collected — potentially leaving orphaned `FRRConfiguration` resources in the old namespace
- Addresses review feedback from #587 (https://github.com/openstack-k8s-operators/infra-operator/pull/587#discussion_r3311652379)
