### PR TITLE
Make fencing sleeps interruptible, add dual-key HMAC tests, document small clusters

### DIFF
--- a/docs/instanceha_architecture.md
+++ b/docs/instanceha_architecture.md
@@ -2122,7 +2122,7 @@ spec:
       serviceAccountName: instanceha-instanceha
       securityContext:
         fsGroup: 42401
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 45
       containers:
       - name: instanceha
         image: <resolved from infra-instanceha-config ConfigMap or RELATED_IMAGE env var>
@@ -2215,6 +2215,52 @@ spec:
         configMap:
           name: instanceha-config          # from spec.instanceHaConfigMap
 ```
+
+---
+
+## Small Cluster Tuning
+
+InstanceHA works on clusters of any size, but the default safety thresholds are tuned for medium-to-large deployments. On clusters with 3–5 compute nodes, the percentage-based safety gates can block evacuation during legitimate multi-node failures because a small absolute number of failures translates to a large percentage.
+
+### Affected Safety Gates
+
+| Gate | Default | 3-node impact | 4-node impact |
+|------|---------|---------------|---------------|
+| **THRESHOLD** (global, `>`) | 50% | 2 failures = 66.7% → **blocked** | 2 failures = 50% → allowed (check is `>`, not `>=`) |
+| **HEARTBEAT_CLIFF_THRESHOLD** (`>=`) | 50% | 2 heartbeat losses = 66.7% → **cliff triggered** | 2 losses = 50% → **cliff triggered** (check is `>=`) |
+| **Per-aggregate threshold** | N/A (absolute count) | Not affected (uses absolute `instanceha:max_failures`) | Not affected |
+
+Single-node failures are handled correctly at any cluster size.
+
+### Recommended Configuration
+
+For clusters with 3–5 compute nodes where simultaneous multi-node failures are a realistic scenario (not just network partitions):
+
+```yaml
+config:
+  THRESHOLD: 100              # Disable global threshold — trust fencing to proceed
+  CHECK_HEARTBEAT: true       # Enable heartbeat detection to distinguish host vs nova-compute failures
+  HEARTBEAT_CLIFF_THRESHOLD: 100  # Disable cliff detection — trust individual heartbeat status
+```
+
+Setting `THRESHOLD: 100` disables the global percentage check entirely. This is safe because:
+1. Heartbeat detection (`CHECK_HEARTBEAT`) provides the primary protection against fencing during network partitions
+2. The K8s API reachability gate (gate 1) suppresses fencing if the pod itself loses network connectivity
+3. Per-aggregate thresholds (if configured) still apply as an absolute count, which is better suited to small clusters
+
+If heartbeats are not deployed, a more conservative approach:
+
+```yaml
+config:
+  THRESHOLD: 67               # Allow up to 2/3 failure ratio
+```
+
+### Why the Defaults Are Conservative
+
+The default `THRESHOLD: 50` and `HEARTBEAT_CLIFF_THRESHOLD: 50` are deliberately conservative because:
+- False positives (unnecessary fencing) are more dangerous than false negatives (delayed evacuation)
+- On larger clusters, losing >50% of nodes simultaneously almost always indicates a network partition, not real failures
+- Small clusters are the exception, not the rule, in production OpenStack deployments
 
 ---
 
@@ -2345,6 +2391,7 @@ config:
 - Value of `0` blocks all evacuations (any failure percentage exceeds 0%)
 - Value of `100` disables threshold checking (nothing can exceed 100%)
 - Aggregate-aware calculation uses only evacuable hosts as denominator
+- **Small clusters**: On a 3-node cluster, 2 simultaneous failures = 66.7%, which exceeds the default 50%. On a 4-node cluster, 2 failures = 50% (not blocked, since the check is `>`). Operators of small clusters who expect multi-node failures should raise this value. See [Small Cluster Tuning](#small-cluster-tuning).
 
 ---
 
@@ -3005,6 +3052,34 @@ config:
 ```
 
 **Notes**: Should be at least 2x the heartbeat send interval (default 30s) to tolerate missed packets.
