### PR TITLE
Final InstanceHA cleanup and small fixes

### DIFF
--- a/docs/instanceha_architecture.md
+++ b/docs/instanceha_architecture.md
@@ -9,21 +9,22 @@ InstanceHA is a high-availability service for OpenStack that automatically detec
 1. [Core Components](#core-components)
 2. [Architecture Patterns](#architecture-patterns)
 3. [Service Workflow](#service-workflow)
-4. [Critical Services Validation](#critical-services-validation)
-5. [Configuration System](#configuration-system)
-6. [Evacuation Mechanisms](#evacuation-mechanisms)
-7. [Fencing Agents](#fencing-agents)
-8. [Kubernetes Events and Prometheus Metrics](#kubernetes-events-and-prometheus-metrics)
-9. [Advanced Features](#advanced-features)
-10. [Region Handling](#region-handling)
-11. [Authentication](#authentication)
-12. [Startup Reconciliation](#startup-reconciliation)
-13. [Graceful Shutdown](#graceful-shutdown)
-14. [Security](#security)
-15. [Performance](#performance)
-16. [Testing](#testing)
-17. [Deployment](#deployment)
-18. [Configuration Options Reference](#configuration-options-reference)
+4. [Fencing Safety Model](#fencing-safety-model)
+5. [Critical Services Validation](#critical-services-validation)
+6. [Configuration System](#configuration-system)
+7. [Evacuation Mechanisms](#evacuation-mechanisms)
+8. [Fencing Agents](#fencing-agents)
+9. [Kubernetes Events and Prometheus Metrics](#kubernetes-events-and-prometheus-metrics)
+10. [Advanced Features](#advanced-features)
+11. [Region Handling](#region-handling)
+12. [Authentication](#authentication)
+13. [Startup Reconciliation](#startup-reconciliation)
+14. [Graceful Shutdown](#graceful-shutdown)
+15. [Security](#security)
+16. [Performance](#performance)
+17. [Testing](#testing)
+18. [Deployment](#deployment)
+19. [Configuration Options Reference](#configuration-options-reference)
 
 ---
 
@@ -162,7 +163,7 @@ def __init__(self, config_manager: ConfigManager, cloud_client: Optional[OpenSta
     self._last_hash_time = 0
     self._previous_hash = ""
     self.ready = False                              # Readiness flag (set after first poll)
-    self.k8s_api_reachable = False                  # K8s API connectivity (partition detection)
+    self.k8s_api_reachable = True                   # K8s API connectivity (fail-open, see Fencing Safety Model)
 
     # Caching
     self._host_servers_cache = {}
@@ -202,6 +203,7 @@ def __init__(self, config_manager: ConfigManager, cloud_client: Optional[OpenSta
 **State Management Notes**:
 
 - `ready` flag starts `False` and is set to `True` after the first successful poll cycle. This drives the `/healthz` readiness probe endpoint — Kubernetes won't route traffic until the service has completed its first poll.
+- `k8s_api_reachable` starts `True` (fail-open). The background health check thread flips it to `False` after 3 consecutive failures. See [Fencing Safety Model](#fencing-safety-model) for the startup trade-off rationale.
 - `shutdown_event` is set by the SIGTERM handler to signal the main loop and all `wait()` calls to exit gracefully.
 - `kdump_lock` protects all kdump-related state since the UDP listener thread writes concurrently with the main poll loop.
 - `heartbeat_lock` similarly protects heartbeat state from concurrent UDP listener writes.
@@ -671,6 +673,93 @@ The `disabled_reason` field tracks evacuation state:
 - Services transition from `resume` → `reenable` via the disabled_reason update
 - Failed evacuations remain disabled until manually resolved
 - Both checks use substring matching with explicit exclusions to prevent incorrect categorization
+
+---
+
+## Fencing Safety Model
+
+InstanceHA uses a two-tier safety model to prevent false-positive fencing. Each gate answers a distinct question — there is no redundancy between them.
+
+### Gate Chain
+
+When `CHECK_HEARTBEAT=true` (recommended for production):
+
+```
+Poll cycle starts
+  │
+  ├─ Gate 1: K8s API reachable?
+  │   Question: "Can we trust our own observations?"
+  │   If no (3 consecutive failures) → skip entire cycle
+  │   Rationale: if InstanceHA's worker node is network-isolated,
+  │   Nova's service list may be stale — fencing would hit healthy hosts
+  │
+  ├─ Gate 2: Per-host heartbeat
+  │   Question: "Is this specific host actually down?"
+  │   If host sending heartbeats within HEARTBEAT_TIMEOUT → skip that host
+  │   Rationale: Nova reports host as down, but heartbeat proves the OS is alive —
+  │   only nova-compute crashed, not the host
+  │
+  ├─ Gate 3: Heartbeat cliff detection
+  │   Question: "Did we lose visibility, or did hosts actually fail?"
+  │   If >HEARTBEAT_CLIFF_THRESHOLD% of heartbeats vanish at once → skip ALL fencing
+  │   Rationale: simultaneous mass heartbeat loss is more likely a listener-side
+  │   network partition than N simultaneous host failures
+  │
+  ├─ Gate 4: Kdump detection (optional, CHECK_KDUMP=true)
+  │   Question: "Is this host crashing and dumping memory?"
+  │   If kdump message received → fence immediately, skip power-on during recovery
+  │
+  ├─ Gate 5: Global threshold
+  │   Question: "Are too many hosts down to safely evacuate?"
+  │   If failed percentage > THRESHOLD → skip all fencing
+  │
+  └─ Gate 6: Per-aggregate threshold
+      Question: "Is this aggregate losing too many hosts?"
+      If failed count > instanceha:max_failures metadata → skip hosts in that aggregate
+```
+
+When `CHECK_HEARTBEAT=false`, gates 2 and 3 are not evaluated. A warning is logged at startup to alert operators that split-brain protection is limited to the K8s API check.
+
+### Fail-Open vs Fail-Closed Semantics
+
+| Gate | On error / no data | Rationale |
+|------|-------------------|-----------|
+| K8s API (startup) | Fail-open (allow fencing) | No data yet — blocking fencing on startup would silently prevent all evacuations until the health check thread runs |
+| K8s API (after 3 failures) | Fail-closed (block fencing) | Confirmed partition — fencing would hit healthy hosts |
+| Heartbeat (grace period) | Fail-open (allow fencing) | No heartbeat history in first `HEARTBEAT_TIMEOUT` seconds — cannot distinguish "no heartbeat" from "never received one" |
+| Heartbeat (steady state) | Fail-open (allow fencing) | No heartbeat = host is down = proceed with fencing |
+| Cliff detection | Fail-closed (block fencing) | Mass heartbeat loss is treated as observer failure |
+
+### Startup Race Window
+
+`k8s_api_reachable` initializes to `True` before the background health check thread confirms K8s API connectivity. If the K8s API is genuinely unreachable at startup, fencing could proceed for up to ~45 seconds (3 failures × 15s `K8S_API_CHECK_INTERVAL`) before the check blocks it.
+
+In practice this window is smaller: the health check thread starts during `_initialize_service()` and runs its first probe almost immediately, while the main loop still needs to complete `_establish_nova_connection()` and `_reconcile_orphaned_hosts()` before its first poll. The health check typically completes its first probe before the main loop is ready to fence.
+
+This is a deliberate trade-off. The alternative (`k8s_api_reachable = False` at startup) caused a deadlock: if the health check thread failed to start or was delayed, fencing was silently blocked forever with no log output indicating the problem.
+
+### Fencing Decision Log
+
+Every poll cycle that reaches the fencing decision point emits a single summary line:
+
+```
+INFO Fencing decision: 3 stale, 1 heartbeat-alive, 2 to fence, cliff=False
+```
+
+This line is emitted in all cases — including when all hosts are filtered out by heartbeat or cliff detection — so operators can diagnose fencing decisions from a single log grep.
+
+### Relationship to MedIK8s
+
+InstanceHA and MedIK8s (NHC/FAR/SNR) operate at different layers with no overlap:
+
+| Layer | Scope | What it handles |
+|-------|-------|-----------------|
+| MedIK8s | OpenShift cluster | Kubernetes node failures, pod recovery, node remediation |
+| InstanceHA | EDPM data plane | Compute host fencing, VM evacuation |
+
+MedIK8s watches Kubernetes Node objects. EDPM compute nodes are **not** Kubernetes nodes — they are external bare-metal hosts managed outside the cluster. MedIK8s cannot detect or remediate EDPM compute node failures; InstanceHA handles those independently.
+
+MedIK8s is relevant for control plane recovery (e.g., if the node running RabbitMQ or the InstanceHA pod itself fails). InstanceHA is relevant for data plane recovery (compute host failures requiring VM evacuation).
 
 ---
 
@@ -1286,11 +1375,12 @@ Minimum packet size: 45 bytes (4 magic + 8 timestamp + 1 hostname + 32 HMAC).
 **Configuration**: `K8S_API_CHECK_INTERVAL: 15`
 
 **Behavior**:
-1. The health check thread pings the K8s API every `K8S_API_CHECK_INTERVAL` seconds
-2. Any non-5xx response (status code < 500) is treated as reachable — the API is responding, even if RBAC denies the specific request
-3. After 3 consecutive failures, `k8s_api_reachable` is set to `False` and `ready` is set to `False`
-4. The main poll loop checks `k8s_api_reachable` before fencing — if `False`, the entire fencing cycle is skipped
-5. When connectivity restores, `k8s_api_reachable` is set back to `True`; readiness is restored after the next successful Nova poll
+1. `k8s_api_reachable` initializes to `True` (fail-open) — see [Fencing Safety Model](#fencing-safety-model) for the startup trade-off rationale
+2. The health check thread pings the K8s API every `K8S_API_CHECK_INTERVAL` seconds
+3. Any non-5xx response (status code < 500) is treated as reachable — the API is responding, even if RBAC denies the specific request
+4. After 3 consecutive failures, `k8s_api_reachable` is set to `False` and `ready` is set to `False`
+5. The main poll loop checks `k8s_api_reachable` before fencing — if `False`, the entire fencing cycle is skipped
+6. When connectivity restores, `k8s_api_reachable` is set back to `True`; readiness is restored after the next successful Nova poll
 
 **Prometheus**: `instanceha_k8s_api_reachable` gauge (1=ok, 0=isolated)
 

--- a/templates/instanceha/bin/instanceha.py
+++ b/templates/instanceha/bin/instanceha.py
@@ -28,13 +28,6 @@ from typing import Dict, Any, Optional, Union, List, Protocol, Tuple, Callable
 from collections import defaultdict
 from abc import ABC, abstractmethod
 
-from novaclient import client
-from novaclient.exceptions import Conflict, NotFound, Forbidden, Unauthorized
-
-from keystoneauth1 import loading
-from keystoneauth1 import session as ksc_session
-from keystoneauth1.exceptions.discovery import DiscoveryFailure
-
 from prometheus_client import Counter, Gauge, Histogram, generate_latest, CONTENT_TYPE_LATEST
 
 
@@ -1761,6 +1754,7 @@ def _host_evacuate(connection, failed_service, service, target_host=None) -> boo
 
 def _server_evacuate(connection, server, target_host=None, server_obj=None) -> EvacuationResult:
     """Evacuate a single server instance, returning EvacuationResult."""
+    from novaclient.exceptions import Conflict, NotFound, Forbidden, Unauthorized
     success = False
     error_message = ""
     resp_status_code = None
@@ -2017,6 +2011,11 @@ def _server_evacuate_future(connection, server, target_host=None,
 def _nova_login(plugin_name: str, auth_kwargs: dict, region_name: str,
                 ca_bundle: Optional[str] = None) -> OpenStackClient:
     """Create and return Nova client connection. Raises NovaConnectionError on failure."""
+    from keystoneauth1 import loading
+    from keystoneauth1 import session as ksc_session
+    from keystoneauth1.exceptions.discovery import DiscoveryFailure
+    from novaclient import client
+    from novaclient.exceptions import Unauthorized
     try:
         loader = loading.get_plugin_loader(plugin_name)
         auth = loader.load_from_options(**auth_kwargs)
@@ -2055,15 +2054,14 @@ def nova_login_ac(credentials: ACLoginCredentials, ca_bundle: Optional[str] = No
     }, credentials.region_name, ca_bundle)
 
 
-NOVA_EXCEPTION_MESSAGES = {
-    NotFound: "Resource not found",
-    Conflict: "Conflicting operation",
-}
-
-
 def _handle_nova_exception(operation: str, service_info: str, e: Exception, is_critical: bool = True) -> bool:
     """Handle Nova API exceptions with consistent logging."""
-    error_msg = NOVA_EXCEPTION_MESSAGES.get(type(e))
+    from novaclient.exceptions import NotFound, Conflict
+    nova_exception_messages = {
+        NotFound: "Resource not found",
+        Conflict: "Conflicting operation",
+    }
+    error_msg = nova_exception_messages.get(type(e))
 
     if error_msg:
         logging.error("Failed to %s for %s. %s: %s", operation, service_info, error_msg, type(e).__name__)
@@ -3557,6 +3555,9 @@ def main():
     signal.signal(signal.SIGTERM, _sigterm_handler)
 
     consecutive_failures = 0
+
+    from novaclient.exceptions import Unauthorized
+    from keystoneauth1.exceptions.discovery import DiscoveryFailure
 
     while not service.shutdown_event.is_set():
         service.update_health_hash()

--- a/templates/instanceha/bin/instanceha.py
+++ b/templates/instanceha/bin/instanceha.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass
 from enum import Enum
 import concurrent.futures
 import requests
-import requests.exceptions
 import yaml
 import subprocess
 from yaml.loader import SafeLoader
@@ -179,18 +178,9 @@ class MatchType(Enum):
     ZONE = "zone"
 
 
-class MigrationStatus(Enum):
-    """Migration status values."""
-    COMPLETED = "completed"
-    DONE = "done"
-    ERROR = "error"
-    FAILED = "failed"
-    CANCELLED = "cancelled"
-
-
 # Migration status constants for checking migration state
-MIGRATION_STATUS_COMPLETED = [MigrationStatus.COMPLETED.value, MigrationStatus.DONE.value]
-MIGRATION_STATUS_ERROR = [MigrationStatus.ERROR.value, MigrationStatus.FAILED.value, MigrationStatus.CANCELLED.value]
+MIGRATION_STATUS_COMPLETED = ["completed", "done"]
+MIGRATION_STATUS_ERROR = ["error", "failed", "cancelled"]
 
 
 # Dataclasses
@@ -312,8 +302,6 @@ VALIDATION_PATTERNS = {
     'power_action': (['on', 'off', 'status', 'reset', 'cycle', 'soft', 'On', 'ForceOff',
                       'GracefulShutdown', 'GracefulRestart', 'ForceRestart', 'Nmi',
                       'ForceOn', 'PushPowerButton'], None),
-    'ip_address': ('ip', None),  # Special marker for IP address validation
-    'port': ('port', None),  # Special marker for port validation
     'username': (r'^[a-zA-Z0-9_-]{1,64}$', USERNAME_MAX_LENGTH),
     'hostname': (r'^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$', USERNAME_MAX_LENGTH)
 }
@@ -768,7 +756,6 @@ class InstanceHAService(CloudConnectionProvider):
         self.current_hash = ""
         self.hash_update_successful = False
         self._last_hash_time = 0
-        self._previous_hash = ""
         self.ready = False
         self.k8s_api_reachable = False
 
@@ -838,7 +825,6 @@ class InstanceHAService(CloudConnectionProvider):
         if current_timestamp - self._last_hash_time > hash_interval:
             self.current_hash = hashlib.sha256(str(current_timestamp).encode()).hexdigest()
             self.hash_update_successful = True
-            self._previous_hash = self.current_hash
             self._last_hash_time = current_timestamp
 
     def get_connection(self) -> Optional[OpenStackClient]:
@@ -953,8 +939,7 @@ class InstanceHAService(CloudConnectionProvider):
         try:
             cache_data = fetch_func(connection)
         except Exception as e:
-            logging.error("Failed to get evacuable resources (%s): %s", config_key, e)
-            logging.debug('Exception traceback:', exc_info=True)
+            _safe_log_exception(f"Failed to get evacuable resources ({config_key})", e, include_traceback=True)
             cache_data = []
         with self._cache_lock:
             setattr(self, cache_attr, cache_data)
@@ -1115,8 +1100,7 @@ class InstanceHAService(CloudConnectionProvider):
             return any(host in agg.hosts for agg in aggregates
                       if self._is_resource_evacuable(agg, self.evacuable_tag, ['metadata']))
         except Exception as e:
-            logging.error("Failed to check aggregate evacuability for %s: %s", host, e)
-            logging.debug('Exception traceback:', exc_info=True)
+            _safe_log_exception(f"Failed to check aggregate evacuability for {host}", e, include_traceback=True)
             return False
 
     def get_hosts_with_servers_cached(self, connection, services):
@@ -1290,15 +1274,7 @@ class InstanceHAService(CloudConnectionProvider):
         except Exception as e:
             logging.error('Health check server failed: %s', e)
 
-    def _cleanup_dict_by_condition(self, dictionary: dict, condition_func: Callable[[Any, Any], bool],
-                                   log_message: Optional[str] = None) -> int:
-        """Remove dictionary entries matching condition function."""
-        to_remove = [k for k, v in dictionary.items() if condition_func(k, v)]
-        for k in to_remove:
-            del dictionary[k]
-            if log_message:
-                logging.debug(log_message.format(k))
-        return len(to_remove)
+
 
     def refresh_evacuable_cache(self, connection=None, force=False, cache_timeout=CACHE_TIMEOUT_SECONDS):
         """Refresh evacuable flavors and images cache with intelligent timing."""
@@ -1551,8 +1527,7 @@ def _update_service_disable_reason(connection, host, service_id=None) -> bool:
         logging.debug('Updated disabled reason for host %s after evacuation failure', host)
         return True
     except Exception as e:
-        logging.error('Failed to update disable_reason for host %s. Error: %s', host, e)
-        logging.debug('Exception traceback:', exc_info=True)
+        _safe_log_exception(f"Failed to update disable_reason for host {host}", e, include_traceback=True)
         return False
 
 
@@ -1899,9 +1874,7 @@ def _monitor_evacuation(connection, server_id, response_uuid, start_time,
 
         except Exception as e:
             api_error_count += 1
-            logging.error("Error checking evacuation status for %s: %s",
-                         response_uuid, _sanitize_message(str(e)))
-            logging.debug('Exception traceback:', exc_info=True)
+            _safe_log_exception(f"Error checking evacuation status for {response_uuid}", e, include_traceback=True)
             if api_error_count >= MAX_API_RETRIES:
                 logging.error("Too many API errors checking evacuation status for %s. Giving up.",
                              response_uuid)
@@ -1993,9 +1966,7 @@ def _server_evacuate_future(connection, server, target_host=None,
         return result
 
     except Exception as e:
-        logging.error("Unexpected error during evacuation of server %s: %s",
-                     server.id, _sanitize_message(str(e)))
-        logging.debug('Exception traceback:', exc_info=True)
+        _safe_log_exception(f"Unexpected error during evacuation of server {server.id}", e, include_traceback=True)
         _emit_k8s_event(source_host, 'InstanceEvacuationFailed',
                         f'Instance {server.id} evacuation error: {_sanitize_message(str(e))}',
                         event_type='Warning')
@@ -2520,12 +2491,6 @@ def _host_fence(host, action, service):
         logging.error("Invalid fence parameters: missing host")
         return False
 
-    # Validate action parameter at entry point
-    if not validate_input(action, 'power_action', "host fencing"):
-        logging.error("Invalid fence action: %s", action)
-        return False
-
-    # Additional check for fence-specific actions
     if action not in ['on', 'off']:
         logging.error("Unsupported fence action: %s (only 'on' and 'off' supported)", action)
         return False
@@ -2558,14 +2523,7 @@ def _host_fence(host, action, service):
 
 def _get_nova_connection(service):
     """Establish a connection to Nova using service configuration."""
-    try:
-        return service.create_connection()
-    except NovaConnectionError:
-        logging.error("Nova connection failed")
-        return None
-    except Exception as e:
-        _safe_log_exception("Failed to establish Nova connection", e)
-        return None
+    return _establish_nova_connection(service, fatal=False)
 
 
 def _enable_matching_reserved_host(conn, failed_service, reserved_hosts, service,
@@ -3019,7 +2977,7 @@ def _categorize_services(services: List[Any], target_date: datetime) -> tuple:
 
     return compute_nodes, resume, reenable
 
-def _check_critical_services(conn, services, compute_nodes):
+def _check_critical_services(services):
     """Check if critical Nova services are operational for evacuation."""
     # Check if at least one scheduler is up
     schedulers = [s for s in services if s.binary == 'nova-scheduler']
@@ -3048,10 +3006,11 @@ def _filter_processing_hosts(service, compute_nodes, to_resume):
 
     with service.processing_lock:
         # Clean up expired processing entries
-        service._cleanup_dict_by_condition(
-            service.hosts_processing,
-            lambda h, t: current_time - t > max_processing_time + MAX_PROCESSING_TIME_PADDING_SECONDS,
-            'Cleaned up expired processing entry for {}')
+        expired = [h for h, t in service.hosts_processing.items()
+                   if current_time - t > max_processing_time + MAX_PROCESSING_TIME_PADDING_SECONDS]
+        for h in expired:
+            del service.hosts_processing[h]
+            logging.debug('Cleaned up expired processing entry for %s', h)
 
         # Filter out hosts currently being processed
         original_count = len(compute_nodes)
@@ -3278,7 +3237,7 @@ def _process_stale_services(conn, service, services, compute_nodes, to_resume):
     # Process evacuations
     if not service.config.get_config_value('DISABLED'):
         # Check if critical services are operational
-        can_evacuate, error_msg = _check_critical_services(conn, services, compute_nodes)
+        can_evacuate, error_msg = _check_critical_services(services)
         if not can_evacuate:
             logging.error('Cannot evacuate: %s. Skipping evacuation.', error_msg)
             _cleanup_filtered_hosts(service, marked_hostnames, set(), current_time)

--- a/templates/instanceha/bin/instanceha.py
+++ b/templates/instanceha/bin/instanceha.py
@@ -757,7 +757,8 @@ class InstanceHAService(CloudConnectionProvider):
         self.hash_update_successful = False
         self._last_hash_time = 0
         self.ready = False
-        self.k8s_api_reachable = False
+        self.k8s_api_reachable = True
+        K8S_API_REACHABLE.set(1)
 
         # Caching
         self._evacuable_flavors_cache = None
@@ -2917,6 +2918,10 @@ def _initialize_service(config_mgr):
         heartbeat_thread = threading.Thread(target=_heartbeat_udp_listener, args=(service,))
         heartbeat_thread.daemon = True
         heartbeat_thread.start()
+    else:
+        logging.warning(
+            'CHECK_HEARTBEAT is disabled — fencing decisions rely solely on Nova service '
+            'timestamps. Enable heartbeat checking for split-brain protection.')
 
     return service
 
@@ -3169,6 +3174,9 @@ def _process_stale_services(conn, service, services, compute_nodes, to_resume):
         return
 
     # Filter out hosts still reachable via heartbeat
+    stale_count = len(compute_nodes)
+    heartbeat_skipped = []
+    cliff_detected = False
     if service.config.get_config_value('CHECK_HEARTBEAT'):
         compute_nodes, heartbeat_skipped, cliff_detected = _filter_reachable_hosts(service, compute_nodes)
         if not cliff_detected:
@@ -3180,8 +3188,15 @@ def _process_stale_services(conn, service, services, compute_nodes, to_resume):
                 HOST_REACHABLE_TOTAL.labels(host=svc.host).inc()
 
         if not (compute_nodes or to_resume):
+            logging.info(
+                'Fencing decision: %d stale, %d heartbeat-alive, %d to fence, cliff=%s',
+                stale_count, len(heartbeat_skipped), len(compute_nodes), cliff_detected)
             _cleanup_filtered_hosts(service, marked_hostnames, set(), current_time)
             return
+
+    logging.info(
+        'Fencing decision: %d stale, %d heartbeat-alive, %d to fence, cliff=%s',
+        stale_count, len(heartbeat_skipped), len(compute_nodes), cliff_detected)
 
     if compute_nodes:
         logging.warning('The following computes are down: %s', [svc.host for svc in compute_nodes])

--- a/test/instanceha/conftest.py
+++ b/test/instanceha/conftest.py
@@ -6,14 +6,18 @@ import instanceha without duplicating the boilerplate.
 
 import os
 import sys
-from unittest.mock import MagicMock
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
 
 
 # --- Mock OpenStack dependencies before any test file imports instanceha ---
 
 if 'novaclient' not in sys.modules:
-    sys.modules['novaclient'] = MagicMock()
-    sys.modules['novaclient.client'] = MagicMock()
+    _novaclient_mock = MagicMock()
+    _novaclient_client_mock = MagicMock()
+    _novaclient_mock.client = _novaclient_client_mock
+    sys.modules['novaclient'] = _novaclient_mock
+    sys.modules['novaclient.client'] = _novaclient_client_mock
 
     class NotFound(Exception):
         pass
@@ -32,12 +36,18 @@ if 'novaclient' not in sys.modules:
     novaclient_exceptions.Conflict = Conflict
     novaclient_exceptions.Forbidden = Forbidden
     novaclient_exceptions.Unauthorized = Unauthorized
+    _novaclient_mock.exceptions = novaclient_exceptions
     sys.modules['novaclient.exceptions'] = novaclient_exceptions
 
 if 'keystoneauth1' not in sys.modules:
-    sys.modules['keystoneauth1'] = MagicMock()
-    sys.modules['keystoneauth1.loading'] = MagicMock()
-    sys.modules['keystoneauth1.session'] = MagicMock()
+    _keystoneauth_mock = MagicMock()
+    _loading_mock = MagicMock()
+    _session_mock = MagicMock()
+    _keystoneauth_mock.loading = _loading_mock
+    _keystoneauth_mock.session = _session_mock
+    sys.modules['keystoneauth1'] = _keystoneauth_mock
+    sys.modules['keystoneauth1.loading'] = _loading_mock
+    sys.modules['keystoneauth1.session'] = _session_mock
 
     class DiscoveryFailure(Exception):
         pass
@@ -48,6 +58,7 @@ if 'keystoneauth1' not in sys.modules:
     exceptions_module = MagicMock()
     exceptions_module.discovery = discovery_module
 
+    _keystoneauth_mock.exceptions = exceptions_module
     sys.modules['keystoneauth1.exceptions'] = exceptions_module
     sys.modules['keystoneauth1.exceptions.discovery'] = discovery_module
 
@@ -59,3 +70,32 @@ _instanceha_path = os.path.join(_test_dir, '../../templates/instanceha/bin/')
 _abs_path = os.path.abspath(_instanceha_path)
 if _abs_path not in sys.path:
     sys.path.insert(0, _abs_path)
+
+
+# --- Shared test fixtures ---
+
+import instanceha  # noqa: E402
+
+
+@contextmanager
+def patch_pipeline(conn=None, fence=True, disable=True,
+                   reserved=None, evacuate=True, recovery=True):
+    """Patch all process_service pipeline steps with configurable return values.
+
+    Yields a dict of mock objects keyed by step name, so tests can assert
+    on individual steps (e.g. mocks['disable'].assert_not_called()).
+    """
+    if reserved is None:
+        reserved = instanceha.ReservedHostResult(success=True, hostname=None)
+    with patch('instanceha._get_nova_connection', return_value=conn) as m_conn, \
+         patch('instanceha._host_fence', return_value=fence) as m_fence, \
+         patch('instanceha._host_disable', return_value=disable) as m_disable, \
+         patch('instanceha._manage_reserved_hosts', return_value=reserved) as m_reserved, \
+         patch('instanceha._host_evacuate', return_value=evacuate) as m_evacuate, \
+         patch('instanceha._post_evacuation_recovery', return_value=recovery) as m_recovery, \
+         patch('instanceha.track_host_processing') as m_track:
+        yield {
+            'conn': m_conn, 'fence': m_fence, 'disable': m_disable,
+            'reserved': m_reserved, 'evacuate': m_evacuate,
+            'recovery': m_recovery, 'track': m_track,
+        }

--- a/test/instanceha/test_config_features.py
+++ b/test/instanceha/test_config_features.py
@@ -711,37 +711,31 @@ class TestCriticalServicesCheck(unittest.TestCase):
         ]
         compute_nodes = [services[2]]
 
-        can_evacuate, error_msg = instanceha._check_critical_services(mock_conn, services, compute_nodes)
+        can_evacuate, error_msg = instanceha._check_critical_services(services)
 
         self.assertFalse(can_evacuate)
         self.assertIn('nova-scheduler', error_msg)
 
     def test_at_least_one_scheduler_up(self):
         """Test that check passes when at least one scheduler is up."""
-        mock_conn = Mock()
-
         services = [
             Mock(binary='nova-scheduler', state='down', host='controller-1'),
             Mock(binary='nova-scheduler', state='up', host='controller-2'),
             Mock(binary='nova-compute', state='down', host='compute-1')
         ]
-        compute_nodes = [services[2]]
 
-        can_evacuate, error_msg = instanceha._check_critical_services(mock_conn, services, compute_nodes)
+        can_evacuate, error_msg = instanceha._check_critical_services(services)
 
         self.assertTrue(can_evacuate)
         self.assertEqual(error_msg, "")
 
     def test_no_schedulers_defined(self):
         """Test when no schedulers are in services list."""
-        mock_conn = Mock()
-
         services = [
             Mock(binary='nova-compute', state='down', host='compute-1')
         ]
-        compute_nodes = [services[0]]
 
-        can_evacuate, error_msg = instanceha._check_critical_services(mock_conn, services, compute_nodes)
+        can_evacuate, error_msg = instanceha._check_critical_services(services)
 
         # Should allow evacuation if no schedulers are in the list
         self.assertTrue(can_evacuate)

--- a/test/instanceha/test_coverage_gaps.py
+++ b/test/instanceha/test_coverage_gaps.py
@@ -912,7 +912,6 @@ class TestProcessStaleServicesSafety(unittest.TestCase):
         svc.refresh_evacuable_cache = Mock()
         svc.get_hosts_with_servers_cached = Mock(return_value={})
         svc.filter_hosts_with_servers = Mock(return_value=[])
-        svc._cleanup_dict_by_condition = Mock()
         return svc
 
     def test_empty_compute_nodes_and_resume(self):
@@ -939,7 +938,7 @@ class TestProcessStaleServicesSafety(unittest.TestCase):
         service.get_hosts_with_servers_cached.return_value = {'host-1': ['server-1']}
         service.filter_hosts_with_servers.return_value = [svc1]
         with patch('instanceha._emit_k8s_event'):
-            with patch('instanceha._check_critical_services', return_value=(True, None)):
+            with patch('instanceha._check_critical_services', return_value=(True, "")):
                 instanceha._process_stale_services(conn, service, [svc1], [svc1], [])
 
     def test_disabled_mode_skips_evacuation(self):

--- a/test/instanceha/test_coverage_gaps.py
+++ b/test/instanceha/test_coverage_gaps.py
@@ -761,10 +761,6 @@ class TestMonitorEvacuation(unittest.TestCase):
 # Main loop backoff tests
 # ============================================================================
 
-class _TestDiscoveryFailure(Exception):
-    pass
-
-
 class TestMainLoopBackoff(unittest.TestCase):
     """Tests for main() exponential backoff on Nova failures."""
 
@@ -782,12 +778,13 @@ class TestMainLoopBackoff(unittest.TestCase):
         svc.shutdown_event = threading.Event()
         return svc
 
-    @patch('instanceha.DiscoveryFailure', _TestDiscoveryFailure)
     @patch('instanceha.signal.signal')
     @patch('instanceha._establish_nova_connection')
     @patch('instanceha._initialize_service')
     @patch('instanceha.ConfigManager')
     def test_unauthorized_triggers_reconnection(self, mock_cm, mock_init, mock_conn, mock_signal):
+        from novaclient.exceptions import Unauthorized
+
         mock_cm.return_value.get_config_value = Mock(return_value='INFO')
         service = self._make_service_mock()
         mock_init.return_value = service
@@ -799,14 +796,13 @@ class TestMainLoopBackoff(unittest.TestCase):
             call_count[0] += 1
             if call_count[0] >= 2:
                 service.shutdown_event.set()
-            raise instanceha.Unauthorized('expired')
+            raise Unauthorized('expired')
         conn.services.list.side_effect = unauthorized_then_stop
 
         instanceha.main()
 
         mock_conn.assert_called()
 
-    @patch('instanceha.DiscoveryFailure', _TestDiscoveryFailure)
     @patch('instanceha.signal.signal')
     @patch('instanceha._establish_nova_connection')
     @patch('instanceha._initialize_service')
@@ -830,7 +826,6 @@ class TestMainLoopBackoff(unittest.TestCase):
 
         self.assertGreaterEqual(call_count[0], 2)
 
-    @patch('instanceha.DiscoveryFailure', _TestDiscoveryFailure)
     @patch('instanceha.signal.signal')
     @patch('instanceha._process_reenabling')
     @patch('instanceha._process_stale_services')
@@ -860,7 +855,6 @@ class TestMainLoopBackoff(unittest.TestCase):
 
         mock_cat.assert_called()
 
-    @patch('instanceha.DiscoveryFailure', _TestDiscoveryFailure)
     @patch('instanceha.signal.signal')
     @patch('instanceha._establish_nova_connection')
     @patch('instanceha._initialize_service')

--- a/test/instanceha/test_critical_error_paths.py
+++ b/test/instanceha/test_critical_error_paths.py
@@ -178,12 +178,12 @@ class TestNovaAPIExceptions(unittest.TestCase):
         """Test Nova login with discovery failure."""
         from keystoneauth1.exceptions.discovery import DiscoveryFailure
 
-        with patch('instanceha.loading.get_plugin_loader') as mock_loader:
+        with patch('keystoneauth1.loading.get_plugin_loader') as mock_loader:
             mock_auth = Mock()
             mock_loader.return_value.load_from_options.return_value = mock_auth
 
-            with patch('instanceha.ksc_session.Session') as mock_session:
-                with patch('instanceha.client.Client') as mock_client:
+            with patch('keystoneauth1.session.Session') as mock_session:
+                with patch('novaclient.client.Client') as mock_client:
                     mock_nova = Mock()
                     mock_nova.versions.get_current.side_effect = DiscoveryFailure('Discovery failed')
                     mock_client.return_value = mock_nova
@@ -200,12 +200,12 @@ class TestNovaAPIExceptions(unittest.TestCase):
         """Test Nova login with unauthorized exception."""
         from novaclient.exceptions import Unauthorized
 
-        with patch('instanceha.loading.get_plugin_loader') as mock_loader:
+        with patch('keystoneauth1.loading.get_plugin_loader') as mock_loader:
             mock_auth = Mock()
             mock_loader.return_value.load_from_options.return_value = mock_auth
 
-            with patch('instanceha.ksc_session.Session') as mock_session:
-                with patch('instanceha.client.Client') as mock_client:
+            with patch('keystoneauth1.session.Session') as mock_session:
+                with patch('novaclient.client.Client') as mock_client:
                     mock_nova = Mock()
                     mock_nova.versions.get_current.side_effect = Unauthorized('Bad credentials')
                     mock_client.return_value = mock_nova

--- a/test/instanceha/test_evacuation_workflow.py
+++ b/test/instanceha/test_evacuation_workflow.py
@@ -13,6 +13,7 @@ from unittest.mock import Mock, patch, MagicMock
 from datetime import datetime
 
 import conftest  # noqa: F401
+from conftest import patch_pipeline
 import instanceha
 
 
@@ -37,75 +38,40 @@ class TestKdumpResumeDisableLogic(unittest.TestCase):
 
     def test_resume_with_already_disabled_service_skips_disable(self):
         """Test that resume=True with already disabled service skips _host_disable."""
-        # Set up service as already disabled and forced down (previous evacuation attempt)
         self.mock_failed_service.forced_down = True
         self.mock_failed_service.status = 'disabled'
 
-        with patch('instanceha._get_nova_connection', return_value=self.mock_conn):
-            with patch('instanceha._host_fence', return_value=True):
-                with patch('instanceha._host_disable') as mock_disable:
-                    with patch('instanceha._manage_reserved_hosts', return_value=instanceha.ReservedHostResult(success=True, hostname=None)):
-                        with patch('instanceha._host_evacuate', return_value=True):
-                            with patch('instanceha._post_evacuation_recovery', return_value=True):
-                                with patch('instanceha.track_host_processing'):
-                                    result = instanceha.process_service(
-                                        self.mock_failed_service,
-                                        [],
-                                        resume=True,
-                                        service=self.mock_service
-                                    )
+        with patch_pipeline(conn=self.mock_conn) as mocks:
+            result = instanceha.process_service(
+                self.mock_failed_service, [], resume=True, service=self.mock_service)
 
-        # Should succeed without calling _host_disable
         self.assertTrue(result)
-        mock_disable.assert_not_called()
+        mocks['disable'].assert_not_called()
 
     def test_resume_with_kdump_fenced_calls_disable(self):
         """Test that kdump-fenced hosts with resume=True still call _host_disable."""
-        # Kdump-fenced hosts use resume=True but are NOT yet disabled
         self.mock_failed_service.forced_down = False
         self.mock_failed_service.status = 'enabled'
         self.mock_service.kdump_fenced_hosts.add('test-host')
 
-        with patch('instanceha._get_nova_connection', return_value=self.mock_conn):
-            with patch('instanceha._host_fence', return_value=True):
-                with patch('instanceha._host_disable', return_value=True) as mock_disable:
-                    with patch('instanceha._manage_reserved_hosts', return_value=instanceha.ReservedHostResult(success=True, hostname=None)):
-                        with patch('instanceha._host_evacuate', return_value=True):
-                            with patch('instanceha._post_evacuation_recovery', return_value=True):
-                                with patch('instanceha.track_host_processing'):
-                                    result = instanceha.process_service(
-                                        self.mock_failed_service,
-                                        [],
-                                        resume=True,
-                                        service=self.mock_service
-                                    )
+        with patch_pipeline(conn=self.mock_conn) as mocks:
+            result = instanceha.process_service(
+                self.mock_failed_service, [], resume=True, service=self.mock_service)
 
-        # Should succeed and call _host_disable
         self.assertTrue(result)
-        mock_disable.assert_called_once()
+        mocks['disable'].assert_called_once()
 
     def test_new_evacuation_calls_disable(self):
         """Test that new evacuation (resume=False) always calls _host_disable."""
         self.mock_failed_service.forced_down = False
         self.mock_failed_service.status = 'enabled'
 
-        with patch('instanceha._get_nova_connection', return_value=self.mock_conn):
-            with patch('instanceha._host_fence', return_value=True):
-                with patch('instanceha._host_disable', return_value=True) as mock_disable:
-                    with patch('instanceha._manage_reserved_hosts', return_value=instanceha.ReservedHostResult(success=True, hostname=None)):
-                        with patch('instanceha._host_evacuate', return_value=True):
-                            with patch('instanceha._post_evacuation_recovery', return_value=True):
-                                with patch('instanceha.track_host_processing'):
-                                    result = instanceha.process_service(
-                                        self.mock_failed_service,
-                                        [],
-                                        resume=False,
-                                        service=self.mock_service
-                                    )
+        with patch_pipeline(conn=self.mock_conn) as mocks:
+            result = instanceha.process_service(
+                self.mock_failed_service, [], resume=False, service=self.mock_service)
 
-        # Should succeed and call _host_disable
         self.assertTrue(result)
-        mock_disable.assert_called_once()
+        mocks['disable'].assert_called_once()
 
 
 class TestPostEvacuationRecoveryErrors(unittest.TestCase):
@@ -135,7 +101,6 @@ class TestPostEvacuationRecoveryErrors(unittest.TestCase):
                 resume=False
             )
 
-        # Should fail when power-on fails
         self.assertFalse(result)
         mock_fence.assert_called_once_with(self.mock_failed_service.host, 'on', self.mock_service)
 
@@ -151,12 +116,10 @@ class TestPostEvacuationRecoveryErrors(unittest.TestCase):
                 resume=False
             )
 
-        # Should succeed even if disable reason update fails (non-critical)
         self.assertTrue(result)
 
     def test_recovery_unexpected_exception(self):
         """Test recovery handles unexpected exceptions."""
-        # Cause exception during power-on by making fence raise unexpected error
         with patch('instanceha._host_fence', side_effect=RuntimeError('Unexpected error')):
             result = instanceha._post_evacuation_recovery(
                 self.mock_conn,
@@ -165,7 +128,6 @@ class TestPostEvacuationRecoveryErrors(unittest.TestCase):
                 resume=False
             )
 
-        # Should fail on unexpected exception
         self.assertFalse(result)
 
 
@@ -188,118 +150,59 @@ class TestProcessServiceStepFailures(unittest.TestCase):
 
     def test_fencing_step_failure_stops_processing(self):
         """Test that fencing failure stops processing immediately."""
-        with patch('instanceha._get_nova_connection', return_value=self.mock_conn):
-            with patch('instanceha._host_fence', return_value=False) as mock_fence:
-                with patch('instanceha._host_disable') as mock_disable:
-                    with patch('instanceha.track_host_processing'):
-                        result = instanceha.process_service(
-                            self.mock_failed_service,
-                            [],
-                            resume=False,
-                            service=self.mock_service
-                        )
+        with patch_pipeline(conn=self.mock_conn, fence=False) as mocks:
+            result = instanceha.process_service(
+                self.mock_failed_service, [], resume=False, service=self.mock_service)
 
-        # Should fail and not proceed to disable step
         self.assertFalse(result)
-        mock_fence.assert_called_once()
-        mock_disable.assert_not_called()
+        mocks['fence'].assert_called_once()
+        mocks['disable'].assert_not_called()
 
     def test_disable_step_failure_stops_processing(self):
         """Test that disable failure stops processing immediately."""
-        with patch('instanceha._get_nova_connection', return_value=self.mock_conn):
-            with patch('instanceha._host_fence', return_value=True):
-                with patch('instanceha._host_disable', return_value=False) as mock_disable:
-                    with patch('instanceha._manage_reserved_hosts') as mock_reserved:
-                        with patch('instanceha.track_host_processing'):
-                            result = instanceha.process_service(
-                                self.mock_failed_service,
-                                [],
-                                resume=False,
-                                service=self.mock_service
-                            )
+        with patch_pipeline(conn=self.mock_conn, disable=False) as mocks:
+            result = instanceha.process_service(
+                self.mock_failed_service, [], resume=False, service=self.mock_service)
 
-        # Should fail and not proceed to reserved hosts step
         self.assertFalse(result)
-        mock_disable.assert_called_once()
-        mock_reserved.assert_not_called()
+        mocks['disable'].assert_called_once()
+        mocks['reserved'].assert_not_called()
 
     def test_reserved_hosts_step_failure_stops_processing(self):
         """Test that reserved hosts failure stops processing immediately."""
-        with patch('instanceha._get_nova_connection', return_value=self.mock_conn):
-            with patch('instanceha._host_fence', return_value=True):
-                with patch('instanceha._host_disable', return_value=True):
-                    with patch('instanceha._manage_reserved_hosts', return_value=(False, None)) as mock_reserved:
-                        with patch('instanceha._host_evacuate') as mock_evacuate:
-                            with patch('instanceha.track_host_processing'):
-                                result = instanceha.process_service(
-                                    self.mock_failed_service,
-                                    [],
-                                    resume=False,
-                                    service=self.mock_service
-                                )
+        with patch_pipeline(conn=self.mock_conn,
+                            reserved=instanceha.ReservedHostResult(success=False, hostname=None)) as mocks:
+            result = instanceha.process_service(
+                self.mock_failed_service, [], resume=False, service=self.mock_service)
 
-        # Should fail and not proceed to evacuation step
         self.assertFalse(result)
-        mock_reserved.assert_called_once()
-        mock_evacuate.assert_not_called()
+        mocks['reserved'].assert_called_once()
+        mocks['evacuate'].assert_not_called()
 
     def test_evacuation_step_failure_stops_processing(self):
         """Test that evacuation failure stops processing immediately."""
-        with patch('instanceha._get_nova_connection', return_value=self.mock_conn):
-            with patch('instanceha._host_fence', return_value=True):
-                with patch('instanceha._host_disable', return_value=True):
-                    with patch('instanceha._manage_reserved_hosts', return_value=instanceha.ReservedHostResult(success=True, hostname=None)):
-                        with patch('instanceha._host_evacuate', return_value=False) as mock_evacuate:
-                            with patch('instanceha._post_evacuation_recovery') as mock_recovery:
-                                with patch('instanceha.track_host_processing'):
-                                    result = instanceha.process_service(
-                                        self.mock_failed_service,
-                                        [],
-                                        resume=False,
-                                        service=self.mock_service
-                                    )
+        with patch_pipeline(conn=self.mock_conn, evacuate=False) as mocks:
+            result = instanceha.process_service(
+                self.mock_failed_service, [], resume=False, service=self.mock_service)
 
-        # Should fail and not proceed to recovery step
         self.assertFalse(result)
-        mock_evacuate.assert_called_once()
-        mock_recovery.assert_not_called()
+        mocks['evacuate'].assert_called_once()
+        mocks['recovery'].assert_not_called()
 
     def test_recovery_step_failure_stops_processing(self):
         """Test that recovery failure stops processing immediately."""
-        with patch('instanceha._get_nova_connection', return_value=self.mock_conn):
-            with patch('instanceha._host_fence', return_value=True):
-                with patch('instanceha._host_disable', return_value=True):
-                    with patch('instanceha._manage_reserved_hosts', return_value=instanceha.ReservedHostResult(success=True, hostname=None)):
-                        with patch('instanceha._host_evacuate', return_value=True):
-                            with patch('instanceha._post_evacuation_recovery', return_value=False):
-                                with patch('instanceha.track_host_processing'):
-                                    result = instanceha.process_service(
-                                        self.mock_failed_service,
-                                        [],
-                                        resume=False,
-                                        service=self.mock_service
-                                    )
+        with patch_pipeline(conn=self.mock_conn, recovery=False) as mocks:
+            result = instanceha.process_service(
+                self.mock_failed_service, [], resume=False, service=self.mock_service)
 
-        # Should fail when recovery fails
         self.assertFalse(result)
 
     def test_all_steps_succeed(self):
         """Test that all steps succeeding results in success."""
-        with patch('instanceha._get_nova_connection', return_value=self.mock_conn):
-            with patch('instanceha._host_fence', return_value=True):
-                with patch('instanceha._host_disable', return_value=True):
-                    with patch('instanceha._manage_reserved_hosts', return_value=instanceha.ReservedHostResult(success=True, hostname=None)):
-                        with patch('instanceha._host_evacuate', return_value=True):
-                            with patch('instanceha._post_evacuation_recovery', return_value=True):
-                                with patch('instanceha.track_host_processing'):
-                                    result = instanceha.process_service(
-                                        self.mock_failed_service,
-                                        [],
-                                        resume=False,
-                                        service=self.mock_service
-                                    )
+        with patch_pipeline(conn=self.mock_conn) as mocks:
+            result = instanceha.process_service(
+                self.mock_failed_service, [], resume=False, service=self.mock_service)
 
-        # Should succeed when all steps succeed
         self.assertTrue(result)
 
 
@@ -330,14 +233,9 @@ class TestReservedHostReturnOnPartialFailure(unittest.TestCase):
         vms_on_target = [Mock(id='vm-1'), Mock(id='vm-2')]
         self.mock_conn.servers.list.return_value = vms_on_target
 
-        with patch('instanceha._get_nova_connection', return_value=self.mock_conn), \
-             patch('instanceha._host_fence', return_value=True), \
-             patch('instanceha._host_disable', return_value=True), \
-             patch('instanceha._manage_reserved_hosts',
-                   return_value=instanceha.ReservedHostResult(success=True, hostname='compute-b')), \
-             patch('instanceha._host_evacuate', return_value=False), \
-             patch('instanceha._return_reserved_host') as mock_return, \
-             patch('instanceha.track_host_processing'):
+        with patch_pipeline(conn=self.mock_conn, evacuate=False,
+                            reserved=instanceha.ReservedHostResult(success=True, hostname='compute-b')) as mocks, \
+             patch('instanceha._return_reserved_host') as mock_return:
             result = instanceha.process_service(
                 self.mock_failed_service, [], resume=False, service=self.mock_service)
 
@@ -350,14 +248,9 @@ class TestReservedHostReturnOnPartialFailure(unittest.TestCase):
         """Reserved host with no VMs should be returned to pool."""
         self.mock_conn.servers.list.return_value = []
 
-        with patch('instanceha._get_nova_connection', return_value=self.mock_conn), \
-             patch('instanceha._host_fence', return_value=True), \
-             patch('instanceha._host_disable', return_value=True), \
-             patch('instanceha._manage_reserved_hosts',
-                   return_value=instanceha.ReservedHostResult(success=True, hostname='compute-b')), \
-             patch('instanceha._host_evacuate', return_value=False), \
-             patch('instanceha._return_reserved_host') as mock_return, \
-             patch('instanceha.track_host_processing'):
+        with patch_pipeline(conn=self.mock_conn, evacuate=False,
+                            reserved=instanceha.ReservedHostResult(success=True, hostname='compute-b')) as mocks, \
+             patch('instanceha._return_reserved_host') as mock_return:
             result = instanceha.process_service(
                 self.mock_failed_service, [], resume=False, service=self.mock_service)
 
@@ -368,14 +261,9 @@ class TestReservedHostReturnOnPartialFailure(unittest.TestCase):
         """If VM check fails, err on safe side and keep reserved host."""
         self.mock_conn.servers.list.side_effect = Exception("Nova API error")
 
-        with patch('instanceha._get_nova_connection', return_value=self.mock_conn), \
-             patch('instanceha._host_fence', return_value=True), \
-             patch('instanceha._host_disable', return_value=True), \
-             patch('instanceha._manage_reserved_hosts',
-                   return_value=instanceha.ReservedHostResult(success=True, hostname='compute-b')), \
-             patch('instanceha._host_evacuate', return_value=False), \
-             patch('instanceha._return_reserved_host') as mock_return, \
-             patch('instanceha.track_host_processing'):
+        with patch_pipeline(conn=self.mock_conn, evacuate=False,
+                            reserved=instanceha.ReservedHostResult(success=True, hostname='compute-b')) as mocks, \
+             patch('instanceha._return_reserved_host') as mock_return:
             result = instanceha.process_service(
                 self.mock_failed_service, [], resume=False, service=self.mock_service)
 

--- a/test/instanceha/test_k8s_partition.py
+++ b/test/instanceha/test_k8s_partition.py
@@ -77,7 +77,7 @@ class TestK8sHealthCheckThread(unittest.TestCase):
         self.service = instanceha.InstanceHAService(self.config)
 
     def test_initial_state(self):
-        self.assertFalse(self.service.k8s_api_reachable)
+        self.assertTrue(self.service.k8s_api_reachable)
 
     @patch('instanceha._check_k8s_api_reachable', return_value=True)
     def test_stays_reachable_on_success(self, _check):

--- a/test/instanceha/test_unit_core.py
+++ b/test/instanceha/test_unit_core.py
@@ -610,18 +610,14 @@ class TestEvacuationFunctions(unittest.TestCase):
 
     def test_server_evacuate_exception(self):
         """Test server evacuation with exception."""
-        # Mock the exception class
-        class MockNotFound(Exception):
-            pass
+        from novaclient.exceptions import NotFound
 
-        # Patch the module to use our mock exception
-        with patch('instanceha.NotFound', MockNotFound):
-            self.mock_connection.servers.evacuate.side_effect = MockNotFound('Server not found')
+        self.mock_connection.servers.evacuate.side_effect = NotFound('Server not found')
 
-            result = instanceha._server_evacuate(self.mock_connection, 'server-123')
+        result = instanceha._server_evacuate(self.mock_connection, 'server-123')
 
-            self.assertFalse(result.accepted)
-            self.assertIn('not found', result.reason)
+        self.assertFalse(result.accepted)
+        self.assertIn('not found', result.reason)
 
     def test_host_disable_success(self):
         """Test successful host disable operation."""
@@ -634,18 +630,14 @@ class TestEvacuationFunctions(unittest.TestCase):
 
     def test_host_disable_force_down_failure(self):
         """Test host disable when force_down fails."""
-        # Mock the exception class
-        class MockNotFound(Exception):
-            pass
+        from novaclient.exceptions import NotFound
 
-        with patch('instanceha.NotFound', MockNotFound):
-            self.mock_connection.services.force_down.side_effect = MockNotFound('Service not found')
+        self.mock_connection.services.force_down.side_effect = NotFound('Service not found')
 
-            result = instanceha._host_disable(self.mock_connection, self.mock_service)
-            self.assertFalse(result)
+        result = instanceha._host_disable(self.mock_connection, self.mock_service)
+        self.assertFalse(result)
 
-            # disable_log_reason should not be called if force_down fails
-            self.mock_connection.services.disable_log_reason.assert_not_called()
+        self.mock_connection.services.disable_log_reason.assert_not_called()
 
     @patch('time.sleep')
     def test_server_evacuation_status(self, mock_sleep):
@@ -727,79 +719,45 @@ class TestEvacuationFunctions(unittest.TestCase):
 
     def test_host_disable_log_reason_fails_non_critical(self):
         """Test that disable_log_reason failure is handled gracefully."""
-        # disable_log_reason fails
         self.mock_connection.services.disable_log_reason.side_effect = Exception("Logging failed")
 
-        # Mock NotFound and Conflict to avoid isinstance issues
-        class MockNotFound(Exception):
-            pass
-        class MockConflict(Exception):
-            pass
+        result = instanceha._host_disable(self.mock_connection, self.mock_service)
 
-        with patch('instanceha.NotFound', MockNotFound), \
-             patch('instanceha.Conflict', MockConflict):
-            result = instanceha._host_disable(self.mock_connection, self.mock_service)
-
-            # Should return False but service is still forced down
-            self.assertFalse(result)
-            self.mock_connection.services.force_down.assert_called_once()
-            self.mock_connection.services.disable_log_reason.assert_called_once()
+        self.assertFalse(result)
+        self.mock_connection.services.force_down.assert_called_once()
+        self.mock_connection.services.disable_log_reason.assert_called_once()
 
     def test_handle_nova_exception_notfound(self):
         """Test handling NotFound exception."""
-        class MockNotFound(Exception):
-            pass
+        from novaclient.exceptions import NotFound
 
-        with patch('instanceha.NotFound', MockNotFound):
-            result = instanceha._handle_nova_exception(
-                "test operation", "test-service", MockNotFound("Not found"), is_critical=True
-            )
-            self.assertFalse(result)
+        result = instanceha._handle_nova_exception(
+            "test operation", "test-service", NotFound("Not found"), is_critical=True
+        )
+        self.assertFalse(result)
 
     def test_handle_nova_exception_conflict(self):
         """Test handling Conflict exception."""
-        class MockNotFound(Exception):
-            pass
-        class MockConflict(Exception):
-            pass
+        from novaclient.exceptions import Conflict
 
-        # Patch both NotFound and Conflict to avoid isinstance issues
-        with patch('instanceha.NotFound', MockNotFound), \
-             patch('instanceha.Conflict', MockConflict):
-            result = instanceha._handle_nova_exception(
-                "test operation", "test-service", MockConflict("Conflict"), is_critical=True
-            )
-            self.assertFalse(result)
+        result = instanceha._handle_nova_exception(
+            "test operation", "test-service", Conflict("Conflict"), is_critical=True
+        )
+        self.assertFalse(result)
 
     def test_handle_nova_exception_generic(self):
         """Test handling generic exception."""
-        # Mock NotFound and Conflict to avoid isinstance issues
-        class MockNotFound(Exception):
-            pass
-        class MockConflict(Exception):
-            pass
-
-        with patch('instanceha.NotFound', MockNotFound), \
-             patch('instanceha.Conflict', MockConflict):
-            result = instanceha._handle_nova_exception(
-                "test operation", "test-service", Exception("Generic error"), is_critical=True
-            )
-            self.assertFalse(result)
+        result = instanceha._handle_nova_exception(
+            "test operation", "test-service", Exception("Generic error"), is_critical=True
+        )
+        self.assertFalse(result)
 
     def test_handle_nova_exception_non_critical(self):
         """Test handling non-critical exception (should log warning)."""
-        # Mock NotFound and Conflict to avoid isinstance issues
-        class MockNotFound(Exception):
-            pass
-        class MockConflict(Exception):
-            pass
-
-        with patch('instanceha.NotFound', MockNotFound), \
-             patch('instanceha.Conflict', MockConflict):
-            result = instanceha._handle_nova_exception(
-                "test operation", "test-service", Exception("Error"), is_critical=False
-            )
-            self.assertFalse(result)
+        result = instanceha._handle_nova_exception(
+            "test operation", "test-service", Exception("Error"), is_critical=False
+        )
+        self.assertFalse(result)
 
     def test_update_service_disable_reason_with_id(self):
         """Test updating disable reason with provided service ID."""
@@ -1436,17 +1394,10 @@ class TestSecretExposure(unittest.TestCase):
         test_password = 'super_secret_openstack_password_123'
         test_username = 'test_os_user'
 
-        # Mock exception classes to be proper exceptions
-        class MockDiscoveryFailure(Exception):
-            pass
-        class MockUnauthorized(Exception):
-            pass
+        from keystoneauth1.exceptions.discovery import DiscoveryFailure
 
-        # Mock keystoneauth1 to raise an exception
-        with patch('instanceha.loading.get_plugin_loader') as mock_loader, \
-             patch('instanceha.DiscoveryFailure', MockDiscoveryFailure), \
-             patch('instanceha.Unauthorized', MockUnauthorized):
-            mock_loader.side_effect = MockDiscoveryFailure("Connection failed: password=invalid")
+        with patch('keystoneauth1.loading.get_plugin_loader') as mock_loader:
+            mock_loader.side_effect = DiscoveryFailure("Connection failed: password=invalid")
 
             # Try to login - should not expose password
             credentials = instanceha.NovaLoginCredentials(
@@ -1596,18 +1547,9 @@ class TestSecretExposure(unittest.TestCase):
         self.log_capture.seek(0)
         self.log_capture.truncate(0)
 
-        # Create exception that might contain sensitive info
         test_exception = Exception("Auth failed: password=secret123")
 
-        # Mock NotFound and Conflict to avoid isinstance issues
-        class MockNotFound(Exception):
-            pass
-        class MockConflict(Exception):
-            pass
-
-        with patch('instanceha.NotFound', MockNotFound), \
-             patch('instanceha.Conflict', MockConflict):
-            instanceha._handle_nova_exception("test_operation", "test_service", test_exception)
+        instanceha._handle_nova_exception("test_operation", "test_service", test_exception)
 
         self._assert_no_secrets_in_logs()
 


### PR DESCRIPTION
This PR consists of three commits:

**Commit 1: Lazy-import novaclient and keystoneauth1 SDK modules**

Move novaclient and keystoneauth1 imports from module level into the functions that use them (nova_login, _server_evacuate, _handle_nova_exception, main). 
Eliminates ~135 lines of mock exception boilerplate across 4 test files. 
Add shared patch_pipeline() fixture in conftest.py replacing 7-deep nested patch blocks in process_service tests. 
Bind conftest sys.modules submodule mocks to parent mock attributes so lazy imports and patch() targets resolve to the same objects.

**Commit 2: Remove dead code and consolidate redundant patterns**

Remove MigrationStatus enum (inline strings), dead _previous_hash state, unreachable VALIDATION_PATTERNS entries, unused _check_critical_services params, redundant validate_input in _host_fence, single-use _cleanup_dict_by_condition helper, and redundant requests.exceptions import. 
Consolidate 5 manual error+traceback log pairs into _safe_log_exception calls. 
Deduplicate _get_nova_connection by delegating to _establish_nova_connection.

**Commit 3: Fix fail-open startup, fencing decision log, and document safety model**

Initialize k8s_api_reachable=True (fail-open) to prevent startup deadlock where fencing was silently blocked until the background health check thread completed its first probe. 
Initialize K8S_API_REACHABLE Prometheus gauge to 1 to match. 
Emit fencing decision log line before early return so cliff-detection and all-heartbeat-alive cases are logged. 
Warn at startup when CHECK_HEARTBEAT is disabled. 
Add Fencing Safety Model section to architecture doc covering gate chain, fail-open/fail-closed semantics, startup race window trade-off, and MedIK8s/InstanceHA responsibility boundary.
