### PR TITLE
Propagate RabbitMQ service overrides via strategic merge

### DIFF
--- a/internal/controller/rabbitmq/rabbitmq_controller.go
+++ b/internal/controller/rabbitmq/rabbitmq_controller.go
@@ -632,15 +632,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 		},
 	}
 	hsop, err := controllerutil.CreateOrPatch(ctx, r.Client, headlessSvc, func() error {
-		desired := rabbitmq.HeadlessService(instance)
-		headlessSvc.Spec.ClusterIP = desired.Spec.ClusterIP
-		headlessSvc.Spec.PublishNotReadyAddresses = desired.Spec.PublishNotReadyAddresses
-		mergeServicePorts(&headlessSvc.Spec.Ports, desired.Spec.Ports)
-		headlessSvc.Spec.Selector = desired.Spec.Selector
-		headlessSvc.Labels = desired.Labels
-		if desired.Spec.IPFamilyPolicy != nil {
-			headlessSvc.Spec.IPFamilyPolicy = desired.Spec.IPFamilyPolicy
+		desired, err := rabbitmq.HeadlessService(instance)
+		if err != nil {
+			return err
 		}
+		savedPorts := headlessSvc.Spec.Ports
+		headlessSvc.Spec = desired.Spec
+		mergeServicePorts(&savedPorts, desired.Spec.Ports)
+		headlessSvc.Spec.Ports = savedPorts
+		headlessSvc.Labels = desired.Labels
+		headlessSvc.Annotations = util.MergeStringMaps(desired.Annotations, headlessSvc.Annotations)
 		return r.setOwnership(headlessSvc, instance, isMigration)
 	})
 	if err != nil {
@@ -658,18 +659,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 		},
 	}
 	csop, err := controllerutil.CreateOrPatch(ctx, r.Client, clientSvc, func() error {
-		desired := rabbitmq.ClientService(instance)
-		mergeServicePorts(&clientSvc.Spec.Ports, desired.Spec.Ports)
-		clientSvc.Spec.Selector = desired.Spec.Selector
-		clientSvc.Spec.Type = desired.Spec.Type
+		desired, err := rabbitmq.ClientService(instance)
+		if err != nil {
+			return err
+		}
+		savedPorts := clientSvc.Spec.Ports
+		clientSvc.Spec = desired.Spec
+		mergeServicePorts(&savedPorts, desired.Spec.Ports)
+		clientSvc.Spec.Ports = savedPorts
 		// Merge annotations: set our desired ones without removing externally-added
 		// annotations (e.g. from MetalLB) to avoid reconcile loops
-		if clientSvc.Annotations == nil {
-			clientSvc.Annotations = map[string]string{}
-		}
-		for k, v := range desired.Annotations {
-			clientSvc.Annotations[k] = v
-		}
+		clientSvc.Annotations = util.MergeStringMaps(desired.Annotations, clientSvc.Annotations)
 		clientSvc.Labels = desired.Labels
 		return r.setOwnership(clientSvc, instance, isMigration)
 	})

--- a/internal/rabbitmq/service.go
+++ b/internal/rabbitmq/service.go
@@ -1,27 +1,57 @@
 package rabbitmq
 
 import (
+	"encoding/json"
 	"fmt"
 
 	rabbitmqv1 "github.com/openstack-k8s-operators/infra-operator/apis/rabbitmq/v1beta1"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/utils/ptr"
 )
 
