### PR TITLE
Propagate RabbitMQ LoadBalancerClass override

### DIFF
--- a/internal/rabbitmq/service.go
+++ b/internal/rabbitmq/service.go
@@ -26,6 +26,14 @@ func serviceOverrideIPFamilyPolicy(r *rabbitmqv1.RabbitMq) *corev1.IPFamilyPolic
 	return nil
 }
 
+// serviceOverrideLoadBalancerClass returns the LoadBalancerClass from override, or nil
+func serviceOverrideLoadBalancerClass(r *rabbitmqv1.RabbitMq) *string {
+	if r.Spec.Override.Service != nil && r.Spec.Override.Service.Spec != nil {
+		return r.Spec.Override.Service.Spec.LoadBalancerClass
+	}
+	return nil
+}
+
 const (
 	// AMQPPort is the standard AMQP port
 	AMQPPort = 5672
@@ -150,6 +158,9 @@ func ClientService(r *rabbitmqv1.RabbitMq) *corev1.Service {
 	// Apply IPFamilyPolicy from override if specified
 	if ipfp := serviceOverrideIPFamilyPolicy(r); ipfp != nil {
 		svc.Spec.IPFamilyPolicy = ipfp
+	}
+	if lbClass := serviceOverrideLoadBalancerClass(r); lbClass != nil {
+		svc.Spec.LoadBalancerClass = lbClass
 	}
 
 	return svc

--- a/internal/rabbitmq/service_test.go
+++ b/internal/rabbitmq/service_test.go
@@ -1,0 +1,67 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rabbitmq
+
+import (
+	"testing"
+
+	rabbitmqv1 "github.com/openstack-k8s-operators/infra-operator/apis/rabbitmq/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestClientServiceLoadBalancerClassOverride(t *testing.T) {
+	lbClass := "metallb.io/metallb"
+
+	r := &rabbitmqv1.RabbitMq{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rabbitmq",
+			Namespace: "openstack",
+		},
+		Spec: rabbitmqv1.RabbitMqSpec{
+			RabbitMqSpecCore: rabbitmqv1.RabbitMqSpecCore{
+				Override: rabbitmqv1.RabbitMQOverrideSpec{
+					Service: &rabbitmqv1.RabbitMQServiceOverride{
+						Spec: &corev1.ServiceSpec{
+							Type:              corev1.ServiceTypeLoadBalancer,
+							LoadBalancerClass: &lbClass,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	svc := ClientService(r)
+
+	if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		t.Fatalf(
+			"expected service type %q, got %q",
+			corev1.ServiceTypeLoadBalancer,
+			svc.Spec.Type,
+		)
+	}
+
+	// FIXME: This documents the current bug. The RabbitMq CRD accepts
+	// override.service.spec.loadBalancerClass, but ClientService does not
+	// propagate it to the generated Service. The fix should update this
+	// assertion to require svc.Spec.LoadBalancerClass to equal lbClass.
+	if svc.Spec.LoadBalancerClass != nil {
+		t.Fatalf(
+			"expected loadBalancerClass to be unset for current broken behavior, got %q",
+			*svc.Spec.LoadBalancerClass,
+		)
+	}
+}

--- a/internal/rabbitmq/service_test.go
+++ b/internal/rabbitmq/service_test.go
@@ -54,13 +54,13 @@ func TestClientServiceLoadBalancerClassOverride(t *testing.T) {
 		)
 	}
 
-	// FIXME: This documents the current bug. The RabbitMq CRD accepts
-	// override.service.spec.loadBalancerClass, but ClientService does not
-	// propagate it to the generated Service. The fix should update this
-	// assertion to require svc.Spec.LoadBalancerClass to equal lbClass.
-	if svc.Spec.LoadBalancerClass != nil {
+	if svc.Spec.LoadBalancerClass == nil {
+		t.Fatal("expected loadBalancerClass override to be propagated, got nil")
+	}
+	if *svc.Spec.LoadBalancerClass != lbClass {
 		t.Fatalf(
-			"expected loadBalancerClass to be unset for current broken behavior, got %q",
+			"expected loadBalancerClass %q, got %q",
+			lbClass,
 			*svc.Spec.LoadBalancerClass,
 		)
 	}


### PR DESCRIPTION
RabbitMq service overrides accept spec.loadBalancerClass, but the
client-facing Service renderer did not propagate it to the generated
Service.

On MicroShift, unclassed LoadBalancer Services can be claimed by the
built-in LoadBalancer controller, causing RabbitMQ DNS data to expose the
node IP instead of the MetalLB VIP expected by dataplane nodes.

This PR keeps the two-commit green-green flow:
- document the existing behavior with a FIXME unit test
- propagate loadBalancerClass and flip the assertion

Validation:
- go test ./internal/rabbitmq -count=1

Closes: [OSPRH-30887](https://redhat.atlassian.net/browse/OSPRH-30887)