+
+---
+
+#### HEARTBEAT_CLIFF_THRESHOLD
+**Type**: Integer
+**Default**: `50`
+**Range**: `10-100` (percentage)
+
+**Description**: Maximum percentage of heartbeat-active hosts that can disappear in a single poll cycle before cliff detection triggers. When the drop exceeds this threshold, InstanceHA assumes a listener-side network partition rather than simultaneous host failures and skips all fencing for that cycle.
+
+**Usage**:
+- Evaluated in `_filter_reachable_hosts()` each poll cycle when `CHECK_HEARTBEAT` is enabled
+- Compares `heartbeat_previous_active_count` (previous cycle) against current active count
+- Only evaluated when the previous active count was >= 3 (avoids false triggers during startup ramp-up)
+
+**Behavior**:
+- If drop percentage >= `HEARTBEAT_CLIFF_THRESHOLD`: skip all fencing this cycle, emit `HeartbeatCliff` K8s event (Warning)
+- Baseline count is preserved during a cliff event, so the cliff re-triggers on subsequent cycles until heartbeats recover
+- When no cliff is detected, update `heartbeat_previous_active_count` for the next cycle
+
+**Small Cluster Considerations**: On a 3-node cluster with all nodes sending heartbeats, losing 2 nodes simultaneously causes a 66.7% drop — exceeding the default 50% threshold. This blocks fencing for that cycle. If simultaneous multi-node failures are expected (not partitions), raise this value (e.g., `100` to disable cliff detection entirely). See [Small Cluster Tuning](#small-cluster-tuning).
+
+**Example**:
+```yaml
+config:
+  CHECK_HEARTBEAT: true
+  HEARTBEAT_CLIFF_THRESHOLD: 100  # Disable cliff detection (trust individual heartbeat status)
+```
 
 ---
 

--- a/internal/instanceha/funcs.go
+++ b/internal/instanceha/funcs.go
@@ -177,7 +177,7 @@ func Deployment(
 						FSGroup: ptr.To(instanceHaUID),
 					},
 					Volumes:                       volumes,
-					TerminationGracePeriodSeconds: ptr.To[int64](30),
+					TerminationGracePeriodSeconds: ptr.To[int64](45),
 					Containers: []corev1.Container{{
 						Name:    "instanceha",
 						Image:   containerImage,

--- a/templates/instanceha/bin/instanceha.py
+++ b/templates/instanceha/bin/instanceha.py
@@ -405,11 +405,18 @@ def _make_ssl_request(method: str, url: str, auth: tuple, timeout: int,
 
 
 def _wait_for_power_off(check_func: Callable[[], Optional[str]], timeout: int,
-                       host_identifier: str, expected_state: str, agent_type: str) -> bool:
+                       host_identifier: str, expected_state: str, agent_type: str,
+                       shutdown_event=None) -> bool:
     """Wait for host to power off by polling power state."""
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        time.sleep(1)
+        if shutdown_event and shutdown_event.is_set():
+            logging.warning("Shutdown requested, aborting power-off wait for %s", host_identifier)
+            return False
+        if shutdown_event:
+            shutdown_event.wait(1)
+        else:
+            time.sleep(1)
         power_state = check_func()
         if power_state == expected_state:
             logging.info("%s power off successful for %s", agent_type, host_identifier)
@@ -1720,7 +1727,7 @@ def _host_evacuate(connection, failed_service, service, target_host=None) -> boo
         logging.info("Nothing to evacuate")
         return True
 
-    time.sleep(service.config.get_config_value('DELAY'))
+    _interruptible_sleep(service.shutdown_event, service.config.get_config_value('DELAY'))
 
     if service.config.get_config_value('ORCHESTRATED_RESTART') is True or service.config.get_config_value('SMART_EVACUATION'):
         return _concurrent_evacuate(connection, evacuables, service, host, failed_service.id, target_host=target_host)
@@ -1929,7 +1936,7 @@ def _server_evacuate_future(connection, server, target_host=None,
             return False
 
         logging.debug("Starting evacuation of %s", response.uuid)
-        time.sleep(INITIAL_EVACUATION_WAIT_SECONDS)
+        _interruptible_sleep(shutdown_event, INITIAL_EVACUATION_WAIT_SECONDS)
 
         result = _monitor_evacuation(connection, server.id, response.uuid, start_time,
                                      max_retries=max_retries,
@@ -2194,7 +2201,7 @@ def _get_power_state(agent_type: str, session: requests.Session = None, **kwargs
 
     return None
 
-def _redfish_reset(url, user, passwd, timeout, action, config_mgr):
+def _redfish_reset(url, user, passwd, timeout, action, config_mgr, shutdown_event=None):
     """Perform a Redfish reset operation on a computer system."""
     if not all([url, user, passwd, action]):
         logging.error("Redfish reset failed: missing required parameters")
@@ -2225,7 +2232,8 @@ def _redfish_reset(url, user, passwd, timeout, action, config_mgr):
                     try:
                         return _wait_for_power_off(
                             lambda: _get_power_state('redfish', session=poll_session, url=url, user=user, passwd=passwd, timeout=timeout, config_mgr=config_mgr),
-                            timeout, safe_url, 'OFF', 'Redfish')
+                            timeout, safe_url, 'OFF', 'Redfish',
+                            shutdown_event=shutdown_event)
                     finally:
                         poll_session.close()
                 else:
@@ -2345,7 +2353,13 @@ def _bmh_wait_for_power_off(get_url, headers, cacert, host, timeout, poll_interv
 
     with requests.Session() as session:
         while time.monotonic() < timeout_end:
-            time.sleep(poll_interval)
+            if service.shutdown_event and service.shutdown_event.is_set():
+                logging.warning("Shutdown requested, aborting power-off wait for %s", host)
+                return False
+            if service.shutdown_event:
+                service.shutdown_event.wait(poll_interval)
+            else:
+                time.sleep(poll_interval)
 
             try:
                 response = session.get(get_url, headers=headers, verify=cacert, timeout=request_timeout)
@@ -2393,7 +2407,7 @@ def _validate_fencing_inputs(fencing_data, agent_name) -> bool:
         validations['username'] = fencing_data["login"]
     return validate_inputs(validations, agent_name)
 
-def _execute_ipmi_fence(host, action, fencing_data, timeout) -> bool:
+def _execute_ipmi_fence(host, action, fencing_data, timeout, shutdown_event=None) -> bool:
     """Execute IPMI fencing operation with retry logic."""
     timeout = max(5, min(300, int(timeout or 30)))
     ipaddr, ipport, login, passwd = fencing_data["ipaddr"], fencing_data["ipport"], \
@@ -2415,7 +2429,8 @@ def _execute_ipmi_fence(host, action, fencing_data, timeout) -> bool:
     if action == 'off':
         return _wait_for_power_off(
             lambda: _get_power_state('ipmi', ip=ipaddr, port=ipport, user=login, passwd=passwd, timeout=timeout),
-            timeout, host, 'CHASSIS POWER IS OFF', 'IPMI')
+            timeout, host, 'CHASSIS POWER IS OFF', 'IPMI',
+            shutdown_event=shutdown_event)
 
     logging.info("IPMI %s successful for %s", action, host)
     return True
@@ -2433,7 +2448,8 @@ def _fence_ipmi(host, action, fencing_data, service):
     if not _validate_fencing_inputs(fencing_data, "IPMI"):
         return False
     timeout = fencing_data.get("timeout", service.config.get_config_value('FENCING_TIMEOUT'))
-    return _execute_ipmi_fence(host, action, fencing_data, timeout)
+    return _execute_ipmi_fence(host, action, fencing_data, timeout,
+                              shutdown_event=service.shutdown_event)
 
 
 def _fence_redfish(host, action, fencing_data, service):
@@ -2448,7 +2464,8 @@ def _fence_redfish(host, action, fencing_data, service):
     redfish_action = "ForceOff" if action == "off" else "On"
     timeout = fencing_data.get("timeout", service.config.get_config_value('FENCING_TIMEOUT'))
     return _redfish_reset(url, fencing_data["login"], fencing_data["passwd"],
-                        timeout, redfish_action, service.config)
+                        timeout, redfish_action, service.config,
+                        shutdown_event=service.shutdown_event)
 
 
 def _fence_bmh(host, action, fencing_data, service):
@@ -3545,6 +3562,7 @@ def main():
 
             services = conn.services.list(binary="nova-compute")
             if not services:
+                logging.info("Poll cycle completed: no compute services found, next poll in %ds", poll_interval)
                 service.shutdown_event.wait(poll_interval)
                 continue
 
@@ -3556,9 +3574,12 @@ def main():
             _process_stale_services(conn, service, services, compute_nodes_list, to_resume)
             _process_reenabling(conn, service, to_reenable)
 
+            stale_count = len(compute_nodes_list)
             if not service.ready:
                 service.ready = True
                 logging.info("Readiness probe active — first poll cycle completed")
+            logging.info("Poll cycle completed: %d compute services, %d stale, next poll in %ds",
+                         len(services), stale_count, poll_interval)
             consecutive_failures = 0
             POLL_CONSECUTIVE_FAILURES.set(0)
             POLL_CYCLE_TOTAL.labels(result='success').inc()

--- a/test/instanceha/test_config_features.py
+++ b/test/instanceha/test_config_features.py
@@ -495,7 +495,7 @@ class TestDelayConfig(unittest.TestCase):
         mock_server.id = 'server-123'
 
         # Mock the evacuation functions to avoid actual evacuation
-        with patch('time.sleep') as mock_sleep:
+        with patch('instanceha._interruptible_sleep') as mock_sleep:
             with patch('instanceha._get_evacuable_servers', return_value=[mock_server]):
                 with patch('instanceha._traditional_evacuate', return_value=True):
                     failed_service = Mock()
@@ -505,8 +505,8 @@ class TestDelayConfig(unittest.TestCase):
                     # Call _host_evacuate which contains the DELAY sleep
                     result = instanceha._host_evacuate(mock_conn, failed_service, service)
 
-                    # Verify sleep was called with 0 (DELAY=0)
-                    mock_sleep.assert_called_once_with(0)
+                    # Verify interruptible sleep was called with shutdown_event and 0 (DELAY=0)
+                    mock_sleep.assert_called_once_with(service.shutdown_event, 0)
 
     def test_delay_non_zero_delays_evacuation(self):
         """Test that DELAY>0 delays evacuation by specified seconds."""
@@ -524,7 +524,7 @@ class TestDelayConfig(unittest.TestCase):
         mock_server = Mock()
         mock_server.id = 'server-123'
 
-        with patch('time.sleep') as mock_sleep:
+        with patch('instanceha._interruptible_sleep') as mock_sleep:
             with patch('instanceha._get_evacuable_servers', return_value=[mock_server]):
                 with patch('instanceha._traditional_evacuate', return_value=True):
                     failed_service = Mock()
@@ -533,8 +533,8 @@ class TestDelayConfig(unittest.TestCase):
 
                     result = instanceha._host_evacuate(mock_conn, failed_service, service)
 
-                    # Verify sleep was called with configured DELAY value
-                    mock_sleep.assert_called_once_with(5)
+                    # Verify interruptible sleep was called with shutdown_event and configured DELAY value
+                    mock_sleep.assert_called_once_with(service.shutdown_event, 5)
 
     def test_delay_with_smart_evacuation(self):
         """Test that DELAY works with SMART_EVACUATION enabled."""
@@ -552,7 +552,7 @@ class TestDelayConfig(unittest.TestCase):
         mock_server = Mock()
         mock_server.id = 'server-123'
 
-        with patch('time.sleep') as mock_sleep:
+        with patch('instanceha._interruptible_sleep') as mock_sleep:
             with patch('instanceha._get_evacuable_servers', return_value=[mock_server]):
                 with patch('instanceha._concurrent_evacuate', return_value=True):
                     failed_service = Mock()
@@ -561,8 +561,8 @@ class TestDelayConfig(unittest.TestCase):
 
                     result = instanceha._host_evacuate(mock_conn, failed_service, service)
 
-                    # Verify sleep was called with DELAY before smart evacuation
-                    mock_sleep.assert_called_once_with(3)
+                    # Verify interruptible sleep was called with shutdown_event and DELAY before smart evacuation
+                    mock_sleep.assert_called_once_with(service.shutdown_event, 3)
 
     def test_delay_boundary_values(self):
         """Test DELAY boundary values (min=0, max=300)."""

--- a/test/instanceha/test_coverage_gaps.py
+++ b/test/instanceha/test_coverage_gaps.py
@@ -274,16 +274,20 @@ class TestFenceIpmi(unittest.TestCase):
     def test_valid_params_calls_execute(self, mock_exec):
         """Valid params delegates to _execute_ipmi_fence."""
         data = {"ipaddr": "192.168.1.10", "ipport": "623", "login": "admin", "passwd": "secret"}
-        result = instanceha._fence_ipmi("host1", "off", data, self._make_service())
+        svc = self._make_service()
+        result = instanceha._fence_ipmi("host1", "off", data, svc)
         self.assertTrue(result)
-        mock_exec.assert_called_once_with("host1", "off", data, 30)
+        mock_exec.assert_called_once_with("host1", "off", data, 30,
+                                          shutdown_event=svc.shutdown_event)
 
     @patch('instanceha._execute_ipmi_fence', return_value=True)
     def test_uses_custom_timeout_from_fencing_data(self, mock_exec):
         """Uses timeout from fencing_data if provided."""
         data = {"ipaddr": "192.168.1.10", "ipport": "623", "login": "admin", "passwd": "secret", "timeout": 60}
-        instanceha._fence_ipmi("host1", "off", data, self._make_service())
-        mock_exec.assert_called_once_with("host1", "off", data, 60)
+        svc = self._make_service()
+        instanceha._fence_ipmi("host1", "off", data, svc)
+        mock_exec.assert_called_once_with("host1", "off", data, 60,
+                                          shutdown_event=svc.shutdown_event)
 
     @patch('instanceha._execute_ipmi_fence', return_value=False)
     def test_returns_false_when_execute_fails(self, mock_exec):

--- a/test/instanceha/test_fencing_agents.py
+++ b/test/instanceha/test_fencing_agents.py
@@ -591,8 +591,7 @@ class TestIPMIFencing(unittest.TestCase):
 
     @patch('instanceha._get_power_state')
     @patch('instanceha.subprocess.run')
-    @patch('instanceha.time.sleep')
-    def test_ipmi_power_off_wait_success(self, mock_sleep, mock_run, mock_get_power_state):
+    def test_ipmi_power_off_wait_success(self, mock_run, mock_get_power_state):
         """Test IPMI power off waits for confirmation."""
         # Mock successful power off command
         mock_run.return_value = Mock()
@@ -603,6 +602,7 @@ class TestIPMIFencing(unittest.TestCase):
         # Create mock service and fencing data
         mock_service = Mock()
         mock_service.config.get_config_value.return_value = 30
+        mock_service.shutdown_event.is_set.return_value = False
 
         # Test the function
         result = instanceha._execute_fence_operation('test-host', 'off', {
@@ -617,15 +617,12 @@ class TestIPMIFencing(unittest.TestCase):
         # Should return True after power off confirmation
         self.assertTrue(result)
         self.assertEqual(mock_get_power_state.call_count, 2)  # Called twice
-        # Sleep should be called at least once with value 1
-        self.assertGreaterEqual(mock_sleep.call_count, 1)
-        # Check that sleep was called with 1 at least once
-        self.assertIn(call(1), mock_sleep.call_args_list)
+        # Interruptible wait should be called at least once with value 1
+        mock_service.shutdown_event.wait.assert_called_with(1)
 
     @patch('instanceha._get_power_state')
     @patch('instanceha.subprocess.run')
-    @patch('instanceha.time.sleep')
-    def test_ipmi_power_off_timeout(self, mock_sleep, mock_run, mock_get_power_state):
+    def test_ipmi_power_off_timeout(self, mock_run, mock_get_power_state):
         """Test IPMI power off times out waiting for confirmation."""
         # Mock successful power off command
         mock_run.return_value = Mock()
@@ -636,6 +633,7 @@ class TestIPMIFencing(unittest.TestCase):
         # Create mock service and fencing data
         mock_service = Mock()
         mock_service.config.get_config_value.return_value = 30
+        mock_service.shutdown_event.is_set.return_value = False
 
         # Test the function with timeout=2
         result = instanceha._execute_fence_operation('test-host', 'off', {
@@ -650,9 +648,9 @@ class TestIPMIFencing(unittest.TestCase):
         # Should return False due to timeout
         self.assertFalse(result)
         # With deadline-based loop, exact call count depends on timing;
-        # verify it was called at least once and sleep was invoked
+        # verify it was called at least once and interruptible wait was used
         self.assertGreaterEqual(mock_get_power_state.call_count, 1)
-        self.assertGreaterEqual(mock_sleep.call_count, 1)
+        mock_service.shutdown_event.wait.assert_called_with(1)
 
     @patch('instanceha.subprocess.run')
     def test_ipmi_power_on_no_wait(self, mock_run):
@@ -823,6 +821,7 @@ class TestBMHFencing(unittest.TestCase):
         self.mock_service = Mock()
         self.mock_service.config = Mock()
         self.mock_service.config.get_config_value = Mock(return_value=30)
+        self.mock_service.shutdown_event.is_set.return_value = False
 
     @patch('instanceha.os.path.exists')
     @patch('instanceha.requests.patch')
@@ -899,9 +898,8 @@ class TestBMHFencing(unittest.TestCase):
     @patch('instanceha.os.path.exists')
     @patch('instanceha.requests.Session')
     @patch('instanceha.requests.patch')
-    @patch('instanceha.time.sleep')
     @patch('instanceha.time.monotonic')
-    def test_bmh_wait_for_power_off_success(self, mock_monotonic, mock_sleep, mock_patch, mock_session_class, mock_exists):
+    def test_bmh_wait_for_power_off_success(self, mock_monotonic, mock_patch, mock_session_class, mock_exists):
         """Test BMH wait for power off successfully detects power off."""
         # Mock CA cert exists
         mock_exists.return_value = True
@@ -1346,6 +1344,7 @@ class TestBMHFencingEdgeCases(unittest.TestCase):
         """Test race condition when power state changes during polling."""
         service = Mock()
         service.config.get_config_value.return_value = 600  # FENCING_TIMEOUT
+        service.shutdown_event.is_set.return_value = False
 
         call_count = [0]
 
@@ -1367,8 +1366,7 @@ class TestBMHFencingEdgeCases(unittest.TestCase):
         mock_session.__exit__ = Mock(return_value=None)
         mock_session.get.side_effect = side_effect
 
-        with patch('requests.Session', return_value=mock_session), \
-             patch('time.sleep'):  # Mock sleep to avoid delays
+        with patch('requests.Session', return_value=mock_session):
             get_url = 'https://api.test.com/apis/metal3.io/v1alpha1/namespaces/test-ns/baremetalhosts/test-bmh'
             headers = {'Authorization': 'Bearer fake-token'}
 
@@ -1425,6 +1423,7 @@ class TestBMHFencingEdgeCases(unittest.TestCase):
         """Test that status check respects polling interval."""
         service = Mock()
         service.config.get_config_value.return_value = 600  # FENCING_TIMEOUT
+        service.shutdown_event.is_set.return_value = False
 
         mock_response = Mock()
         mock_response.status_code = 200
@@ -1437,8 +1436,7 @@ class TestBMHFencingEdgeCases(unittest.TestCase):
         mock_session.__exit__ = Mock(return_value=None)
         mock_session.get.return_value = mock_response
 
-        with patch('requests.Session', return_value=mock_session), \
-             patch('time.sleep') as mock_sleep:
+        with patch('requests.Session', return_value=mock_session):
             get_url = 'https://api.test.com/apis/metal3.io/v1alpha1/namespaces/test-ns/baremetalhosts/test-bmh'
             headers = {'Authorization': 'Bearer fake-token'}
 
@@ -1448,9 +1446,8 @@ class TestBMHFencingEdgeCases(unittest.TestCase):
 
             # Should complete on first check (poweredOn=False)
             self.assertTrue(result)
-            # Should only sleep once (at start of loop before check)
-            self.assertEqual(mock_sleep.call_count, 1)
-            mock_sleep.assert_called_with(0.5)
+            # Should only wait once (at start of loop before check)
+            service.shutdown_event.wait.assert_called_once_with(0.5)
 
 
 

--- a/test/instanceha/test_heartbeat_detection.py
+++ b/test/instanceha/test_heartbeat_detection.py
@@ -94,6 +94,47 @@ class TestResolveHostnamePacket(unittest.TestCase):
         result = instanceha._resolve_hostname_packet(data, ('10.0.0.1', 12345), 'Heartbeat', hmac_keys=[bad_key])
         self.assertIsNone(result)
 
+    def test_current_key_accepted_in_dual_key_list(self):
+        """Current key (first in list) validates the packet."""
+        current_key = b'\x01' * 32
+        previous_key = b'\x02' * 32
+        data = self._make_packet(b'compute-01')  # signed with _TEST_HMAC_KEY == current_key
+        result = instanceha._resolve_hostname_packet(
+            data, ('10.0.0.1', 12345), 'Heartbeat', hmac_keys=[current_key, previous_key])
+        self.assertEqual(result, 'compute-01')
+
+    def test_previous_key_accepted_during_rotation(self):
+        """Previous key (second in list) still validates — critical for rotation window."""
+        current_key = b'\x03' * 32
+        previous_key = _TEST_HMAC_KEY  # packet was signed with this key
+        data = self._make_packet(b'compute-01')
+        result = instanceha._resolve_hostname_packet(
+            data, ('10.0.0.1', 12345), 'Heartbeat', hmac_keys=[current_key, previous_key])
+        self.assertEqual(result, 'compute-01')
+
+    def test_unknown_key_rejected_with_dual_keys(self):
+        """Packet signed with a key not in the key list is rejected."""
+        key_a = b'\x03' * 32
+        key_b = b'\x04' * 32
+        data = self._make_packet(b'compute-01')  # signed with _TEST_HMAC_KEY, neither key_a nor key_b
+        result = instanceha._resolve_hostname_packet(
+            data, ('10.0.0.1', 12345), 'Heartbeat', hmac_keys=[key_a, key_b])
+        self.assertIsNone(result)
+
+    def test_no_hmac_keys_rejects_valid_packet(self):
+        """A valid packet is rejected when no HMAC keys are configured."""
+        data = self._make_packet(b'compute-01')
+        result = instanceha._resolve_hostname_packet(
+            data, ('10.0.0.1', 12345), 'Heartbeat', hmac_keys=None)
+        self.assertIsNone(result)
+
+    def test_empty_hmac_keys_rejects_valid_packet(self):
+        """A valid packet is rejected when HMAC key list is empty."""
+        data = self._make_packet(b'compute-01')
+        result = instanceha._resolve_hostname_packet(
+            data, ('10.0.0.1', 12345), 'Heartbeat', hmac_keys=[])
+        self.assertIsNone(result)
+
     def test_stale_timestamp_rejected(self):
         payload = struct.pack('!I', instanceha.HEARTBEAT_MAGIC_NUMBER)
         payload += struct.pack('!Q', int(time.time()) - 700)

--- a/test/instanceha/test_thread_safety.py
+++ b/test/instanceha/test_thread_safety.py
@@ -227,6 +227,7 @@ class TestMonotonicTimeouts(unittest.TestCase):
         """Test that _bmh_wait_for_power_off uses time.monotonic for timeout."""
         mock_service = Mock()
         mock_service.config.get_config_value.return_value = 30
+        mock_service.shutdown_event.is_set.return_value = False
 
         mock_session = Mock()
         mock_session.__enter__ = Mock(return_value=mock_session)
@@ -238,12 +239,11 @@ class TestMonotonicTimeouts(unittest.TestCase):
         mock_session.get.return_value = mock_response
 
         with patch('instanceha.time.monotonic', side_effect=[0, 0, 1]) as mock_mono:
-            with patch('instanceha.time.sleep'):
-                with patch('instanceha.requests.Session', return_value=mock_session):
-                    result = instanceha._bmh_wait_for_power_off(
-                        'https://api/bmh', {'Authorization': 'Bearer test'},
-                        None, 'test-host', 30, 1, mock_service
-                    )
+            with patch('instanceha.requests.Session', return_value=mock_session):
+                result = instanceha._bmh_wait_for_power_off(
+                    'https://api/bmh', {'Authorization': 'Bearer test'},
+                    None, 'test-host', 30, 1, mock_service
+                )
 
         mock_mono.assert_called()
         self.assertTrue(result)


### PR DESCRIPTION
Convert all significant time.sleep() calls in fencing and evacuation paths to use shutdown_event.wait() so SIGTERM is honored promptly. This allows terminationGracePeriodSeconds to be set to 45s (default FENCING_TIMEOUT + buffer), since polling loops no longer block shutdown.

Converted paths: _wait_for_power_off (IPMI/Redfish), _bmh_wait_for_power_off, DELAY sleep in _host_evacuate, initial evacuation wait in _server_evacuate_future.

Add 5 dual-key heartbeat validation tests covering the HMAC key rotation contract: current key accepted, previous key accepted during rotation window, unknown key rejected, no keys rejects, empty key list rejects.

Add Small Cluster Tuning documentation section explaining how THRESHOLD and HEARTBEAT_CLIFF_THRESHOLD interact on 3-5 node clusters, with recommended configuration. Add missing HEARTBEAT_CLIFF_THRESHOLD config reference entry.

Add per-cycle INFO log line reporting compute service count, stale count, and next poll interval so operators can confirm the script is actively polling.