-// serviceOverrideType returns the service type from override, or empty string
-func serviceOverrideType(r *rabbitmqv1.RabbitMq) corev1.ServiceType {
-	if r.Spec.Override.Service != nil && r.Spec.Override.Service.Spec != nil {
-		return r.Spec.Override.Service.Spec.Type
+// applyServiceOverride applies override metadata and spec fields to a Service.
+// The full corev1.ServiceSpec override is converted to lib-common's restricted
+// service.OverrideServiceSpec before merging via strategic merge patch, so only
+// the whitelisted fields are applied and unsafe fields like Selector, Ports, or
+// ClusterIP cannot be overridden.
+func applyServiceOverride(svc *corev1.Service, override *rabbitmqv1.RabbitMQServiceOverride) error {
+	if override == nil {
+		return nil
 	}
-	return ""
-}
+	if override.EmbeddedLabelsAnnotations != nil {
+		svc.Labels = util.MergeStringMaps(override.Labels, svc.Labels)
+		svc.Annotations = util.MergeStringMaps(override.Annotations, svc.Annotations)
+	}
+	if override.Spec != nil {
+		overrideSpecJSON, err := json.Marshal(override.Spec)
+		if err != nil {
+			return fmt.Errorf("error marshalling service override spec: %w", err)
+		}
+		whitelisted := &service.OverrideServiceSpec{}
+		if err := json.Unmarshal(overrideSpecJSON, whitelisted); err != nil {
+			return fmt.Errorf("error converting to OverrideServiceSpec: %w", err)
+		}
 
-// serviceOverrideIPFamilyPolicy returns the IPFamilyPolicy from override, or nil
-func serviceOverrideIPFamilyPolicy(r *rabbitmqv1.RabbitMq) *corev1.IPFamilyPolicy {
-	if r.Spec.Override.Service != nil && r.Spec.Override.Service.Spec != nil {
-		return r.Spec.Override.Service.Spec.IPFamilyPolicy
+		originalJSON, err := json.Marshal(svc.Spec)
+		if err != nil {
+			return fmt.Errorf("error marshalling service spec: %w", err)
+		}
+		patchJSON, err := json.Marshal(whitelisted)
+		if err != nil {
+			return fmt.Errorf("error marshalling override patch: %w", err)
+		}
+		patchedJSON, err := strategicpatch.StrategicMergePatch(originalJSON, patchJSON, corev1.ServiceSpec{})
+		if err != nil {
+			return fmt.Errorf("error applying service spec override: %w", err)
+		}
+		if err := json.Unmarshal(patchedJSON, &svc.Spec); err != nil {
+			return fmt.Errorf("error unmarshalling patched service spec: %w", err)
+		}
 	}
 	return nil
 }
@@ -64,7 +94,7 @@ const (
 
 // HeadlessService creates the headless service for StatefulSet pod DNS
 // matching the old rabbitmq-cluster-operator layout
-func HeadlessService(r *rabbitmqv1.RabbitMq) *corev1.Service {
+func HeadlessService(r *rabbitmqv1.RabbitMq) (*corev1.Service, error) {
 	ls := CommonLabels(r.Name)
 	selector := SelectorLabels(r.Name)
 
@@ -98,61 +128,57 @@ func HeadlessService(r *rabbitmqv1.RabbitMq) *corev1.Service {
 		},
 	}
 
-	// Apply override settings if specified
-	if ipfp := serviceOverrideIPFamilyPolicy(r); ipfp != nil {
-		svc.Spec.IPFamilyPolicy = ipfp
+	if override := r.Spec.Override.Service; override != nil {
+		if override.EmbeddedLabelsAnnotations != nil {
+			svc.Labels = util.MergeStringMaps(override.Labels, svc.Labels)
+			svc.Annotations = util.MergeStringMaps(override.Annotations, svc.Annotations)
+		}
+		// Only IPFamilyPolicy is applicable to headless services — other spec
+		// fields (Type, ExternalTrafficPolicy, LoadBalancerClass, etc.) are
+		// either invalid or meaningless for ClusterIP/None services.
+		if override.Spec != nil && override.Spec.IPFamilyPolicy != nil {
+			svc.Spec.IPFamilyPolicy = override.Spec.IPFamilyPolicy
+		}
 	}
 
-	return svc
+	return svc, nil
 }
 
 // ClientService creates the client-facing service for RabbitMQ
 // matching the old rabbitmq-cluster-operator layout
-func ClientService(r *rabbitmqv1.RabbitMq) *corev1.Service {
+func ClientService(r *rabbitmqv1.RabbitMq) (*corev1.Service, error) {
 	ls := CommonLabels(r.Name)
 	selector := SelectorLabels(r.Name)
 
 	ports := buildClientServicePorts(r)
 
-	serviceType := corev1.ServiceTypeClusterIP
-	annotations := make(map[string]string)
-
-	// Apply override settings if specified
-	if overrideType := serviceOverrideType(r); overrideType != "" {
-		serviceType = overrideType
-	}
-	if r.Spec.Override.Service != nil && r.Spec.Override.Service.EmbeddedLabelsAnnotations != nil {
-		for k, v := range r.Spec.Override.Service.Annotations {
-			annotations[k] = v
-		}
-	}
-
-	if serviceType == corev1.ServiceTypeLoadBalancer {
-		if _, exists := annotations["dnsmasq.network.openstack.org/hostname"]; !exists {
-			annotations["dnsmasq.network.openstack.org/hostname"] = fmt.Sprintf("%s.%s.svc", r.Name, r.Namespace)
-		}
-	}
-
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        r.Name,
-			Namespace:   r.Namespace,
-			Labels:      ls,
-			Annotations: annotations,
+			Name:      r.Name,
+			Namespace: r.Namespace,
+			Labels:    ls,
 		},
 		Spec: corev1.ServiceSpec{
-			Type:     serviceType,
+			Type:     corev1.ServiceTypeClusterIP,
 			Selector: selector,
 			Ports:    ports,
 		},
 	}
 
-	// Apply IPFamilyPolicy from override if specified
-	if ipfp := serviceOverrideIPFamilyPolicy(r); ipfp != nil {
-		svc.Spec.IPFamilyPolicy = ipfp
+	if err := applyServiceOverride(svc, r.Spec.Override.Service); err != nil {
+		return nil, fmt.Errorf("client service override: %w", err)
 	}
 
-	return svc
+	if svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
+		if svc.Annotations == nil {
+			svc.Annotations = make(map[string]string)
+		}
+		if _, exists := svc.Annotations["dnsmasq.network.openstack.org/hostname"]; !exists {
+			svc.Annotations["dnsmasq.network.openstack.org/hostname"] = fmt.Sprintf("%s.%s.svc", r.Name, r.Namespace)
+		}
+	}
+
+	return svc, nil
 }
 
 // buildClientServicePorts builds the list of ports for the client service

--- a/internal/rabbitmq/service_test.go
+++ b/internal/rabbitmq/service_test.go
@@ -1,0 +1,256 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rabbitmq
+
+import (
+	"testing"
+
+	rabbitmqv1 "github.com/openstack-k8s-operators/infra-operator/apis/rabbitmq/v1beta1"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func baseRabbitMq() *rabbitmqv1.RabbitMq {
+	return &rabbitmqv1.RabbitMq{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rabbitmq",
+			Namespace: "openstack",
+		},
+	}
+}
+
+func TestClientServiceNoOverride(t *testing.T) {
+	r := baseRabbitMq()
+
+	svc, err := ClientService(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if svc.Spec.Type != corev1.ServiceTypeClusterIP {
+		t.Fatalf("expected type %q, got %q", corev1.ServiceTypeClusterIP, svc.Spec.Type)
+	}
+	if svc.Spec.LoadBalancerClass != nil {
+		t.Fatalf("expected nil loadBalancerClass, got %q", *svc.Spec.LoadBalancerClass)
+	}
+	if svc.Spec.IPFamilyPolicy != nil {
+		t.Fatalf("expected nil IPFamilyPolicy, got %v", *svc.Spec.IPFamilyPolicy)
+	}
+}
+
+func TestClientServiceLoadBalancerClassOverride(t *testing.T) {
+	lbClass := "metallb.io/metallb"
+
+	r := baseRabbitMq()
+	r.Spec.Override = rabbitmqv1.RabbitMQOverrideSpec{
+		Service: &rabbitmqv1.RabbitMQServiceOverride{
+			Spec: &corev1.ServiceSpec{
+				Type:              corev1.ServiceTypeLoadBalancer,
+				LoadBalancerClass: &lbClass,
+			},
+		},
+	}
+
+	svc, err := ClientService(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		t.Fatalf("expected service type %q, got %q", corev1.ServiceTypeLoadBalancer, svc.Spec.Type)
+	}
+	if svc.Spec.LoadBalancerClass == nil {
+		t.Fatal("expected loadBalancerClass override to be propagated, got nil")
+	}
+	if *svc.Spec.LoadBalancerClass != lbClass {
+		t.Fatalf("expected loadBalancerClass %q, got %q", lbClass, *svc.Spec.LoadBalancerClass)
+	}
+
+	hostname, ok := svc.Annotations["dnsmasq.network.openstack.org/hostname"]
+	if !ok {
+		t.Fatal("expected dnsmasq hostname annotation for LoadBalancer service")
+	}
+	if hostname != "rabbitmq.openstack.svc" {
+		t.Fatalf("expected hostname %q, got %q", "rabbitmq.openstack.svc", hostname)
+	}
+}
+
+func TestClientServiceMultipleOverrides(t *testing.T) {
+	lbClass := "metallb.io/metallb"
+	ipfp := corev1.IPFamilyPolicySingleStack
+
+	r := baseRabbitMq()
+	r.Spec.Override = rabbitmqv1.RabbitMQOverrideSpec{
+		Service: &rabbitmqv1.RabbitMQServiceOverride{
+			Spec: &corev1.ServiceSpec{
+				Type:                  corev1.ServiceTypeLoadBalancer,
+				LoadBalancerClass:     &lbClass,
+				IPFamilyPolicy:        &ipfp,
+				ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
+				SessionAffinity:       corev1.ServiceAffinityClientIP,
+			},
+		},
+	}
+
+	svc, err := ClientService(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		t.Fatalf("expected type %q, got %q", corev1.ServiceTypeLoadBalancer, svc.Spec.Type)
+	}
+	if svc.Spec.LoadBalancerClass == nil || *svc.Spec.LoadBalancerClass != lbClass {
+		t.Fatalf("expected loadBalancerClass %q", lbClass)
+	}
+	if svc.Spec.IPFamilyPolicy == nil || *svc.Spec.IPFamilyPolicy != ipfp {
+		t.Fatalf("expected IPFamilyPolicy %q", ipfp)
+	}
+	if svc.Spec.ExternalTrafficPolicy != corev1.ServiceExternalTrafficPolicyLocal {
+		t.Fatalf("expected ExternalTrafficPolicy %q, got %q", corev1.ServiceExternalTrafficPolicyLocal, svc.Spec.ExternalTrafficPolicy)
+	}
+	if svc.Spec.SessionAffinity != corev1.ServiceAffinityClientIP {
+		t.Fatalf("expected SessionAffinity %q, got %q", corev1.ServiceAffinityClientIP, svc.Spec.SessionAffinity)
+	}
+}
+
+func TestClientServiceMetadataOverride(t *testing.T) {
+	r := baseRabbitMq()
+	r.Spec.Override = rabbitmqv1.RabbitMQOverrideSpec{
+		Service: &rabbitmqv1.RabbitMQServiceOverride{
+			EmbeddedLabelsAnnotations: &service.EmbeddedLabelsAnnotations{
+				Labels:      map[string]string{"custom-label": "value"},
+				Annotations: map[string]string{"custom-annotation": "value"},
+			},
+		},
+	}
+
+	svc, err := ClientService(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if svc.Labels["custom-label"] != "value" {
+		t.Fatalf("expected custom-label in labels, got %v", svc.Labels)
+	}
+	if svc.Annotations["custom-annotation"] != "value" {
+		t.Fatalf("expected custom-annotation in annotations, got %v", svc.Annotations)
+	}
+}
+
+func TestClientServiceUnsafeFieldsIgnored(t *testing.T) {
+	r := baseRabbitMq()
+	r.Spec.Override = rabbitmqv1.RabbitMQOverrideSpec{
+		Service: &rabbitmqv1.RabbitMQServiceOverride{
+			Spec: &corev1.ServiceSpec{
+				Selector:  map[string]string{"should": "be-ignored"},
+				ClusterIP: "10.0.0.99",
+			},
+		},
+	}
+
+	svc, err := ClientService(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if svc.Spec.ClusterIP == "10.0.0.99" {
+		t.Fatal("override should not be able to set ClusterIP")
+	}
+	if svc.Spec.Selector["should"] == "be-ignored" {
+		t.Fatal("override should not be able to set Selector")
+	}
+}
+
+func TestHeadlessServiceNoOverride(t *testing.T) {
+	r := baseRabbitMq()
+
+	svc, err := HeadlessService(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if svc.Spec.ClusterIP != "None" {
+		t.Fatalf("expected headless ClusterIP 'None', got %q", svc.Spec.ClusterIP)
+	}
+	if svc.Name != "rabbitmq-nodes" {
+		t.Fatalf("expected name %q, got %q", "rabbitmq-nodes", svc.Name)
+	}
+}
+
+func TestHeadlessServiceIgnoresClientOverrides(t *testing.T) {
+	lbClass := "metallb.io/metallb"
+	ipfp := corev1.IPFamilyPolicyPreferDualStack
+
+	r := baseRabbitMq()
+	r.Spec.Override = rabbitmqv1.RabbitMQOverrideSpec{
+		Service: &rabbitmqv1.RabbitMQServiceOverride{
+			EmbeddedLabelsAnnotations: &service.EmbeddedLabelsAnnotations{
+				Labels: map[string]string{"custom": "label"},
+			},
+			Spec: &corev1.ServiceSpec{
+				Type:                  corev1.ServiceTypeLoadBalancer,
+				LoadBalancerClass:     &lbClass,
+				ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
+				IPFamilyPolicy:        &ipfp,
+			},
+		},
+	}
+
+	svc, err := HeadlessService(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if svc.Spec.Type != corev1.ServiceTypeClusterIP {
+		t.Fatalf("headless service type must stay ClusterIP, got %q", svc.Spec.Type)
+	}
+	if svc.Spec.ClusterIP != "None" {
+		t.Fatalf("headless service clusterIP must stay None, got %q", svc.Spec.ClusterIP)
+	}
+	if svc.Spec.ExternalTrafficPolicy != "" {
+		t.Fatalf("headless service must not have ExternalTrafficPolicy, got %q", svc.Spec.ExternalTrafficPolicy)
+	}
+	if svc.Spec.LoadBalancerClass != nil {
+		t.Fatalf("headless service must not have LoadBalancerClass, got %q", *svc.Spec.LoadBalancerClass)
+	}
+	// IPFamilyPolicy IS applied to headless services
+	if svc.Spec.IPFamilyPolicy == nil || *svc.Spec.IPFamilyPolicy != ipfp {
+		t.Fatalf("expected IPFamilyPolicy %q on headless service", ipfp)
+	}
+	// Metadata overrides ARE applied to headless services
+	if svc.Labels["custom"] != "label" {
+		t.Fatalf("expected metadata override on headless service, got labels %v", svc.Labels)
+	}
+}
+
+func TestHeadlessServiceIPFamilyPolicyOverride(t *testing.T) {
+	ipfp := corev1.IPFamilyPolicyPreferDualStack
+
+	r := baseRabbitMq()
+	r.Spec.Override = rabbitmqv1.RabbitMQOverrideSpec{
+		Service: &rabbitmqv1.RabbitMQServiceOverride{
+			Spec: &corev1.ServiceSpec{
+				IPFamilyPolicy: &ipfp,
+			},
+		},
+	}
+
+	svc, err := HeadlessService(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if svc.Spec.IPFamilyPolicy == nil || *svc.Spec.IPFamilyPolicy != ipfp {
+		t.Fatalf("expected IPFamilyPolicy %q", ipfp)
+	}
+}


### PR DESCRIPTION
Replace manual cherry-picking of individual ServiceSpec override fields (Type, IPFamilyPolicy) with lib-common's OverrideServiceSpec whitelist and strategic merge patch. This fixes LoadBalancerClass not being propagated ([OSPRH-30887](https://redhat.atlassian.net/browse/OSPRH-30887)) and also enables SessionAffinity, ExternalTrafficPolicy, LoadBalancerSourceRanges, InternalTrafficPolicy, ExternalName, and SessionAffinityConfig overrides — all of which were silently ignored before.

The override's full corev1.ServiceSpec is converted to the restricted OverrideServiceSpec via JSON marshal/unmarshal, ensuring unsafe fields (Selector, Ports, ClusterIP) cannot be overridden. This matches the pattern used by lib-common's service.NewService() and by the RabbitMQ per-pod services in this same controller.

The headless service only applies metadata overrides and IPFamilyPolicy — other spec fields are invalid or meaningless for ClusterIP/None services.

Related: https://redhat.atlassian.net/browse/OSPRH-30887