### PR TITLE
InstanceHA cliff detection expiry, per-cycle fencing cap, Nova request ID correlation

### DIFF
--- a/docs/instanceha_application_credentials.md
+++ b/docs/instanceha_application_credentials.md
@@ -1,5 +1,7 @@
 # InstanceHA Application Credential Authentication
 
+> **Related docs**: [instanceha_guide.md -- Authentication](instanceha_guide.md#authentication) (quick setup) | [instanceha_architecture.md -- Authentication](instanceha_architecture.md#authentication) (internal design)
+
 By default InstanceHA authenticates to OpenStack using username/password
 credentials from `clouds.yaml` and `secure.yaml`. As an alternative you can
 use a **Keystone Application Credential**, which provides scoped, time-limited
@@ -10,10 +12,10 @@ access that can be rotated independently of the service user password.
 - A Keystone user with sufficient privileges to query and evacuate VMs
   (typically the `admin` role on the relevant project).
 - The `keystone-operator` deployed with `KeystoneApplicationCredential` CR support.
-- The `clouds.yaml` ConfigMap must still be present — InstanceHA reads
+- The `clouds.yaml` ConfigMap must still be present -- InstanceHA reads
   `auth_url` and `region_name` from it even when using Application Credentials.
 
-## Step 1 — Create a KeystoneApplicationCredential CR
+## Step 1 -- Create a KeystoneApplicationCredential CR
 
 Create a `KeystoneApplicationCredential` custom resource. The keystone-operator
 will create the credential in Keystone and store the resulting ID and secret in
@@ -86,7 +88,7 @@ oc get keystoneapplicationcredential ac-instanceha -o jsonpath='{.status.conditi
 oc get secret ac-instanceha-secret -o jsonpath='{.data}' | jq
 ```
 
-## Step 2 — Configure the InstanceHa CR
+## Step 2 -- Configure the InstanceHa CR
 
 Set `spec.auth.applicationCredentialSecret` to the name of the Secret created
 above:
@@ -117,7 +119,7 @@ The InstanceHA Python process detects `AC_ENABLED`, reads `AC_ID` and
 `v3applicationcredential` keystoneauth plugin. If the credential files are
 missing or empty it falls back to password authentication.
 
-## Step 3 — Verify
+## Step 3 -- Verify
 
 Check that the pod has the AC volume mounted:
 
@@ -165,7 +167,7 @@ InstanceHA needs to:
 | List/show images (Glance)         | `GET /v2/images`                       | `admin`      |
 
 If you omit `accessRules` from the `KeystoneApplicationCredential` spec, the
-credential inherits all permissions of its parent user — simpler but less
+credential inherits all permissions of its parent user -- simpler but less
 restrictive.
 
 ## Credential rotation

--- a/docs/instanceha_architecture.md
+++ b/docs/instanceha_architecture.md
@@ -125,7 +125,6 @@ _config_map: Dict[str, ConfigItem] = {
     'KDUMP_TIMEOUT': ConfigItem('int', 30, 5, 300),
     'CHECK_HEARTBEAT': ConfigItem('bool', False),
     'HEARTBEAT_TIMEOUT': ConfigItem('int', 120, 30, 600),
-    'HEARTBEAT_CLIFF_THRESHOLD': ConfigItem('int', 50, 10, 100),
     'DISABLED': ConfigItem('bool', False),
     'SSL_VERIFY': ConfigItem('bool', True),
     'FENCING_TIMEOUT': ConfigItem('int', 30, 5, 120),
@@ -133,6 +132,9 @@ _config_map: Dict[str, ConfigItem] = {
     'ORCHESTRATED_RESTART': ConfigItem('bool', False),
     'SKIP_SERVERS_WITH_NAME': ConfigItem('list', []),
     'EVACUATION_RETRIES': ConfigItem('int', DEFAULT_EVACUATION_RETRIES, 1, 20),  # DEFAULT_EVACUATION_RETRIES = 5
+    'HEARTBEAT_CLIFF_THRESHOLD': ConfigItem('int', 50, 10, 100),
+    'HEARTBEAT_CLIFF_MAX_CYCLES': ConfigItem('int', 3, 1, 20),
+    'MAX_HOSTS_PER_CYCLE': ConfigItem('int', 10, 1, 100),
     'K8S_API_CHECK_INTERVAL': ConfigItem('int', 15, 5, 120),
 }
 ```
@@ -161,12 +163,11 @@ def __init__(self, config_manager: ConfigManager, cloud_client: Optional[OpenSta
     self.current_hash = ""
     self.hash_update_successful = False
     self._last_hash_time = 0
-    self._previous_hash = ""
     self.ready = False                              # Readiness flag (set after first poll)
     self.k8s_api_reachable = True                   # K8s API connectivity (fail-open, see Fencing Safety Model)
+    K8S_API_REACHABLE.set(1)
 
     # Caching
-    self._host_servers_cache = {}
     self._evacuable_flavors_cache = None
     self._evacuable_images_cache = None
     self._cache_timestamp = 0
@@ -175,22 +176,29 @@ def __init__(self, config_manager: ConfigManager, cloud_client: Optional[OpenSta
 
     # Threading
     self.health_check_thread = None
+    self._http_server = None
     self.udp_ip = ''
     self.shutdown_event = threading.Event()          # Graceful SIGTERM shutdown
 
-    # Kdump state (protected by kdump_lock)
-    self.kdump_lock = threading.Lock()               # Protects all kdump state
+    # Kdump state (protected by kdump_lock - UDP listener writes concurrently)
+    self.kdump_lock = threading.Lock()
     self.kdump_hosts_timestamp = defaultdict(float)
     self.kdump_hosts_checking = defaultdict(float)
     self.kdump_listener_stop_event = threading.Event()
     self.kdump_fenced_hosts = set()
 
-    # Heartbeat state (protected by heartbeat_lock)
+    # Heartbeat state (protected by heartbeat_lock - UDP listener writes concurrently)
     self.heartbeat_lock = threading.Lock()
     self.heartbeat_hosts_timestamp = defaultdict(float)
     self.heartbeat_listener_stop_event = threading.Event()
     self.heartbeat_listener_start_time = 0.0
     self.heartbeat_previous_active_count = 0        # Cliff detection baseline
+    self.heartbeat_consecutive_cliff_cycles = 0
+    self.last_poll_time = time.monotonic()
+
+    self.heartbeat_hmac_keys = self._load_heartbeat_hmac_keys()
+    if self.heartbeat_hmac_keys:
+        logging.info("Heartbeat HMAC authentication enabled with %d key(s)", len(self.heartbeat_hmac_keys))
 
     # Host processing tracking
     self.hosts_processing = defaultdict(float)
@@ -202,7 +210,7 @@ def __init__(self, config_manager: ConfigManager, cloud_client: Optional[OpenSta
 
 **State Management Notes**:
 
-- `ready` flag starts `False` and is set to `True` after the first successful poll cycle. This drives the `/healthz` readiness probe endpoint — Kubernetes won't route traffic until the service has completed its first poll.
+- `ready` flag starts `False` and is set to `True` after the first successful poll cycle. This drives the `/healthz` readiness probe endpoint -- Kubernetes won't route traffic until the service has completed its first poll.
 - `k8s_api_reachable` starts `True` (fail-open). The background health check thread flips it to `False` after 3 consecutive failures. See [Fencing Safety Model](#fencing-safety-model) for the startup trade-off rationale.
 - `shutdown_event` is set by the SIGTERM handler to signal the main loop and all `wait()` calls to exit gracefully.
 - `kdump_lock` protects all kdump-related state since the UDP listener thread writes concurrently with the main poll loop.
@@ -222,28 +230,6 @@ The initialization is split into five methods, each responsible for a specific d
 
 ---
 
-### 3. CloudConnectionProvider (ABC)
-
-**Purpose**: Abstract interface for cloud connection management.
-
-**Pattern**: ABC-based dependency injection for testability.
-
-**Interface**:
-```python
-class CloudConnectionProvider(ABC):
-    @abstractmethod
-    def get_connection(self) -> Optional[OpenStackClient]:
-        """Get a connection to the cloud provider."""
-        pass
-
-    @abstractmethod
-    def create_connection(self) -> Optional[OpenStackClient]:
-        """Create a new connection to the cloud provider."""
-        pass
-```
-
-**Implementation**: InstanceHAService implements this protocol.
-
 ---
 
 ## Architecture Patterns
@@ -254,7 +240,7 @@ class CloudConnectionProvider(ABC):
 
 **Example**:
 ```python
-class InstanceHAService(CloudConnectionProvider):
+class InstanceHAService:
     def __init__(self, config_manager: ConfigManager,
                  cloud_client: Optional[OpenStackClient] = None):
         self.config = config_manager
@@ -287,10 +273,12 @@ def _redfish_reset(url, user, passwd, timeout, action, config_mgr):
 ```python
 @contextmanager
 def track_host_processing(service: 'InstanceHAService', hostname: str):
-    """Context manager for tracking host processing with automatic cleanup."""
+    """Context manager for tracking host processing state with automatic cleanup."""
+    HOSTS_PROCESSING.inc()
     try:
         yield
     finally:
+        HOSTS_PROCESSING.dec()
         with service.processing_lock:
             service.hosts_processing.pop(hostname, None)
             logging.debug('Cleaned up processing tracking for %s', hostname)
@@ -331,7 +319,7 @@ class UDPSocketManager:
 
 **Cache Access**:
 ```python
-# Pattern: read check → API call outside lock → write update → return local var
+# Pattern: read check -> API call outside lock -> write update -> return local var
 # Lock held only for dictionary operations, not during API calls
 
 # 1. Check cache with lock (fast read)
@@ -600,17 +588,10 @@ def _is_service_resume_candidate(svc) -> bool:
             DISABLED_REASON_EVACUATION_COMPLETE not in reason)
 
 def _is_service_stale(svc, target_date: datetime) -> bool:
-    """Check whether a service's updated_at timestamp is older than target_date.
-
-    Handles both naive and timezone-aware datetime objects by normalizing
-    both to naive UTC before comparison.
-    """
+    """Check whether a service's updated_at timestamp is older than target_date."""
     try:
         updated = svc.updated_at
-        if isinstance(updated, datetime):
-            updated_naive = updated.replace(tzinfo=None)
-        else:
-            updated_naive = datetime.fromisoformat(updated)
+        updated_naive = datetime.fromisoformat(str(updated).replace('Z', '+00:00')).replace(tzinfo=None)
         return updated_naive < target_date.replace(tzinfo=None)
     except (ValueError, TypeError, AttributeError):
         logging.warning("Service %s has invalid updated_at: %r, skipping (not treating as stale)",
@@ -648,11 +629,11 @@ def _categorize_services(services: List[Any], target_date: datetime) -> tuple:
   - Excludes resume candidates to avoid double-processing
 
 **State Transitions**:
-1. Service fails → `compute_nodes` → evacuated → `disabled_reason` = "instanceha evacuation: {timestamp}"
-2. Next poll → `disabled_reason` updated to "instanceha evacuation complete: {timestamp}"
+1. Service fails -> `compute_nodes` -> evacuated -> `disabled_reason` = "instanceha evacuation: {timestamp}"
+2. Next poll -> `disabled_reason` updated to "instanceha evacuation complete: {timestamp}"
    - Service now excluded from `resume` (has "complete" marker)
    - Service now included in `reenable` (has "complete" marker)
-3. Subsequent polls → `reenable` → force_down unset → service reports up → enabled
+3. Subsequent polls -> `reenable` -> force_down unset -> service reports up -> enabled
 4. Service returns to normal operation
 
 **Disabled Reason Values**:
@@ -670,7 +651,7 @@ The `disabled_reason` field tracks evacuation state:
 **Key Design Points**:
 - The `resume` check explicitly excludes "complete" and "FAILED" to prevent loops
 - The `reenable` exclusion also excludes "complete" to prevent excluding completed evacuations
-- Services transition from `resume` → `reenable` via the disabled_reason update
+- Services transition from `resume` -> `reenable` via the disabled_reason update
 - Failed evacuations remain disabled until manually resolved
 - Both checks use substring matching with explicit exclusions to prevent incorrect categorization
 
@@ -678,7 +659,7 @@ The `disabled_reason` field tracks evacuation state:
 
 ## Fencing Safety Model
 
-InstanceHA uses a two-tier safety model to prevent false-positive fencing. Each gate answers a distinct question — there is no redundancy between them.
+InstanceHA uses a two-tier safety model to prevent false-positive fencing. Each gate answers a distinct question -- there is no redundancy between them.
 
 ### Gate Chain
 
@@ -689,50 +670,89 @@ Poll cycle starts
   │
   ├─ Gate 1: K8s API reachable?
   │   Question: "Can we trust our own observations?"
-  │   If no (3 consecutive failures) → skip entire cycle
+  │   If no (3 consecutive failures) -> skip entire cycle
   │   Rationale: if InstanceHA's worker node is network-isolated,
-  │   Nova's service list may be stale — fencing would hit healthy hosts
+  │   Nova's service list may be stale -- fencing would hit healthy hosts
   │
-  ├─ Gate 2: Per-host heartbeat
-  │   Question: "Is this specific host actually down?"
-  │   If host sending heartbeats within HEARTBEAT_TIMEOUT → skip that host
-  │   Rationale: Nova reports host as down, but heartbeat proves the OS is alive —
-  │   only nova-compute crashed, not the host
+  │   ─── enters _process_stale_services ───
   │
-  ├─ Gate 3: Heartbeat cliff detection
+  ├─ Pre-gate: _filter_processing_hosts
+  │   Excludes hosts already being processed (in-flight fencing/evacuation)
+  │
+  ├─ Gate 2: Heartbeat cliff detection
   │   Question: "Did we lose visibility, or did hosts actually fail?"
-  │   If >HEARTBEAT_CLIFF_THRESHOLD% of heartbeats vanish at once → skip ALL fencing
+  │   If >=HEARTBEAT_CLIFF_THRESHOLD% of heartbeats vanish at once -> skip ALL fencing
+  │   Requires >= 3 previously active heartbeat hosts to evaluate
   │   Rationale: simultaneous mass heartbeat loss is more likely a listener-side
   │   network partition than N simultaneous host failures
+  │   Expiry: after HEARTBEAT_CLIFF_MAX_CYCLES consecutive cliff cycles, accept as genuine
   │
-  ├─ Gate 4: Kdump detection (optional, CHECK_KDUMP=true)
-  │   Question: "Is this host crashing and dumping memory?"
-  │   If kdump message received → fence immediately, skip power-on during recovery
+  ├─ Gate 3: Per-host heartbeat
+  │   Question: "Is this specific host actually down?"
+  │   If host sending heartbeats within HEARTBEAT_TIMEOUT -> skip that host
+  │   Rationale: Nova reports host as down, but heartbeat proves the OS is alive --
+  │   only nova-compute crashed, not the host
   │
-  ├─ Gate 5: Global threshold
-  │   Question: "Are too many hosts down to safely evacuate?"
-  │   If failed percentage > THRESHOLD → skip all fencing
+  ├─ Gate 4: All-services-stale circuit breaker
+  │   Question: "Is the data source itself broken?"
+  │   If every active service (>=3) still appears stale after heartbeat filtering -> skip ALL fencing
+  │   Rationale: all hosts down at once is almost certainly a Nova API or
+  │   infrastructure anomaly, not a genuine failure of every server.
+  │   Runs after heartbeat filtering so heartbeat data can disambiguate partial
+  │   failures (e.g., nova-compute crash) from Nova API issues
   │
-  └─ Gate 6: Per-aggregate threshold
-      Question: "Is this aggregate losing too many hosts?"
-      If failed count > instanceha:max_failures metadata → skip hosts in that aggregate
+  ├─ Gate 5: Evacuability filtering (pre-threshold)
+  │   Question: "Which of these down hosts would we actually evacuate?"
+  │   Removes hosts with no VMs, non-evacuable flavors/images, and non-evacuable aggregates
+  │   Nova API query errors on no-VM/flavor filters fail-open (host is kept)
+  │   Rationale: downstream gates operate on the actionable candidate set only
+  │
+  ├─ Gate 6: Global threshold
+  │   Question: "Are too many evacuable hosts down to safely proceed?"
+  │   If failed percentage > THRESHOLD -> skip all fencing (strict `>`, not `>=`)
+  │   Skipped when filtered compute_nodes is empty
+  │   Note: numerator is post-filter down hosts; denominator is all active evacuable hosts
+  │   to_resume hosts are not counted in the calculation, but a threshold breach blocks
+  │   all processing including to_resume
+  │
+  ├─ Gate 7: Per-aggregate threshold
+  │   Question: "Is this aggregate losing too many hosts?"
+  │   If failed count > instanceha:max_failures metadata -> skip hosts in that aggregate
+  │   to_resume hosts bypass this gate (only compute_nodes are filtered)
+  │
+  ├─ Gate 8: Per-cycle rate limit
+  │   Question: "Are we fencing too many hosts at once?"
+  │   If hosts to fence > MAX_HOSTS_PER_CYCLE -> fence the first N, defer the rest
+  │
+  ├─ Gate 9: Critical services check
+  │   Question: "Are the Nova services needed for evacuation running?"
+  │   If all nova-scheduler instances are down -> skip fencing and evacuation
+  │
+  └─ Gate 10: Kdump detection (optional, CHECK_KDUMP=true)
+      Question: "Is this host crashing and dumping memory?"
+      If kdump message received -> evacuate immediately (skip fencing, host already crashed),
+      skip power-on during recovery to allow memory dump to complete
 ```
 
-When `CHECK_HEARTBEAT=false`, gates 2 and 3 are not evaluated. A warning is logged at startup to alert operators that split-brain protection is limited to the K8s API check.
+When `CHECK_HEARTBEAT=false`, gates 2 and 3 are not evaluated and gate 4 (all-services-stale) operates on the unfiltered stale set. A warning is logged at startup to alert operators that split-brain protection is limited to the K8s API check.
 
 ### Fail-Open vs Fail-Closed Semantics
 
 | Gate | On error / no data | Rationale |
 |------|-------------------|-----------|
-| K8s API (startup) | Fail-open (allow fencing) | No data yet — blocking fencing on startup would silently prevent all evacuations until the health check thread runs |
-| K8s API (after 3 failures) | Fail-closed (block fencing) | Confirmed partition — fencing would hit healthy hosts |
-| Heartbeat (grace period) | Fail-open (allow fencing) | No heartbeat history in first `HEARTBEAT_TIMEOUT` seconds — cannot distinguish "no heartbeat" from "never received one" |
+| K8s API (startup) | Fail-open (allow fencing) | No data yet -- blocking fencing on startup would silently prevent all evacuations until the health check thread runs |
+| K8s API (after 3 failures) | Fail-closed (block fencing) | Confirmed partition -- fencing would hit healthy hosts |
+| All-services-stale | Fail-closed (block fencing) | Every active host appearing stale at once is almost certainly a data-source anomaly, not genuine mass failure |
+| Heartbeat (grace period) | Fail-open (allow fencing) | No heartbeat history in first `HEARTBEAT_TIMEOUT` seconds -- cannot distinguish "no heartbeat" from "never received one" |
 | Heartbeat (steady state) | Fail-open (allow fencing) | No heartbeat = host is down = proceed with fencing |
-| Cliff detection | Fail-closed (block fencing) | Mass heartbeat loss is treated as observer failure |
+| Cliff detection | Fail-closed (block fencing), expires after `HEARTBEAT_CLIFF_MAX_CYCLES` | Mass heartbeat loss is treated as observer failure; expiry prevents permanent paralysis |
+| Per-cycle rate limit | Defer excess (allow capped fencing) | Bounds blast radius; deferred hosts are picked up on the next cycle |
+| Critical services (query error) | Fail-open (allow fencing) | If the scheduler query fails, proceed rather than block -- transient API errors should not prevent evacuation |
+| Critical services (all schedulers down) | Fail-closed (block fencing) | Confirmed all schedulers down -- evacuation cannot proceed, fencing without evacuation would only cause downtime |
 
 ### Startup Race Window
 
-`k8s_api_reachable` initializes to `True` before the background health check thread confirms K8s API connectivity. If the K8s API is genuinely unreachable at startup, fencing could proceed for up to ~45 seconds (3 failures × 15s `K8S_API_CHECK_INTERVAL`) before the check blocks it.
+`k8s_api_reachable` initializes to `True` before the background health check thread confirms K8s API connectivity. If the K8s API is genuinely unreachable at startup, fencing could proceed for up to ~45 seconds (3 failures x 15s `K8S_API_CHECK_INTERVAL`) before the check blocks it.
 
 In practice this window is smaller: the health check thread starts during `_initialize_service()` and runs its first probe almost immediately, while the main loop still needs to complete `_establish_nova_connection()` and `_reconcile_orphaned_hosts()` before its first poll. The health check typically completes its first probe before the main loop is ready to fence.
 
@@ -746,7 +766,7 @@ Every poll cycle that reaches the fencing decision point emits a single summary 
 INFO Fencing decision: 3 stale, 1 heartbeat-alive, 2 to fence, cliff=False
 ```
 
-This line is emitted in all cases — including when all hosts are filtered out by heartbeat or cliff detection — so operators can diagnose fencing decisions from a single log grep.
+This line is emitted in all cases -- including when all hosts are filtered out by heartbeat or cliff detection -- so operators can diagnose fencing decisions from a single log grep.
 
 ### Relationship to MedIK8s
 
@@ -757,7 +777,7 @@ InstanceHA and MedIK8s (NHC/FAR/SNR) operate at different layers with no overlap
 | MedIK8s | OpenShift cluster | Kubernetes node failures, pod recovery, node remediation |
 | InstanceHA | EDPM data plane | Compute host fencing, VM evacuation |
 
-MedIK8s watches Kubernetes Node objects. EDPM compute nodes are **not** Kubernetes nodes — they are external bare-metal hosts managed outside the cluster. MedIK8s cannot detect or remediate EDPM compute node failures; InstanceHA handles those independently.
+MedIK8s watches Kubernetes Node objects. EDPM compute nodes are **not** Kubernetes nodes -- they are external bare-metal hosts managed outside the cluster. MedIK8s cannot detect or remediate EDPM compute node failures; InstanceHA handles those independently.
 
 MedIK8s is relevant for control plane recovery (e.g., if the node running RabbitMQ or the InstanceHA pod itself fails). InstanceHA is relevant for data plane recovery (compute host failures requiring VM evacuation).
 
@@ -765,23 +785,27 @@ MedIK8s is relevant for control plane recovery (e.g., if the node running Rabbit
 
 ## Critical Services Validation
 
-**Function**: `_check_critical_services(conn, services, compute_nodes)`
+**Function**: `_check_critical_services(conn)`
 
 **Returns**: `(bool, str)` - can_evacuate flag and error message
 
 ### Scheduler Check
 ```python
-schedulers = [s for s in services if s.binary == 'nova-scheduler']
+try:
+    schedulers = conn.services.list(binary="nova-scheduler")
+except Exception:
+    logging.warning("Could not query nova-scheduler services, proceeding with evacuation")
+    return True, ""
 if schedulers and not any(s.state == 'up' for s in schedulers):
     return False, "All nova-scheduler services are down"
 ```
 
-Checks if at least one `nova-scheduler` service has `state == 'up'`.
+Queries Nova directly for `nova-scheduler` services. On query failure, fails open (allows evacuation). Blocks only when all schedulers are confirmed down.
 
 ### Integration
 
 ```python
-can_evacuate, error_msg = _check_critical_services(conn, services, compute_nodes)
+can_evacuate, error_msg = _check_critical_services(conn)
 if not can_evacuate:
     logging.error('Cannot evacuate: %s. Skipping evacuation.', error_msg)
     _cleanup_filtered_hosts(service, marked_hostnames, set(), current_time)
@@ -912,6 +936,8 @@ def get_int(self, key: str, default: int = 0,
 
 ## Evacuation Mechanisms
 
+See [instanceha_guide.md -- Evacuation Strategies](instanceha_guide.md#evacuation-strategies) for configuration examples and operational guidance.
+
 ### 1. Traditional Evacuation
 
 **Pattern**: Fire-and-forget approach.
@@ -976,7 +1002,7 @@ def _server_evacuate_future(connection, server, target_host=None) -> bool:
 ```
 
 **Monitoring** (`_monitor_evacuation`):
-- Separate counters for migration errors (`EVACUATION_RETRIES`, default 5, configurable 1–20) and API errors (`MAX_API_RETRIES=10`)
+- Separate counters for migration errors (`EVACUATION_RETRIES`, default 5, configurable 1-20) and API errors (`MAX_API_RETRIES=10`)
 - API error counter resets on successful API call
 - On migration failure: resets server state to `error` and re-issues `_server_evacuate` (scheduler picks new target)
 - Hard timeout: `MAX_EVACUATION_TIMEOUT_SECONDS` (300s) via `time.monotonic()`
@@ -991,7 +1017,7 @@ def _server_evacuate_future(connection, server, target_host=None) -> bool:
 - API errors retried independently (budget of 10, not shared with migration errors)
 - Times out after 300 seconds
 - Skips redundant state restore when Nova already preserved the original state after evacuation
-- Restores original VM state after successful evacuation only when needed (`SHUTOFF` → stop, `ERROR` → reset_state)
+- Restores original VM state after successful evacuation only when needed (`SHUTOFF` -> stop, `ERROR` -> reset_state)
 - Unlocks the server in `finally` block (even on failure)
 
 ---
@@ -1007,7 +1033,7 @@ def _server_evacuate_future(connection, server, target_host=None) -> bool:
 **Flow**:
 ```python
 # 1. Read orchestration metadata from all evacuable servers
-# 2. Group servers by restart_group (ungrouped → individual phases)
+# 2. Group servers by restart_group (ungrouped -> individual phases)
 # 3. Sort groups by highest member priority (descending)
 # 4. Evacuate each phase sequentially
 # 5. Within each phase, use ThreadPoolExecutor (concurrent, like smart evacuation)
@@ -1076,6 +1102,8 @@ def is_server_evacuable(self, server, evac_flavors=None, evac_images=None):
 ---
 
 ## Fencing Agents
+
+See [instanceha_guide.md -- Fencing](instanceha_guide.md#fencing) for operator-facing configuration examples and supported agent options.
 
 ### Fencing Agent Dispatch Pattern
 
@@ -1181,6 +1209,8 @@ In addition, each event emission site also increments a corresponding Prometheus
 
 ### Event Catalog
 
+See [instanceha_guide.md -- Kubernetes Events](instanceha_guide.md#kubernetes-events) for the operator-facing event table with descriptions. The table below provides the developer-facing view with "Host" scope and trigger context:
+
 | Reason | Type | Host | When |
 |--------|------|------|------|
 | `HostDown` | Warning | compute host | Compute service detected as down or stale |
@@ -1199,7 +1229,10 @@ In addition, each event emission site also increments a corresponding Prometheus
 | `AggregateThresholdExceeded` | Warning | aggregate name | Failed hosts in aggregate exceed `instanceha:max_failures` metadata limit |
 | `HostReachable` | Warning | compute host | Host reported down by Nova but still reachable via heartbeat (CHECK_HEARTBEAT) |
 | `HostReenabled` | Normal | compute host | Host re-enabled after successful evacuation |
-| `HeartbeatCliff` | Warning | `cluster` | Sudden heartbeat loss detected — possible network partition, fencing skipped for this cycle |
+| `HeartbeatCliff` | Warning | `cluster` | Sudden heartbeat loss detected -- possible network partition, fencing skipped for this cycle |
+| `HeartbeatCliffExpired` | Warning | `cluster` | Cliff detection expired after N consecutive cycles -- proceeding with fencing |
+| `FencingRateLimited` | Warning | `cluster` | Per-cycle fencing cap (`MAX_HOSTS_PER_CYCLE`) hit, excess hosts deferred to next cycle |
+| `AllServicesStale` | Warning | `cluster` | All active compute services appear stale -- likely Nova API issue, fencing skipped |
 | `OrphanedHostRecovered` | Warning | compute host | Startup reconciliation recovered a fenced host left without evacuation marker |
 
 ### Event Structure
@@ -1286,16 +1319,16 @@ The agent exposes Prometheus-format metrics at `:8080/metrics` on the same HTTP 
 **Architecture**:
 - Background UDP listener thread (port 7410)
 - Magic number validation (0x1B302A40)
-- Reverse DNS lookup (IP → hostname)
+- Reverse DNS lookup (IP -> hostname)
 - Timestamp tracking with cleanup
 
 **Behavior**:
 1. **First poll**: When host is detected as down, start waiting for `KDUMP_TIMEOUT` seconds
-2. **Kdump message received**: Host is fenced → evacuate immediately (with `resume=True`)
+2. **Kdump message received**: Host is fenced -> evacuate immediately (with `resume=True`)
    - Host marked with `disabled_reason = "instanceha evacuation (kdump): {timestamp}"`
    - Power-off fencing is skipped (host already down/rebooting)
    - `_host_disable()` is still called (host not yet disabled from Nova's perspective)
-3. **Timeout expired**: No kdump detected → proceed with normal evacuation
+3. **Timeout expired**: No kdump detected -> proceed with normal evacuation
 4. **Evacuation complete**: Update `disabled_reason` to preserve kdump marker
    - `disabled_reason = "instanceha evacuation complete (kdump): {timestamp}"`
    - Excludes service from resume category (has "evacuation complete")
@@ -1319,7 +1352,7 @@ The agent exposes Prometheus-format metrics at `:8080/metrics` on the same HTTP 
 
 ### 2. Heartbeat Detection
 
-**Purpose**: Dual-channel failure detection — distinguish host-level failures from nova-compute crashes by listening for HMAC-authenticated heartbeat packets from compute nodes.
+**Purpose**: Dual-channel failure detection -- distinguish host-level failures from nova-compute crashes by listening for HMAC-authenticated heartbeat packets from compute nodes.
 
 **Architecture**:
 - Background UDP listener thread (port 7411, configurable)
@@ -1334,8 +1367,8 @@ The agent exposes Prometheus-format metrics at `:8080/metrics` on the same HTTP 
 2. The listener verifies each packet's HMAC-SHA256 signature and timestamp freshness (rejects packets older than 120s)
 3. InstanceHA records timestamps in `heartbeat_hosts_timestamp`
 4. When Nova reports a host as down, `_filter_reachable_hosts` checks:
-   - If heartbeat received within `HEARTBEAT_TIMEOUT` seconds → host OS is alive → skip fencing (only nova-compute crashed)
-   - If no heartbeat → host is genuinely down → proceed with fencing and evacuation
+   - If heartbeat received within `HEARTBEAT_TIMEOUT` seconds -> host OS is alive -> skip fencing (only nova-compute crashed)
+   - If no heartbeat -> host is genuinely down -> proceed with fencing and evacuation
 5. **Grace period**: During the first `HEARTBEAT_TIMEOUT` seconds after listener startup, all hosts bypass heartbeat filtering (no heartbeat history exists yet)
 
 **Packet Format (HBV2)**:
@@ -1349,8 +1382,8 @@ Last 32B:    HMAC-SHA256 digest (over bytes 0 through N-32)
 Minimum packet size: 45 bytes (4 magic + 8 timestamp + 1 hostname + 32 HMAC).
 
 **Compute-Side Deployment** (edpm-ansible `edpm_instanceha_monitoring` role):
-- `instanceha-heartbeat.py` — Python script using stdlib only (socket, struct, hmac)
-- `instanceha-heartbeat.timer` — systemd timer (OnBootSec=10s, OnUnitActiveSec=30s)
+- `instanceha-heartbeat.py` -- Python script using stdlib only (socket, struct, hmac)
+- `instanceha-heartbeat.timer` -- systemd timer (OnBootSec=10s, OnUnitActiveSec=30s)
 - Runs as `nobody:nobody` (no root required for UDP send)
 - HMAC key mounted from the `<instance-name>-heartbeat-hmac` secret via EDPM dataSource
 
@@ -1370,16 +1403,16 @@ Minimum packet size: 45 bytes (4 magic + 8 timestamp + 1 hostname + 32 HMAC).
 **Architecture**:
 - Background thread started by `start_k8s_health_check()`
 - Polls `GET /api/v1/namespaces/{namespace}` using the in-cluster service account token
-- Interval controlled by `K8S_API_CHECK_INTERVAL` (default 15s, range 5–120)
+- Interval controlled by `K8S_API_CHECK_INTERVAL` (default 15s, range 5-120)
 
 **Configuration**: `K8S_API_CHECK_INTERVAL: 15`
 
 **Behavior**:
-1. `k8s_api_reachable` initializes to `True` (fail-open) — see [Fencing Safety Model](#fencing-safety-model) for the startup trade-off rationale
+1. `k8s_api_reachable` initializes to `True` (fail-open) -- see [Fencing Safety Model](#fencing-safety-model) for the startup trade-off rationale
 2. The health check thread pings the K8s API every `K8S_API_CHECK_INTERVAL` seconds
-3. Any non-5xx response (status code < 500) is treated as reachable — the API is responding, even if RBAC denies the specific request
+3. Any non-5xx response (status code < 500) is treated as reachable -- the API is responding, even if RBAC denies the specific request
 4. After 3 consecutive failures, `k8s_api_reachable` is set to `False` and `ready` is set to `False`
-5. The main poll loop checks `k8s_api_reachable` before fencing — if `False`, the entire fencing cycle is skipped
+5. The main poll loop checks `k8s_api_reachable` before fencing -- if `False`, the entire fencing cycle is skipped
 6. When connectivity restores, `k8s_api_reachable` is set back to `True`; readiness is restored after the next successful Nova poll
 
 **Prometheus**: `instanceha_k8s_api_reachable` gauge (1=ok, 0=isolated)
@@ -1394,14 +1427,16 @@ Minimum packet size: 45 bytes (4 magic + 8 timestamp + 1 hostname + 32 HMAC).
 - Integrated into `_filter_reachable_hosts()`, runs during each poll cycle when `CHECK_HEARTBEAT` is enabled
 - Compares current active heartbeat count against the previous cycle's count stored in `heartbeat_previous_active_count`
 
-**Configuration**: `HEARTBEAT_CLIFF_THRESHOLD: 50` (default 50%, range 10–100)
+**Configuration**:
+- `HEARTBEAT_CLIFF_THRESHOLD: 50` (default 50%, range 10-100)
+- `HEARTBEAT_CLIFF_MAX_CYCLES: 3` (default 3, range 1-20)
 
 **Behavior**:
 1. At each poll cycle, count hosts with a fresh heartbeat (within `HEARTBEAT_TIMEOUT`)
-2. If the previous count was ≥ 3 and the drop percentage exceeds `HEARTBEAT_CLIFF_THRESHOLD`, skip fencing for this cycle
+2. If the previous count was >= 3 and the drop percentage exceeds `HEARTBEAT_CLIFF_THRESHOLD`, increment `heartbeat_consecutive_cliff_cycles` and skip fencing for this cycle
 3. Emit a `HeartbeatCliff` K8s event (Warning) and increment `instanceha_heartbeat_cliff_total`
-4. The baseline count is preserved during a cliff event, so the cliff re-triggers on subsequent cycles until heartbeats recover
-5. When no cliff is detected, update `heartbeat_previous_active_count` for the next cycle
+4. If the cliff persists for `HEARTBEAT_CLIFF_MAX_CYCLES` consecutive cycles, accept the current state as genuine: reset the baseline to the current count, reset the cycle counter, emit a `HeartbeatCliffExpired` K8s event (Warning), and proceed with fencing
+5. When no cliff is detected, update `heartbeat_previous_active_count` and reset the consecutive cliff counter for the next cycle
 
 ---
 
@@ -1442,11 +1477,11 @@ Minimum packet size: 45 bytes (4 magic + 8 timestamp + 1 hostname + 32 HMAC).
 Failed Host: compute-01 (in aggregate-A)
 Reserved Hosts: reserved-01 (aggregate-A), reserved-02 (aggregate-B)
 
-1. Match by aggregate → Enable reserved-01
+1. Match by aggregate -> Enable reserved-01
 2. If FORCE_RESERVED_HOST_EVACUATION=true:
-   → Evacuate all VMs from compute-01 to reserved-01
+   -> Evacuate all VMs from compute-01 to reserved-01
 3. If FORCE_RESERVED_HOST_EVACUATION=false:
-   → Evacuate VMs (scheduler chooses from all available hosts)
+   -> Evacuate VMs (scheduler chooses from all available hosts)
 ```
 
 ---
@@ -1473,25 +1508,37 @@ Reserved Hosts: reserved-01 (aggregate-A), reserved-02 (aggregate-B)
 
 **Purpose**: Prevent mass evacuations during datacenter-level failures.
 
+**Evaluation order**: The threshold check runs **after** evacuability filtering (`_prepare_evacuation_resources`). The numerator is the count of down hosts that survived filtering (have VMs, match flavor/image/aggregate tags). Hosts Nova reported as down but excluded by tagging are not counted.
+
 **Implementation**:
 ```python
-# Filter to active services only — disabled and force-downed hosts excluded from denominator
-active_services = [s for s in services if 'disabled' not in s.status and not s.forced_down]
-threshold_percent = (len(compute_nodes) / len(active_services)) * 100 if active_services else 0
+# Earlier in the cycle: heartbeat filtering, then evacuability filtering
+compute_nodes, reserved_hosts, images, flavors = _prepare_evacuation_resources(
+    conn, service, services, compute_nodes, aggregates=aggregates)
+
+# Threshold uses the filtered candidate list, not the original stale-service list
+if service.config.get_config_value('TAGGED_AGGREGATES'):
+    total_evacuable = _count_evacuable_hosts(conn, service, services, aggregates=aggregates)
+    threshold_percent = (len(compute_nodes) / total_evacuable * 100) if total_evacuable > 0 else 0
+else:
+    active_services = [s for s in services if 'disabled' not in s.status and not s.forced_down]
+    threshold_percent = (len(compute_nodes) / len(active_services)) * 100 if active_services else 0
 
 if threshold_percent > service.config.get_config_value('THRESHOLD'):
     logging.error('Impacted (%.1f%%) exceeds threshold', threshold_percent)
     return  # Do not evacuate
 ```
 
-Both the standard path and the `TAGGED_AGGREGATES` path (`_count_evacuable_hosts`) use the same active-only filtering.
+Both paths exclude disabled and forced-down hosts from the denominator. The `TAGGED_AGGREGATES` path further restricts the denominator to hosts in evacuable aggregates. The numerator counts only post-filter down hosts (empty hosts excluded); the denominator counts all active evacuable hosts including healthy ones. The check is skipped when filtered `compute_nodes` is empty. `to_resume` candidates are not counted in the threshold calculation and individually bypass per-aggregate filtering, but a global threshold breach blocks all processing including `to_resume`.
+
+**Implication**: A partial infrastructure failure (for example, one Nova cell offline) that affects mostly non-evacuable hosts may not trip the global threshold. Use per-aggregate `instanceha:max_failures`, the all-services-stale gate (full-cluster anomalies only), and external monitoring for cell-level protection. See [Threshold Is Evaluated After Evacuability Filtering](instanceha_guide.md#threshold-is-evaluated-after-evacuability-filtering) in the operator guide.
 
 ### Per-Aggregate Threshold
 
 In addition to the global percentage-based threshold, operators can set an absolute failure limit per aggregate via the `instanceha:max_failures` metadata key on Nova aggregates. When `TAGGED_AGGREGATES` is enabled, the agent checks each evacuable aggregate's metadata after the global threshold passes. If the number of failed hosts in an aggregate exceeds its `instanceha:max_failures` value, evacuation is blocked for all failed hosts in that aggregate.
 
 - **Activation**: Automatic when the metadata key is present (no config option needed)
-- **Multi-aggregate semantics**: Most-restrictive-wins — if a host belongs to multiple aggregates and any one exceeds its limit, the host is blocked
+- **Multi-aggregate semantics**: Most-restrictive-wins -- if a host belongs to multiple aggregates and any one exceeds its limit, the host is blocked
 - **K8s event**: `AggregateThresholdExceeded` (Warning) emitted per blocked aggregate
 - **Metric**: `instanceha_aggregate_threshold_exceeded_total{aggregate}` counter
 
@@ -1630,7 +1677,7 @@ clouds:
 
 ## Authentication
 
-InstanceHA supports two authentication methods for connecting to the Nova API:
+InstanceHA supports two authentication methods for connecting to the Nova API. See [instanceha_guide.md -- Authentication](instanceha_guide.md#authentication) for operator-facing setup instructions and [instanceha_application_credentials.md](instanceha_application_credentials.md) for credential rotation and scoping details.
 
 ### 1. Password Authentication (Default)
 
@@ -1730,7 +1777,7 @@ for svc in services:
         continue
     if 'disabled' in svc.status:
         continue
-    # Orphaned — fenced but not marked for evacuation
+    # Orphaned -- fenced but not marked for evacuation
     conn.services.disable_log_reason(svc.id, disable_reason)
     _emit_k8s_event(svc.host, 'OrphanedHostRecovered', ...)
 ```
@@ -1754,7 +1801,7 @@ for svc in services:
 Hosts recovered by startup reconciliation (or already marked with `"instanceha evacuation:"`) are processed with `resume=True`:
 - **Power-off fencing is skipped** (host was already fenced before the crash)
 - **Host disable is skipped** if the host is already `forced_down` and `disabled`
-- **Evacuation runs** (idempotent — already-evacuated VMs are no-ops)
+- **Evacuation runs** (idempotent -- already-evacuated VMs are no-ops)
 - **Power-on is performed** after evacuation completes, ensuring the host is brought back online
 
 This ensures orphaned hosts are not left powered off indefinitely after a pod crash.
@@ -1765,7 +1812,7 @@ Emits `OrphanedHostRecovered` (Warning) for each recovered host.
 
 ### Known Limitations
 
-**Lock reconciliation scope**: The VM unlock sweep at startup only checks servers on hosts that are `forced_down AND state='down'`. This covers the realistic crash scenario (pod dies mid-evacuation while the host is still fenced). However, if the pod crashes after evacuation succeeds and post-recovery clears `forced_down`, but before the `finally` block unlocks the VMs, the locked VMs on their new (healthy) hosts would not be found by the reconciliation. This window is extremely narrow — the `finally` block in `_server_evacuate_future` runs per-server immediately after each evacuation completes, so the crash would need to occur between the evacuation completing and the `finally` executing. In practice, a SIGKILL (OOM, node crash) during concurrent evacuation would leave VMs on hosts that are still `forced_down`, which the current reconciliation handles correctly.
+**Lock reconciliation scope**: The VM unlock sweep at startup only checks servers on hosts that are `forced_down AND state='down'`. This covers the realistic crash scenario (pod dies mid-evacuation while the host is still fenced). However, if the pod crashes after evacuation succeeds and post-recovery clears `forced_down`, but before the `finally` block unlocks the VMs, the locked VMs on their new (healthy) hosts would not be found by the reconciliation. This window is extremely narrow -- the `finally` block in `_server_evacuate_future` runs per-server immediately after each evacuation completes, so the crash would need to occur between the evacuation completing and the `finally` executing. In practice, a SIGKILL (OOM, node crash) during concurrent evacuation would leave VMs on hosts that are still `forced_down`, which the current reconciliation handles correctly.
 
 A broader scan (checking all servers with `locked_reason == LOCK_REASON_EVACUATION` regardless of host state) would close this theoretical gap but requires listing all servers in the cloud at startup, which may be expensive on large deployments.
 
@@ -1786,12 +1833,12 @@ signal.signal(signal.SIGTERM, _sigterm_handler)
 
 **Behavior**:
 - `shutdown_event` is a `threading.Event` checked in the main loop condition (`while not service.shutdown_event.is_set()`)
-- All `time.sleep()` calls replaced with `service.shutdown_event.wait(seconds)` — these return immediately when the event is set
+- All `time.sleep()` calls replaced with `service.shutdown_event.wait(seconds)` -- these return immediately when the event is set
 - In-flight evacuations complete before shutdown (no abrupt termination)
 - Logs `"Graceful shutdown complete"` on exit
 
 **Kubernetes Integration**:
-- The Deployment's `terminationGracePeriodSeconds` is set to 30 seconds
+- The Deployment's `terminationGracePeriodSeconds` is set to 45 seconds
 - The Deployment strategy is `Recreate` (not `RollingUpdate`) to avoid two instances running simultaneously
 
 ---
@@ -1868,13 +1915,11 @@ _SECRET_PATTERNS = {
 }
 
 def _safe_log_exception(msg: str, e: Exception, include_traceback: bool = False) -> None:
-    safe_msg = str(e)
-    for secret_word, pattern in _SECRET_PATTERNS.items():
-        if secret_word == 'json_password':
-            safe_msg = pattern.sub(r'\1: "***"', safe_msg)
-        else:
-            safe_msg = pattern.sub(f'{secret_word}=***', safe_msg)
+    """Log exception without exposing secrets in messages or tracebacks."""
+    safe_msg = _sanitize_message(str(e))
     logging.error("%s: %s", msg, safe_msg)
+    if include_traceback:
+        logging.debug("Exception traceback:", exc_info=True)
 ```
 
 Credential sanitization covers both `key=value` and JSON `"key": "value"` formats.
@@ -1892,7 +1937,7 @@ Heartbeat packets are authenticated with HMAC-SHA256 (HBV2 protocol) to prevent 
 - The receiver tries both `hmac-key` (current) and `hmac-key-previous` (rotation) keys
 - Only HMAC-authenticated packets are accepted; unsigned packets are silently dropped
 
-Key rotation is triggered via annotation (`instanceha.openstack.org/rotate-hmac-key`). The controller copies current→previous, generates a new key, and removes the annotation.
+Key rotation is triggered via annotation (`instanceha.openstack.org/rotate-hmac-key`). The controller copies current->previous, generates a new key, and removes the annotation.
 
 ---
 
@@ -2220,27 +2265,28 @@ spec:
 
 ## Small Cluster Tuning
 
-InstanceHA works on clusters of any size, but the default safety thresholds are tuned for medium-to-large deployments. On clusters with 3–5 compute nodes, the percentage-based safety gates can block evacuation during legitimate multi-node failures because a small absolute number of failures translates to a large percentage.
+InstanceHA works on clusters of any size, but the default safety thresholds are tuned for medium-to-large deployments. On clusters with 3-5 compute nodes, the percentage-based safety gates can block evacuation during legitimate multi-node failures because a small absolute number of failures translates to a large percentage. See also [instanceha_guide.md -- Tuning by cluster size](instanceha_guide.md#tuning-by-cluster-size) for operator-facing tuning recommendations across all cluster sizes.
 
 ### Affected Safety Gates
 
 | Gate | Default | 3-node impact | 4-node impact |
 |------|---------|---------------|---------------|
-| **THRESHOLD** (global, `>`) | 50% | 2 failures = 66.7% → **blocked** | 2 failures = 50% → allowed (check is `>`, not `>=`) |
-| **HEARTBEAT_CLIFF_THRESHOLD** (`>=`) | 50% | 2 heartbeat losses = 66.7% → **cliff triggered** | 2 losses = 50% → **cliff triggered** (check is `>=`) |
+| **THRESHOLD** (global, `>`) | 50% | 2 failures = 66.7% -> **blocked** | 2 failures = 50% -> allowed (check is `>`, not `>=`) |
+| **HEARTBEAT_CLIFF_THRESHOLD** (`>=`) | 50% | 2 heartbeat losses = 66.7% -> **cliff triggered** | 2 losses = 50% -> **cliff triggered** (check is `>=`) |
+| **MAX_HOSTS_PER_CYCLE** | 10 | Not affected (absolute cap) | Not affected (absolute cap) |
 | **Per-aggregate threshold** | N/A (absolute count) | Not affected (uses absolute `instanceha:max_failures`) | Not affected |
 
 Single-node failures are handled correctly at any cluster size.
 
 ### Recommended Configuration
 
-For clusters with 3–5 compute nodes where simultaneous multi-node failures are a realistic scenario (not just network partitions):
+For clusters with 3-5 compute nodes where simultaneous multi-node failures are a realistic scenario (not just network partitions):
 
 ```yaml
 config:
-  THRESHOLD: 100              # Disable global threshold — trust fencing to proceed
+  THRESHOLD: 100              # Disable global threshold -- trust fencing to proceed
   CHECK_HEARTBEAT: true       # Enable heartbeat detection to distinguish host vs nova-compute failures
-  HEARTBEAT_CLIFF_THRESHOLD: 100  # Disable cliff detection — trust individual heartbeat status
+  HEARTBEAT_CLIFF_THRESHOLD: 100  # Disable cliff detection -- trust individual heartbeat status
 ```
 
 Setting `THRESHOLD: 100` disables the global percentage check entirely. This is safe because:
@@ -2266,7 +2312,7 @@ The default `THRESHOLD: 50` and `HEARTBEAT_CLIFF_THRESHOLD: 50` are deliberately
 
 ## Configuration Options Reference
 
-This section describes each configuration option in the `_config_map`, including its purpose, validation rules, usage in the codebase, and testing coverage.
+This section describes each configuration option in the `_config_map`, including its purpose, validation rules, usage in the codebase, and testing coverage. See [instanceha_guide.md -- Configuration Reference](instanceha_guide.md#configuration-reference) for a compact operator-facing table with all options, defaults, and valid ranges.
 
 ### Core Service Options
 
@@ -2304,7 +2350,7 @@ config:
 **Description**: Service staleness threshold. A compute service is considered stale (and eligible for evacuation) if its `updated_at` timestamp is older than `current_time - DELTA` seconds.
 
 **Usage**:
-- Used in main poll loop to calculate `target_date = datetime.utcnow() - timedelta(seconds=DELTA)`
+- Used in main poll loop to calculate `target_date = datetime.now(timezone.utc) - timedelta(seconds=DELTA)`
 - Services with `updated_at < target_date` are categorized as stale compute nodes
 - Works in conjunction with Nova service heartbeat mechanism
 
@@ -2362,7 +2408,7 @@ config:
 - Calculation depends on `TAGGED_AGGREGATES` setting:
   - When `TAGGED_AGGREGATES=false`: `(failed_hosts / active_hosts) * 100`
   - When `TAGGED_AGGREGATES=true`: `(failed_hosts / active_evacuable_hosts) * 100`
-- If threshold exceeded, evacuation is skipped and error logged
+- If percentage is strictly greater than threshold, evacuation is skipped and error logged
 
 **Behavior**:
 - **Without aggregate filtering** (`TAGGED_AGGREGATES=false`):
@@ -2504,7 +2550,7 @@ config:
   - Polls every 5 seconds until completion or timeout (300s)
   - Separate error budgets: migration errors (max 5) and API errors (max 10)
   - Migration failures trigger automatic re-issue (reset state + new evacuate call)
-  - Restores original VM state after success (`SHUTOFF` → stop, `ERROR` → reset_state)
+  - Restores original VM state after success (`SHUTOFF` -> stop, `ERROR` -> reset_state)
   - Updates service `disabled_reason` on success/failure
   - Uses thread pool (`WORKERS`) for concurrent tracking
 
@@ -2581,14 +2627,14 @@ openstack server set --property instanceha:restart_priority=100 web-server
 
 #### SKIP_SERVERS_WITH_NAME
 **Type**: List (of strings)
-**Default**: `""` (empty string — no servers skipped)
+**Default**: `""` (empty string -- no servers skipped)
 **Range**: N/A
 
 **Description**: List of glob patterns to exclude from evacuation. Any server whose name matches one of these patterns (using `fnmatch` glob syntax) is skipped during evacuation.
 
 **Usage**:
 - Evaluated in `_get_evacuable_servers()` before evacuability filtering
-- Uses glob matching (`fnmatch.fnmatch(server.name, pattern)`) — supports `*` (any chars), `?` (single char), `[seq]` (character set)
+- Uses glob matching (`fnmatch.fnmatch(server.name, pattern)`) -- supports `*` (any chars), `?` (single char), `[seq]` (character set)
 - Skipped servers are logged with their IDs for auditability
 
 **Behavior**:
@@ -2614,7 +2660,7 @@ This would skip servers named `test-vm-1`, `dev-instance-02`, etc.
 #### EVACUATION_RETRIES
 **Type**: Integer
 **Default**: `5`
-**Range**: 1–20
+**Range**: 1-20
 
 **Description**: Maximum number of times to retry a failed per-instance evacuation before giving up.
 
@@ -2665,11 +2711,11 @@ config:
 **Workflow**:
 ```
 1. compute-01 fails (in aggregate-A)
-2. Find reserved hosts in aggregate-A → reserved-01
+2. Find reserved hosts in aggregate-A -> reserved-01
 3. Enable reserved-01
 4. Evacuate VMs from compute-01
-   - If FORCE_RESERVED_HOST_EVACUATION=true → evacuate to reserved-01
-   - If FORCE_RESERVED_HOST_EVACUATION=false → scheduler chooses destination
+   - If FORCE_RESERVED_HOST_EVACUATION=true -> evacuate to reserved-01
+   - If FORCE_RESERVED_HOST_EVACUATION=false -> scheduler chooses destination
 ```
 
 ---
@@ -2838,7 +2884,7 @@ openstack aggregate set --property ha-enabled=true production-hosts
 **Behavior**:
 - Affects re-enable filtering in `_process_reenabling()`
 - When `true`: Services with "evacuation complete" marker are skipped during re-enable processing
-- When `false`: Services progress through re-enable workflow (unset force-down → wait for up → enable)
+- When `false`: Services progress through re-enable workflow (unset force-down -> wait for up -> enable)
 
 **Testing**:
 - Configuration feature tests verify re-enable filtering
@@ -2868,8 +2914,8 @@ config:
 - When `false`: Wait for all migrations to reach "completed" state before unsetting `forced_down`
 
 **Behavior**:
-- Normal workflow: Check migrations → wait for completion → unset force-down → wait for up → enable
-- With `FORCE_ENABLE=true`: Skip migration check → unset force-down → wait for up → enable
+- Normal workflow: Check migrations -> wait for completion -> unset force-down -> wait for up -> enable
+- With `FORCE_ENABLE=true`: Skip migration check -> unset force-down -> wait for up -> enable
 - Kdump delay still respected (60s wait after last kdump message)
 
 **Testing**:
@@ -2905,8 +2951,8 @@ config:
 - **Enabled**:
   - Start UDP listener on port 7410 (or `UDP_PORT` env var)
   - When host detected as down, wait up to `KDUMP_TIMEOUT` seconds for kdump message
-  - If message received: fence host → evacuate with `resume=True` (skip power-off)
-  - If timeout: proceed with normal evacuation (power off → evacuate)
+  - If message received: fence host -> evacuate with `resume=True` (skip power-off)
+  - If timeout: proceed with normal evacuation (power off -> evacuate)
 
 - **Disabled**:
   - No UDP listener thread
@@ -2957,7 +3003,7 @@ fence_kdump_args -p 7410
 - After timeout, proceed with normal evacuation
 
 **Behavior**:
-- Host detected as down → record timestamp
+- Host detected as down -> record timestamp
 - Each poll cycle: check if `current_time - detection_time > KDUMP_TIMEOUT`
 - If kdump message received before timeout: immediate evacuation with kdump marker
 - If timeout expires: normal evacuation workflow
@@ -2985,7 +3031,7 @@ POLL=45, KDUMP_TIMEOUT=300
 - Cycle 3 (t=90s):  Still waiting (90 < 300)
 - ...
 - Cycle 7 (t=270s): Still waiting (270 < 300)
-- Cycle 8 (t=315s): Timeout expired (315 > 300) → evacuate
+- Cycle 8 (t=315s): Timeout expired (315 > 300) -> evacuate
 ```
 
 **Notes**: Multiple poll cycles can occur during timeout period.
@@ -2999,7 +3045,7 @@ POLL=45, KDUMP_TIMEOUT=300
 **Default**: `false`
 **Range**: N/A
 
-**Description**: Enable heartbeat-based dual-channel failure detection. When enabled, compute nodes send periodic UDP heartbeat packets. If Nova reports a host as down but heartbeats are still arriving, the host OS is alive and only nova-compute has crashed — fencing is skipped.
+**Description**: Enable heartbeat-based dual-channel failure detection. When enabled, compute nodes send periodic UDP heartbeat packets. If Nova reports a host as down but heartbeats are still arriving, the host OS is alive and only nova-compute has crashed -- fencing is skipped.
 
 **Usage**:
 - Controls whether heartbeat UDP listener thread is started (port 7411)
@@ -3069,16 +3115,61 @@ config:
 
 **Behavior**:
 - If drop percentage >= `HEARTBEAT_CLIFF_THRESHOLD`: skip all fencing this cycle, emit `HeartbeatCliff` K8s event (Warning)
-- Baseline count is preserved during a cliff event, so the cliff re-triggers on subsequent cycles until heartbeats recover
-- When no cliff is detected, update `heartbeat_previous_active_count` for the next cycle
+- If the cliff persists for `HEARTBEAT_CLIFF_MAX_CYCLES` consecutive cycles, the baseline resets and fencing proceeds
+- When no cliff is detected, update `heartbeat_previous_active_count` and reset the consecutive cliff counter
 
-**Small Cluster Considerations**: On a 3-node cluster with all nodes sending heartbeats, losing 2 nodes simultaneously causes a 66.7% drop — exceeding the default 50% threshold. This blocks fencing for that cycle. If simultaneous multi-node failures are expected (not partitions), raise this value (e.g., `100` to disable cliff detection entirely). See [Small Cluster Tuning](#small-cluster-tuning).
+**Small Cluster Considerations**: On a 3-node cluster with all nodes sending heartbeats, losing 2 nodes simultaneously causes a 66.7% drop -- exceeding the default 50% threshold. This blocks fencing for that cycle. If simultaneous multi-node failures are expected (not partitions), raise this value (e.g., `100` to disable cliff detection entirely). See [Small Cluster Tuning](#small-cluster-tuning).
 
 **Example**:
 ```yaml
 config:
   CHECK_HEARTBEAT: true
   HEARTBEAT_CLIFF_THRESHOLD: 100  # Disable cliff detection (trust individual heartbeat status)
+```
+
+---
+
+#### HEARTBEAT_CLIFF_MAX_CYCLES
+**Type**: Integer
+**Default**: `3`
+**Range**: `1-20`
+
+**Description**: Number of consecutive cliff detection cycles before the agent accepts the current heartbeat state as genuine and proceeds with fencing. Prevents a sustained infrastructure failure (e.g., rack switch outage that kills both heartbeats and hosts) from permanently suppressing fencing.
+
+**Usage**:
+- Evaluated in `_filter_reachable_hosts()` when a cliff is detected
+- Increments `heartbeat_consecutive_cliff_cycles` on each cliff cycle
+- When the counter reaches `HEARTBEAT_CLIFF_MAX_CYCLES`, resets the baseline and cycle counter, emits a `HeartbeatCliffExpired` K8s event (Warning), and allows fencing to proceed
+
+**Safety dependency**: When the cliff expires, the `MAX_HOSTS_PER_CYCLE` rate limiter is the primary defense against fencing too many hosts at once if the expiry was triggered by a network partition rather than a genuine mass failure. These two settings are mutually dependent -- raising `MAX_HOSTS_PER_CYCLE` to a large value while using a low `HEARTBEAT_CLIFF_MAX_CYCLES` weakens the safety net. As a guideline, ensure `HEARTBEAT_CLIFF_MAX_CYCLES * POLL` exceeds the longest expected network reconvergence event in your environment (BGP: ~3 min, ToR switch reboot: ~5 min).
+
+**Interaction with per-host heartbeat filtering**: After cliff expiry, individual hosts whose last heartbeat is still within `HEARTBEAT_TIMEOUT` are still individually skipped. Cliff expiry resets the cliff gate but does not bypass per-host heartbeat checks -- this is intentional defense-in-depth.
+
+**Example**:
+```yaml
+config:
+  CHECK_HEARTBEAT: true
+  HEARTBEAT_CLIFF_MAX_CYCLES: 5  # Wait 5 cycles before accepting cliff as genuine
+```
+
+---
+
+#### MAX_HOSTS_PER_CYCLE
+**Type**: Integer
+**Default**: `10`
+**Range**: `1-100`
+
+**Description**: Maximum number of hosts that can be fenced in a single poll cycle. If more hosts are detected as down, the first `MAX_HOSTS_PER_CYCLE` are fenced and the rest are deferred to the next cycle. This bounds the blast radius of a single poll cycle -- a Nova API anomaly (conductor crash, stale data, Keystone token issue) cannot trigger mass fencing beyond this cap.
+
+**Usage**:
+- Applied in `_process_stale_services()` after all other safety gates (threshold, per-aggregate, heartbeat) have run
+- Deferred hosts are not lost -- they are re-evaluated on the next poll cycle
+- A `FencingRateLimited` K8s event (Warning) is emitted when the cap is hit
+
+**Example**:
+```yaml
+config:
+  MAX_HOSTS_PER_CYCLE: 5  # Conservative: fence at most 5 hosts per cycle
 ```
 
 ---
@@ -3188,7 +3279,7 @@ export SSL_KEY_PATH=/path/to/client-key.pem
 **Behavior**:
 - **IPMI**: Direct timeout for command execution
 - **Redfish**:
-  - Request timeout: `FENCING_TIMEOUT` (clamped to 5–300 seconds per request)
+  - Request timeout: `FENCING_TIMEOUT` (clamped to 5-300 seconds per request)
   - Retries on timeout or transient errors (max 3 attempts)
   - Total operation time: up to `3 * FENCING_TIMEOUT`
 - **BMH**:
@@ -3217,7 +3308,7 @@ timeout 60 ipmitool -I lanplus -H 192.168.1.10 ... power off
 
 *Redfish*:
 ```python
-# 3 retries × 20 second timeout = 60 seconds max
+# 3 retries x 20 second timeout = 60 seconds max
 requests.post(url, timeout=20)  # Retry up to 3 times
 ```
 
@@ -3246,9 +3337,9 @@ requests.post(url, timeout=20)  # Retry up to 3 times
 **Behavior**:
 - Health hash updated approximately every `HASH_INTERVAL` seconds
 - Hash exposed via HTTP health check server on port 8080:
-  - `GET /` — **Liveness probe**: returns 200 with current hash if `hash_update_successful`, 500 otherwise
-  - `GET /healthz` — **Readiness probe**: returns 200 if `ready` flag is set (after first successful poll), 503 otherwise
-  - `GET /metrics` — **Prometheus metrics**: returns all registered metrics in Prometheus text format
+  - `GET /` -- **Liveness probe**: returns 200 with current hash if `hash_update_successful`, 500 otherwise
+  - `GET /healthz` -- **Readiness probe**: returns 200 if `ready` flag is set (after first successful poll), 503 otherwise
+  - `GET /metrics` -- **Prometheus metrics**: returns all registered metrics in Prometheus text format
 - `hash_update_successful` flag indicates service liveness
 - `ready` flag set to `True` after first successful poll cycle completes
 - Hash updated at most once per `HASH_INTERVAL` seconds
@@ -3297,8 +3388,8 @@ config:
   - `test_ipv6_udp.py` (IPv6 UDP listener tests)
 - **Documentation**:
   - This file (instanceha_architecture.md)
-  - [instanceha_guide.md](instanceha_guide.md) — Operator deployment and configuration guide
-  - [instanceha_prometheus.md](instanceha_prometheus.md) — Prometheus monitoring, alerting, and dashboards
+  - [instanceha_guide.md](instanceha_guide.md) -- Operator deployment and configuration guide
+  - [instanceha_prometheus.md](instanceha_prometheus.md) -- Prometheus monitoring, alerting, and dashboards
 - **OpenStack API**: https://docs.openstack.org/api-ref/compute/
 - **Redfish**: https://www.dmtf.org/standards/redfish
 - **Metal3**: https://metal3.io/

--- a/docs/instanceha_guide.md
+++ b/docs/instanceha_guide.md
@@ -53,11 +53,11 @@ InstanceHA runs as a Kubernetes-managed workload alongside the OpenStack control
 
 1. **Detection**: The agent polls the Nova API every `POLL` seconds (default: 45). It queries all `nova-compute` services and checks each one's `updated_at` timestamp. A service is considered failed if it is reported as `down` or if its `updated_at` timestamp is older than `DELTA` seconds (default: 30). When heartbeat verification is enabled (`CHECK_HEARTBEAT`), both the Nova service-list poll and the UDP heartbeat channel must agree that a host is unreachable before it is marked as failed.
 
-2. **Safety checks**: Before acting, the agent verifies that the percentage of failed hosts does not exceed the `THRESHOLD` (default: 50%) — calculated against only active services, excluding already-disabled and already-forced-down hosts — and that at least one `nova-scheduler` is running. These checks prevent cascading evacuations during infrastructure-wide outages. A `ThresholdExceeded` K8s event is emitted when the limit is hit.
+2. **Safety checks**: Before acting, the agent verifies that the percentage of failed hosts does not exceed the `THRESHOLD` (default: 50%) -- calculated against only active services, excluding already-disabled and already-forced-down hosts -- and that at least one `nova-scheduler` is running. These checks prevent cascading evacuations during infrastructure-wide outages. A `ThresholdExceeded` K8s event is emitted when the limit is hit.
 
 3. **Fencing**: The failed host is powered off via its baseboard management controller (BMC) using IPMI, Redfish, or the Metal3 Kubernetes API. Fencing ensures the host is truly offline before evacuation begins, preventing split-brain scenarios where the old and new copies of an instance run simultaneously. The server is locked in Nova (API microversion 2.73, reason `instanceha-evacuation`) to prevent concurrent operations.
 
-4. **Evacuation**: The agent marks the compute service as `forced_down` and `disabled` in Nova, then calls the evacuate API for each eligible instance. Three strategies are available — traditional (fire-and-forget), smart (tracked to completion), and orchestrated (priority-ordered phases). All strategies use continue-on-failure semantics: a single failed evacuation does not abort the remaining ones.
+4. **Evacuation**: The agent marks the compute service as `forced_down` and `disabled` in Nova, then calls the evacuate API for each eligible instance. Three strategies are available -- traditional (fire-and-forget), smart (tracked to completion), and orchestrated (priority-ordered phases). All strategies use continue-on-failure semantics: a single failed evacuation does not abort the remaining ones.
 
 5. **Recovery**: After evacuation completes, the agent updates the service's `disabled_reason` marker. When the host comes back online and its `nova-compute` service reports `up`, the agent automatically re-enables it and unlocks its servers (unless `LEAVE_DISABLED` is set). K8s events are emitted at each stage.
 
@@ -121,78 +121,34 @@ InstanceHA emits Kubernetes events on the InstanceHa CR to provide observability
 | `ThresholdExceeded` | Warning | Too many hosts down simultaneously |
 | `AggregateThresholdExceeded` | Warning | Per-aggregate failure threshold exceeded |
 | `OrphanedHostRecovered` | Warning | Recovered fenced host from prior crash |
-| `HeartbeatCliff` | Warning | Sudden heartbeat loss detected — possible network partition, fencing skipped |
+| `HeartbeatCliff` | Warning | Sudden heartbeat loss detected -- possible network partition, fencing skipped |
+| `HeartbeatCliffExpired` | Warning | Cliff detection expired after N consecutive cycles -- proceeding with fencing |
+| `FencingRateLimited` | Warning | Per-cycle fencing cap (`MAX_HOSTS_PER_CYCLE`) hit, excess hosts deferred to next cycle |
+| `AllServicesStale` | Warning | All active compute services appear stale -- likely Nova API issue, fencing skipped |
 
 Events can be viewed with `oc describe instanceha <name>` or `oc get events --field-selector involvedObject.name=<name>`.
 
 ### Prometheus Metrics
 
-In addition to Kubernetes Events, the agent exposes Prometheus metrics at `http://<pod-ip>:8080/metrics`. These provide time-series data suitable for dashboards, alerting, and capacity planning. See [instanceha_prometheus.md](instanceha_prometheus.md) for a complete operations guide covering scraping setup, alert rules, testing, and Grafana dashboards.
+The agent exposes Prometheus metrics at `http://<pod-ip>:8080/metrics`, covering the full evacuation lifecycle: host failure detection, fencing, evacuation, recovery, and poll loop health. Key metric families:
 
-#### Counters
+- **Counters**: `instanceha_fencing_total`, `instanceha_evacuation_total`, `instanceha_host_down_total`, `instanceha_poll_cycles_total`, and others -- track cumulative event counts with `host` and `result` labels.
+- **Gauges**: `instanceha_poll_consecutive_failures`, `instanceha_hosts_processing`, `instanceha_k8s_api_reachable` -- track current state.
+- **Histograms**: `instanceha_instance_evacuation_duration_seconds` -- track per-instance evacuation latency.
 
-| Metric | Labels | Description |
-|--------|--------|-------------|
-| `instanceha_fencing_total` | `host`, `result` | Total fencing operations (result: `started`, `succeeded`, `failed`) |
-| `instanceha_evacuation_total` | `host`, `result` | Host-level evacuation operations |
-| `instanceha_instance_evacuation_total` | `host`, `result` | Per-instance evacuation operations (smart/orchestrated mode) |
-| `instanceha_host_down_total` | `host` | Host-down detections |
-| `instanceha_host_reachable_total` | `host` | Hosts reported down by Nova but still reachable via heartbeat |
-| `instanceha_host_reenabled_total` | `host` | Hosts re-enabled after evacuation |
-| `instanceha_threshold_exceeded_total` | | Evacuations skipped due to threshold |
-| `instanceha_aggregate_threshold_exceeded_total` | `aggregate` | Evacuations blocked by per-aggregate threshold |
-| `instanceha_recovery_completed_total` | `host` | Full recovery workflows completed |
-| `instanceha_processing_failed_total` | `host` | Service processing failures |
-| `instanceha_orphaned_host_recovered_total` | | Orphaned hosts recovered at startup |
-| `instanceha_poll_cycles_total` | `result` | Poll cycles executed (result: `success`, `error`) |
-| `instanceha_heartbeat_rejected_total` | `reason` | Heartbeat packets rejected (`hmac_failed`, `timestamp_invalid`) |
-| `instanceha_heartbeat_cliff_total` | | Fencing skipped due to sudden heartbeat loss (possible network partition) |
+The infra-operator automatically creates a Kubernetes Service (`<instance-name>-metrics`) that the telemetry-operator discovers and scrapes via the COO Prometheus. **No manual configuration is needed when the telemetry-operator is deployed.**
 
-#### Gauges
-
-| Metric | Description |
-|--------|-------------|
-| `instanceha_poll_consecutive_failures` | Current consecutive Nova API poll failures (resets to 0 on success) |
-| `instanceha_hosts_processing` | Number of hosts currently being processed |
-| `instanceha_k8s_api_reachable` | Whether the Kubernetes API is reachable (1=yes, 0=no) |
-
-#### Histograms
-
-| Metric | Labels | Buckets (seconds) | Description |
-|--------|--------|-------------------|-------------|
-| `instanceha_instance_evacuation_duration_seconds` | `host` | 10, 30, 60, 120, 180, 300, 600 | Duration of individual instance evacuations |
-
-See [instanceha_prometheus.md](instanceha_prometheus.md) for alert rules, Grafana dashboard queries, and PromQL examples.
-
-#### Scraping Configuration
-
-The InstanceHA pod exposes metrics on TCP port 8080. The infra-operator automatically creates a Kubernetes Service (`<instance-name>-metrics`) with the labels `metrics: enabled` and `service: instanceha`, which the telemetry-operator discovers and scrapes via the COO Prometheus. **No manual configuration is needed when the telemetry-operator is deployed.**
-
-For environments using OpenShift user workload monitoring instead of (or in addition to) the telemetry-operator, create a `PodMonitor`:
-
-```yaml
-apiVersion: monitoring.coreos.com/v1
-kind: PodMonitor
-metadata:
-  name: instanceha-metrics
-  namespace: openstack
-spec:
-  selector:
-    matchLabels:
-      service: instanceha  # Replace with your CR name if different
-  podMetricsEndpoints:
-    - port: metrics
-      path: /metrics
-      interval: 30s
-```
+See [instanceha_prometheus.md](instanceha_prometheus.md) for the complete metric catalog, scraping setup (including PodMonitor for user workload monitoring), TLS configuration, alert rules, Grafana dashboard queries, and PromQL examples.
 
 ### Graceful Shutdown
 
-When the pod receives SIGTERM (during scaling, rolling updates, or node drain), InstanceHA finishes any in-flight fencing or evacuation work before exiting. The Deployment is configured with a 30-second termination grace period. The agent's poll loop and evacuation workers check a shutdown flag between cycles, allowing timely response to shutdown signals.
+When the pod receives SIGTERM (during scaling, rolling updates, or node drain), InstanceHA immediately marks itself as not-ready (`ready = False`), stops the heartbeat and kdump listeners, shuts down the health check HTTP server, and sets the shutdown flag. In-flight fencing and evacuation workers check this flag between operations and finish promptly. The Deployment is configured with a 45-second termination grace period.
+
+> **Note:** The worst-case shutdown time depends on `FENCING_TIMEOUT` (default 30s) plus thread-pool drain time. If you increase `FENCING_TIMEOUT` beyond the default, consider increasing `terminationGracePeriodSeconds` in the Deployment spec accordingly to avoid SIGKILL during in-flight fencing or evacuation. If the pod is killed mid-operation, orphan recovery at the next startup handles any partially-processed hosts.
 
 ### Network Partition Detection
 
-Two complementary mechanisms prevent the agent from fencing healthy hosts when the pod's worker node is network-isolated:
+Two complementary mechanisms prevent the agent from fencing healthy hosts when the pod's worker node is network-isolated. See [instanceha_architecture.md -- Fail-Open vs Fail-Closed Semantics](instanceha_architecture.md#fail-open-vs-fail-closed-semantics) for the rationale behind each gate's behavior on error.
 
 **K8s API connectivity check:**
 - A background thread pings the K8s API every `K8S_API_CHECK_INTERVAL` seconds (default: 15) using the in-cluster service account.
@@ -203,12 +159,13 @@ Two complementary mechanisms prevent the agent from fencing healthy hosts when t
 - The agent tracks the count of active heartbeat hosts between poll cycles.
 - If the count drops by more than `HEARTBEAT_CLIFF_THRESHOLD`% (default: 50%) in a single cycle (minimum 3 hosts previously active), fencing is skipped for that cycle. A sudden mass-silence is far more likely to indicate a listener-side network issue than simultaneous host failures.
 - A `HeartbeatCliff` K8s event (Warning) is emitted and the `instanceha_heartbeat_cliff_total` counter is incremented.
-- The detection re-evaluates on the next cycle — the baseline is preserved during a cliff, so fencing stays blocked until heartbeats recover.
+- If the cliff persists for `HEARTBEAT_CLIFF_MAX_CYCLES` consecutive cycles (default: 3), the agent accepts the current state as a genuine failure, resets the baseline, and proceeds with fencing. This prevents a sustained infrastructure failure (e.g., a rack switch outage) from permanently suppressing fencing.
 
 ```yaml
 config:
   K8S_API_CHECK_INTERVAL: "15"
   HEARTBEAT_CLIFF_THRESHOLD: "50"
+  HEARTBEAT_CLIFF_MAX_CYCLES: "3"
 ```
 
 ---
@@ -275,7 +232,7 @@ spec:
 
 The `networkAttachments` field lists Multus NetworkAttachmentDefinition CRs to attach to the InstanceHA pod. Each entry adds an additional network interface. The UDP listeners (kdump and heartbeat) bind to `::` (dual-stack), so they accept both IPv4 and IPv6 packets on any attached interface.
 
-A common pattern is to separate heartbeat traffic from the API network. Heartbeat packets are small and frequent — putting them on the same network as the Nova API can add noise, and a congested API network could delay heartbeats enough to trigger false positives. Using a dedicated network for heartbeat avoids both problems:
+A common pattern is to separate heartbeat traffic from the API network. Heartbeat packets are small and frequent -- putting them on the same network as the Nova API can add noise, and a congested API network could delay heartbeats enough to trigger false positives. Using a dedicated network for heartbeat avoids both problems:
 
 ```yaml
 spec:
@@ -310,13 +267,48 @@ spec:
 
 Compute nodes then send their heartbeat packets to the InstanceHA pod's IP on the `heartbeat-net` network (e.g., `172.20.0.x:7411`), while the Nova API traffic flows through `internalapi` as usual.
 
-When only a single `networkAttachments` entry is provided (the typical case), all traffic — Nova API, kdump, and heartbeat — shares that interface.
+When only a single `networkAttachments` entry is provided (the typical case), all traffic -- Nova API, kdump, and heartbeat -- shares that interface.
 
 ### Stable IP for UDP Listeners
 
 By default, the InstanceHA pod receives a dynamic IP from the Multus IPAM pool. If the pod restarts, it may get a different IP, and compute nodes sending kdump or heartbeat packets to the old address will fail until reconfigured.
 
 To provide a stable IP that survives pod restarts, create a MetalLB-backed LoadBalancer Service that fronts the InstanceHA UDP ports. Compute nodes send packets to the Service's external IP, and MetalLB routes them to the pod regardless of its current address.
+
+#### Heartbeat only (no kdump)
+
+When kdump detection is disabled (`CHECK_KDUMP: "false"`), the heartbeat Service can share an existing OpenStack IP because `externalTrafficPolicy: Local` is not needed -- the sender's hostname is embedded in the HMAC-authenticated packet payload, so source IP rewriting does not break heartbeat identification:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: instanceha-heartbeat
+  namespace: openstack
+  annotations:
+    metallb.universe.tf/address-pool: internalapi
+    metallb.universe.tf/allow-shared-ip: internalapi
+    metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+spec:
+  type: LoadBalancer
+  selector:
+    service: instanceha
+  ports:
+  - name: heartbeat
+    port: 7411
+    targetPort: 7411
+    protocol: UDP
+```
+
+Replace `172.17.0.80` with the shared IP already used by your `internalapi` services. The `allow-shared-ip` annotation lets this Service share the same IP with other OpenStack services (e.g., keystone, nova, cinder) -- since port 7411/UDP doesn't conflict with any existing service ports, sharing is safe and avoids consuming an additional IP.
+
+#### Heartbeat + kdump
+
+When kdump detection is enabled (`CHECK_KDUMP: "true"`), the kdump listener identifies the crashing host via reverse DNS lookup on the packet's source IP. This requires `externalTrafficPolicy: Local` to preserve the original source IP -- without it, kube-proxy masquerades (SNATs) the source IP when forwarding traffic to the pod, replacing the compute node's real IP with an internal node address and causing the reverse DNS lookup to fail.
+
+> **Important:** MetalLB requires all Services sharing the same IP to use the same `externalTrafficPolicy`. If the existing OpenStack services on `172.17.0.80` use `externalTrafficPolicy: Cluster` (the default), you **cannot** add a new Service with `externalTrafficPolicy: Local` on the same IP -- MetalLB will reject the configuration. You must use a **different IP** (and typically a different network) for the kdump+heartbeat Service.
+
+When using a [dedicated heartbeat network](#dedicated-heartbeat-network), place the MetalLB Service on that network's address pool so UDP traffic stays off the API network entirely:
 
 ```yaml
 apiVersion: v1
@@ -325,14 +317,13 @@ metadata:
   name: instanceha-udp
   namespace: openstack
   annotations:
-    metallb.universe.tf/address-pool: internalapi
-    metallb.universe.tf/allow-shared-ip: internalapi
-    metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+    metallb.universe.tf/address-pool: heartbeat-net
+    metallb.universe.tf/loadBalancerIPs: 172.20.0.80
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local
   selector:
-    service: instanceha  # Replace with your CR name if different
+    service: instanceha
   ports:
   - name: kdump
     port: 7410
@@ -344,13 +335,18 @@ spec:
     protocol: UDP
 ```
 
-> **Important:** `externalTrafficPolicy: Local` is required when kdump detection is enabled (`CHECK_KDUMP: "true"`). The kdump listener identifies the crashing host via reverse DNS lookup on the packet's source IP. Without `Local` policy, kube-proxy masquerades (SNATs) the source IP when forwarding traffic to the pod, replacing the compute node's real IP with an internal node address — causing the reverse DNS lookup to fail. `Local` policy preserves the original source IP by delivering traffic directly to the pod on the receiving node without cross-node forwarding or SNAT. (Heartbeat packets are unaffected — the sender's hostname is embedded in the HMAC-authenticated packet payload, so source IP rewriting does not break heartbeat identification.)
+Replace `172.20.0.80` with an IP from your heartbeat network's MetalLB address pool (the pool must cover the `172.20.0.0/24` range or whichever range your dedicated network uses). Because this is a separate pool from `internalapi`, there is no `externalTrafficPolicy` conflict with existing OpenStack services.
 
-Replace `172.17.0.80` with an IP from your `internalapi` MetalLB address pool. The `allow-shared-ip` annotation lets this Service share the same IP with other OpenStack services (e.g., keystone, nova, cinder) that already use the `internalapi` pool — since the InstanceHA ports (7410/UDP, 7411/UDP) don't conflict with any existing service ports, sharing is safe and avoids consuming an additional IP. If you prefer a dedicated IP, pick an unused address and remove the `allow-shared-ip` annotation.
+If you do not have a dedicated heartbeat network, you can still use the `internalapi` pool -- but you must pick an **unused** IP and omit the `allow-shared-ip` annotation:
 
-> **Note:** The `address-pool` value must match the actual MetalLB IPAddressPool name. In a standard openstack-k8s-operators deployment this is `internalapi`. You can verify the pool name with `oc get ipaddresspools -n metallb-system`.
+```yaml
+    metallb.universe.tf/address-pool: internalapi
+    metallb.universe.tf/loadBalancerIPs: 172.17.0.85
+```
 
-Then configure compute nodes to send kdump and heartbeat packets to that IP instead of the pod IP.
+> **Note:** The `address-pool` value must match the actual MetalLB IPAddressPool name. Verify pool names with `oc get ipaddresspools -n metallb-system`.
+
+Then configure compute nodes to send kdump and heartbeat packets to the Service IP instead of the pod IP.
 
 ### Required Secrets and ConfigMaps
 
@@ -467,7 +463,7 @@ See `docs/instanceha_application_credentials.md` for details on credential rotat
 
 ## Fencing
 
-Fencing (also called STONITH — Shoot The Other Node In The Head) ensures that a failed compute host is truly powered off before its instances are rebuilt elsewhere. Without fencing, a host that appears down but is actually partitioned could continue running instances, leading to data corruption or IP conflicts.
+Fencing (also called STONITH -- Shoot The Other Node In The Head) ensures that a failed compute host is truly powered off before its instances are rebuilt elsewhere. Without fencing, a host that appears down but is actually partitioned could continue running instances, leading to data corruption or IP conflicts. See [instanceha_architecture.md -- Fencing Safety Model](instanceha_architecture.md#fencing-safety-model) for the 10-gate safety model and internal implementation details.
 
 ### Supported Fencing Agents
 
@@ -502,7 +498,7 @@ compute-1:
   uuid: System.Embedded.1  # Redfish system ID
 ```
 
-Redfish operations attempt up to 3 times with per-request timeout of `FENCING_TIMEOUT` (configurable range: 5–120 seconds). All URLs are validated to prevent SSRF attacks (localhost and link-local addresses are blocked).
+Redfish operations attempt up to 3 times with per-request timeout of `FENCING_TIMEOUT` (configurable range: 5-120 seconds). All URLs are validated to prevent SSRF attacks (localhost and link-local addresses are blocked).
 
 ### Metal3 (BMH) Configuration
 
@@ -570,6 +566,8 @@ When `TAGGED_FLAVORS` and/or `TAGGED_IMAGES` are enabled but no flavors or image
 
 ## Evacuation Strategies
 
+See [instanceha_architecture.md -- Evacuation Mechanisms](instanceha_architecture.md#evacuation-mechanisms) for the internal implementation details, code flow, and retry logic.
+
 ### Traditional (Default)
 
 ```yaml
@@ -601,11 +599,11 @@ config:
 Evacuates instances in priority-ordered phases, useful when applications have startup dependencies (e.g., databases before application servers). Phases are defined via instance metadata:
 
 ```bash
-# Assign a server to restart group 1 (databases first — highest priority)
+# Assign a server to restart group 1 (databases first -- highest priority)
 openstack server set --property instanceha:restart_group=1 db-server
 openstack server set --property instanceha:restart_priority=1000 db-server
 
-# Assign a server to restart group 2 (application servers second — lower priority)
+# Assign a server to restart group 2 (application servers second -- lower priority)
 openstack server set --property instanceha:restart_group=2 app-server
 openstack server set --property instanceha:restart_priority=500 app-server
 ```
@@ -757,7 +755,7 @@ config:
 ### Reserved Host Return on Failure
 
 If evacuation fails and a reserved host was activated:
-- If VMs landed on the reserved host (checked via `servers.list(host=target)`), the host is kept active — it has workload and cannot be a spare.
+- If VMs landed on the reserved host (checked via `servers.list(host=target)`), the host is kept active -- it has workload and cannot be a spare.
 - If no VMs landed on it, the host is disabled again and returned to the pool.
 - On API errors, the host is kept active as the safe default.
 
@@ -779,6 +777,55 @@ If the threshold is exceeded, InstanceHA logs an error, emits a `ThresholdExceed
 
 Setting `THRESHOLD` to `100` disables the check entirely (allows up to 100% of hosts to fail before blocking). Setting `THRESHOLD` to `0` blocks all evacuations since any failure exceeds a 0% threshold.
 
+### Threshold Is Evaluated After Evacuability Filtering
+
+The global `THRESHOLD` check does **not** count every host Nova reports as down. It runs **after** `_prepare_evacuation_resources()` has narrowed the candidate list. Only hosts that would actually be fenced and evacuated are included in the numerator. The denominator counts **all** active evacuable compute services (including healthy hosts), while the numerator counts only post-filter down hosts -- empty compute nodes are excluded from the numerator but still counted in the denominator, so idle host pools lower the failure percentage.
+
+If evacuability filtering removes every stale host (for example, all down hosts had no VMs), the global threshold check is **skipped** entirely -- even when many hosts were stale upstream.
+
+Hosts in the `to_resume` list (interrupted evacuations) are not counted in the threshold calculation and individually bypass per-aggregate filtering. However, if the global `THRESHOLD` is breached by new fencing candidates, the function returns early -- blocking `to_resume` processing as well. When no new candidates survive filtering, the threshold check is skipped and `to_resume` proceeds unimpeded.
+
+**What is removed before the threshold check:**
+
+| Filter | Effect on threshold numerator |
+|--------|------------------------------|
+| Hosts with no VMs | Excluded -- empty compute nodes are not counted |
+| `TAGGED_FLAVORS` / `TAGGED_IMAGES` | Hosts with no evacuable VMs on them are excluded |
+| `TAGGED_AGGREGATES` | Hosts outside evacuable aggregates are excluded |
+| Heartbeat gate (Gate 4, `CHECK_HEARTBEAT=true` only) | Hosts still sending heartbeats are excluded earlier in the cycle |
+| Nova API query failure (no-VM/flavor filters) | Host is kept -- query errors fail-open so hosts are not incorrectly skipped |
+
+**Denominator behavior:**
+
+| Setting | Denominator |
+|---------|-------------|
+| `TAGGED_AGGREGATES: false` | All active compute services (not disabled, not forced-down) |
+| `TAGGED_AGGREGATES: true` | Active compute services in evacuable aggregates only |
+
+**Example:** Nova reports 40 hosts as down across the region. Only 8 are in evacuable aggregates and carry evacuable workloads. With `TAGGED_AGGREGATES: true` and `THRESHOLD: 50`, the agent calculates `8 / total_evacuable x 100` -- not `40 / total_active x 100`. A datacenter-wide outage that mostly affects non-evacuable or untagged hosts may **not** trip the global threshold, even though many physical hosts are unhealthy.
+
+**Why this design:** The threshold is a guard against **runaway evacuation**, not a general infrastructure health monitor. Counting hosts InstanceHA would never evacuate would cause false threshold trips during partial outages (for example, a cell where most hosts are intentionally untagged).
+
+**Earlier gates still protect against infrastructure-wide anomalies:**
+
+These run after `_filter_processing_hosts` (in-flight hosts excluded) but **before** evacuability filtering (`_prepare_evacuation_resources`):
+
+- **All-services-stale** -- triggers when every active compute service appears stale in one cycle (>=3 active services, after excluding in-flight hosts). Catches Nova API or control-plane issues that make all services look down.
+- **Heartbeat cliff detection** -- only when `CHECK_HEARTBEAT=true`; triggers on a sudden mass loss of heartbeat hosts, regardless of evacuability tags.
+
+After all gates pass, **`MAX_HOSTS_PER_CYCLE`** caps how many hosts are fenced per cycle, limiting blast radius even when every gate allows fencing.
+
+These gates do **not** catch partial infrastructure failures -- for example, an entire Nova cell going offline while other cells remain healthy. In that scenario only ~33% of services may appear stale (in a 3-cell deployment), which does not trigger the all-services-stale check.
+
+**Operational mitigations for partial infrastructure failures:**
+
+1. **Per-aggregate thresholds** -- set `instanceha:max_failures` on cell, rack, or row aggregates so absolute failure counts are enforced within each failure domain, independent of the global percentage.
+2. **Lower `THRESHOLD`** -- when using `TAGGED_AGGREGATES`, tune against the evacuable host pool, not total cluster size. A 10% threshold on 100 evacuable hosts blocks at 10 simultaneous evacuations.
+3. **Prometheus alerting** -- alert on `instanceha_host_down_total` and Nova service staleness independently of InstanceHA's threshold gate. The threshold protects against cascading evacuation; it is not a substitute for infrastructure monitoring.
+4. **Cell maintenance** -- disable compute services in Nova before taking a cell offline. InstanceHA ignores disabled hosts in both the numerator and denominator.
+
+> **Note:** A pre-filter "raw" threshold that counts all stale services before evacuability filtering is not implemented today. If your deployment has large non-evacuable host pools and cell-level failure domains, rely on per-aggregate `instanceha:max_failures` and external monitoring rather than the global `THRESHOLD` alone.
+
 ### Per-Aggregate Failure Limit
 
 For more granular control, you can set an absolute failure limit per aggregate using the `instanceha:max_failures` metadata key on Nova aggregates. This is useful when certain aggregates have fewer hosts and the global percentage-based threshold is too coarse.
@@ -788,9 +835,9 @@ For more granular control, you can set an absolute failure limit per aggregate u
 openstack aggregate set --property instanceha:max_failures=2 my-aggregate
 ```
 
-When `TAGGED_AGGREGATES` is enabled and an aggregate has this metadata key, the agent counts how many failed hosts belong to that aggregate. If the count exceeds the limit, evacuation is blocked for all failed hosts in that aggregate — other aggregates are unaffected.
+When `TAGGED_AGGREGATES` is enabled and an aggregate has this metadata key, the agent counts how many failed hosts belong to that aggregate. If the count exceeds the limit, evacuation is blocked for all failed hosts in that aggregate -- other aggregates are unaffected.
 
-- The global `THRESHOLD` check runs first; the per-aggregate check is an additional filter
+- Both checks run after evacuability filtering; the global `THRESHOLD` check runs first, then the per-aggregate check is an additional filter
 - If a host belongs to multiple aggregates, the most restrictive limit applies
 - Setting `instanceha:max_failures=0` blocks evacuation on any failure in that aggregate
 - Aggregates without the metadata key have no per-aggregate limit
@@ -801,11 +848,13 @@ When `TAGGED_AGGREGATES` is enabled and an aggregate has this metadata key, the 
 
 InstanceHA operates within a single OpenStack region, scoped by the `region_name` in `clouds.yaml`. For deployments spanning multiple regions, deploy one InstanceHa CR per region, each with its own `clouds.yaml` pointing to the correct region.
 
-Each instance is fully independent — no cross-region communication or coordination occurs. A failure in one region does not affect InstanceHA operations in other regions.
+Each instance is fully independent -- no cross-region communication or coordination occurs. A failure in one region does not affect InstanceHA operations in other regions.
 
 ---
 
 ## Configuration Reference
+
+See [instanceha_architecture.md -- Configuration Options Reference](instanceha_architecture.md#configuration-options-reference) for developer-facing details including validation rules, code usage, and test coverage for each option.
 
 ### InstanceHa Custom Resource Fields
 
@@ -836,13 +885,13 @@ All values are strings in the ConfigMap. The agent converts and validates them a
 
 | Parameter | Type | Default | Range | Description |
 |-----------|------|---------|-------|-------------|
-| `POLL` | int | 45 | 15–600 | Seconds between Nova API polls |
-| `DELTA` | int | 30 | 10–300 | Seconds of heartbeat staleness before a service is considered failed |
-| `DELAY` | int | 0 | 0–300 | Seconds to wait after fencing before starting evacuation (allows storage lock release) |
-| `HASH_INTERVAL` | int | 60 | 30–300 | Seconds between health-check hash updates |
-| `FENCING_TIMEOUT` | int | 30 | 5–120 | Seconds allowed for fencing operations |
-| `KDUMP_TIMEOUT` | int | 30 | 5–300 | Seconds to wait for kdump messages before normal evacuation |
-| `HEARTBEAT_TIMEOUT` | int | 120 | 30–600 | Seconds without a heartbeat before marking host down |
+| `POLL` | int | 45 | 15-600 | Seconds between Nova API polls |
+| `DELTA` | int | 30 | 10-300 | Seconds of heartbeat staleness before a service is considered failed |
+| `DELAY` | int | 0 | 0-300 | Seconds to wait after fencing before starting evacuation (allows storage lock release) |
+| `HASH_INTERVAL` | int | 60 | 30-300 | Seconds between health-check hash updates |
+| `FENCING_TIMEOUT` | int | 30 | 5-120 | Seconds allowed for fencing operations |
+| `KDUMP_TIMEOUT` | int | 30 | 5-300 | Seconds to wait for kdump messages before normal evacuation |
+| `HEARTBEAT_TIMEOUT` | int | 120 | 30-600 | Seconds without a heartbeat before marking host down |
 
 #### Evacuation Behavior
 
@@ -850,14 +899,14 @@ All values are strings in the ConfigMap. The agent converts and validates them a
 |-----------|------|---------|-------------|
 | `SMART_EVACUATION` | bool | false | Track migrations to completion instead of fire-and-forget |
 | `ORCHESTRATED_RESTART` | bool | false | Enable priority-ordered evacuation phases |
-| `WORKERS` | int | 4 (range: 1–50) | Thread pool size for concurrent smart/orchestrated evacuations |
-| `THRESHOLD` | int | 50 (range: 0–100) | Max percentage of failed hosts before evacuation is blocked. Set to 100 to disable |
+| `WORKERS` | int | 4 (range: 1-50) | Thread pool size for concurrent smart/orchestrated evacuations |
+| `THRESHOLD` | int | 50 (range: 0-100) | Max percentage of failed hosts before evacuation is blocked. Set to 100 to disable |
 | `EVACUABLE_TAG` | string | `"evacuable"` | Metadata tag name used to identify evacuable resources |
 | `TAGGED_IMAGES` | bool | true | Filter by image tag |
 | `TAGGED_FLAVORS` | bool | true | Filter by flavor tag |
 | `TAGGED_AGGREGATES` | bool | true | Filter by aggregate tag (also affects threshold calculation and reserved host matching) |
 | `SKIP_SERVERS_WITH_NAME` | list | `[]` (empty) | Server name glob patterns (comma-separated) to exclude from evacuation |
-| `EVACUATION_RETRIES` | int | 5 (range: 1–20) | Max per-instance evacuation retry attempts before giving up |
+| `EVACUATION_RETRIES` | int | 5 (range: 1-20) | Max per-instance evacuation retry attempts before giving up |
 
 #### Host Recovery
 
@@ -879,8 +928,17 @@ All values are strings in the ConfigMap. The agent converts and validates them a
 |-----------|------|---------|-------------|
 | `CHECK_KDUMP` | bool | false | Enable kdump detection via UDP listener |
 | `CHECK_HEARTBEAT` | bool | false | Enable heartbeat verification via UDP listener |
-| `HEARTBEAT_CLIFF_THRESHOLD` | int | 50 (range: 10–100) | Percentage drop in active heartbeat hosts that triggers cliff detection (skips fencing for that cycle) |
-| `K8S_API_CHECK_INTERVAL` | int | 15 (range: 5–120) | Seconds between Kubernetes API reachability checks |
+| `HEARTBEAT_CLIFF_THRESHOLD` | int | 50 (range: 10-100) | Percentage drop in active heartbeat hosts that triggers cliff detection (skips fencing for that cycle) |
+| `HEARTBEAT_CLIFF_MAX_CYCLES` | int | 3 (range: 1-20) | Consecutive cliff detection cycles before accepting the state as genuine and proceeding with fencing |
+| `K8S_API_CHECK_INTERVAL` | int | 15 (range: 5-120) | Seconds between Kubernetes API reachability checks |
+
+#### Safety Limits
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `MAX_HOSTS_PER_CYCLE` | int | 10 (range: 1-100) | Maximum number of hosts that can be fenced in a single poll cycle. Excess hosts are deferred to the next cycle. |
+
+`THRESHOLD` (documented above in Evacuation Behavior) also acts as a safety limit -- it blocks all fencing when the percentage of failed hosts exceeds the configured value.
 
 #### Security
 
@@ -896,6 +954,64 @@ All values are strings in the ConfigMap. The agent converts and validates them a
 | `LOGLEVEL` | string | `"INFO"` | Log verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` |
 
 ---
+
+## Upgrading InstanceHA
+
+### How Upgrades Work
+
+InstanceHA uses a **Recreate** deployment strategy with a single replica. During an upgrade the old pod is terminated before the new one starts, creating a brief monitoring gap. This is intentional -- running two InstanceHA agents simultaneously would cause duplicate fencing and evacuation operations.
+
+The upgrade sequence is:
+
+1. Kubernetes sends SIGTERM to the running agent
+2. The agent sets its shutdown flag, stops accepting new fencing/evacuation work, and waits for in-flight operations to complete (up to 45 seconds)
+3. The pod terminates and the new pod starts
+4. On startup, the agent runs **orphan reconciliation**: it scans for hosts left in an inconsistent state (fenced but not yet evacuated) and marks them for evacuation resume
+
+### Monitoring Gap
+
+The gap between the old pod stopping and the new pod completing its first poll cycle is typically 45-120 seconds. The gap is dominated by pod scheduling time and the first poll cycle (default 45 seconds). If in-flight fencing is running when SIGTERM arrives, the termination grace period (45 seconds) bounds how long the old pod lingers before Kubernetes kills it. During this window, host failures are not detected. This is acceptable for most deployments because:
+
+- Failures that occur during the gap are detected on the first poll after startup
+- Orphan reconciliation recovers any partially-completed fencing operations
+- The heartbeat detection system (`CHECK_HEARTBEAT`) resumes with conservative cliff-detection defaults, avoiding false positives from the stale heartbeat state
+
+If this gap is unacceptable for your SLA, schedule upgrades during a maintenance window with InstanceHA disabled.
+
+### Upgrade Procedure
+
+```bash
+# 1. Verify current state -- no in-progress evacuations
+oc get events -n openstack --field-selector involvedObject.name=instanceha | grep -i fenc
+
+# 2. Update the container image (triggers rolling restart)
+oc patch instanceha instanceha -n openstack --type merge \
+  -p '{"spec": {"containerImage": "new-image:tag"}}'
+
+# 3. Wait for the new pod to become ready
+oc rollout status deployment/instanceha -n openstack --timeout=120s
+
+# 4. Verify startup reconciliation ran cleanly
+oc logs deployment/instanceha -n openstack | grep -i reconcil
+```
+
+### Configuration Changes Between Versions
+
+New configuration keys added in newer versions use safe defaults and do not require manual intervention. The `ConfigManager` ignores unknown keys in `config.yaml`, so rolling back to an older version with newer config keys is also safe.
+
+If you change configuration values at the same time as upgrading, the new values take effect when the new pod starts. There is no hot-reload -- all config is read at startup.
+
+### EDPM Heartbeat Service Compatibility
+
+The heartbeat sender on compute nodes (`instanceha-heartbeat.service`) and the InstanceHA agent are independently versioned. The heartbeat packet format is stable:
+
+- Adding HMAC authentication is backwards-compatible -- unauthenticated packets are accepted when no HMAC keys are loaded
+- When enabling HMAC for the first time, deploy the HMAC key to compute nodes via EDPM **before** loading HMAC keys on the agent (HMAC enforcement is automatic when keys are present -- there is no separate toggle)
+- The dual-key rotation mechanism allows upgrading the HMAC key without downtime (see [HMAC Key Rotation](#hmac-key-rotation))
+
+### Rollback
+
+Since InstanceHA is stateless (all state lives in Nova's service list and the Kubernetes API), rollback is the same as an upgrade -- change the container image back. Orphan reconciliation handles any inconsistent state left by the interrupted version.
 
 ## Operational Procedures
 
@@ -924,22 +1040,362 @@ openstack compute service list --long | grep FAILED
 oc get events -n openstack --field-selector involvedObject.name=instanceha
 
 # After investigating and resolving the issue, re-enable:
-openstack compute service set --enable <host> nova-compute
-openstack compute service set --unset-forced-down <host> nova-compute
+openstack compute service set --enable --up <host> nova-compute
 ```
+
+### Responding to a False-Positive Evacuation
+
+A false positive occurs when InstanceHA fences and evacuates a host that was actually healthy -- typically caused by a network partition between the control plane and the compute node. Use this procedure to identify, remediate, and prevent recurrence.
+
+**Step 1: Identify the false positive**
+
+```bash
+# Check K8s events for recent fencing and evacuation actions
+oc get events -n openstack --field-selector involvedObject.name=instanceha \
+  --sort-by='.lastTimestamp' | tail -20
+
+# Check if the host was actually reachable (e.g. via out-of-band)
+# A host that was fenced but was actually up is a false positive
+ipmitool -I lanplus -H <bmc-ip> -U <user> -E power status
+
+# Look for cliff detection events -- if the cliff was triggered but
+# then expired, multiple hosts may have been fenced simultaneously
+oc get events -n openstack --field-selector reason=HeartbeatCliffExpired
+```
+
+**Step 2: Check Prometheus metrics**
+
+```bash
+# Scrape current metrics
+oc exec deployment/instanceha -- curl -s http://localhost:8080/metrics
+
+# Key indicators of false positives:
+# - instanceha_heartbeat_cliff_total increasing without real failures
+# - instanceha_fencing_total increasing faster than expected
+# - instanceha_all_services_stale_total > 0 (suggests control-plane issue, not host failure)
+# - instanceha_fencing_rate_limited_total > 0 (rate limiter firing -- many hosts detected down)
+```
+
+**Step 2.5: Check for cascading false-positive evacuation**
+
+If multiple hosts were fenced in the same time window, evacuated VMs may have landed on hosts that are themselves being fenced -- creating a cascade.
+
+```bash
+# List all hosts fenced recently
+oc get events -n openstack --field-selector reason=FencingSucceeded \
+  --sort-by='.lastTimestamp' | tail -10
+
+# If multiple hosts were fenced within the same few minutes,
+# immediately disable InstanceHA to stop the cascade:
+oc patch instanceha instanceha -n openstack --type merge \
+  -p '{"spec": {"config": {"DISABLED": "True"}}}'
+
+# Then verify evacuation targets are not themselves being fenced
+# before proceeding to re-enable hosts
+```
+
+**Step 3: Immediate remediation**
+
+```bash
+# Re-enable the falsely fenced host
+openstack compute service set --enable --up <host> nova-compute
+
+# If VMs were evacuated, they are now running on other hosts.
+# The fenced host was powered off. With shared storage (Ceph), VM disks
+# are now attached to the new instances. With local ephemeral storage,
+# the old disks remain on the powered-off host but VMs have been rebuilt.
+# No manual VM migration back is needed, but verify VM health:
+openstack server list --host <evacuation-target-host> --all-projects
+```
+
+**Step 4: Preventive tuning**
+
+If false positives recur, adjust these settings:
+
+| Setting | Effect | Recommended change |
+|---------|--------|--------------------|
+| `DELTA` | How long a service must be down before action | Increase (e.g. 30->60) |
+| `CHECK_HEARTBEAT` | Require heartbeat loss before fencing | Enable (`True`) |
+| `HEARTBEAT_TIMEOUT` | Heartbeat staleness threshold | Increase (e.g. 60->120) |
+| `HEARTBEAT_CLIFF_MAX_CYCLES` | Cycles before cliff detection expires | Increase (e.g. 3->5) |
+| `THRESHOLD` | Max % of hosts fenced per cycle | Lower (e.g. 50->10) |
+| `MAX_HOSTS_PER_CYCLE` | Absolute cap on hosts fenced per cycle | Lower (e.g. 10->3) |
+
+Enabling heartbeat verification (`CHECK_HEARTBEAT: "True"`) on a different network provides a second detection channel that significantly reduces false positives from control-plane network (usually internalapi) issues.
 
 ### Adding a New Compute Host
 
 1. Add fencing credentials for the new host to `fencing.yaml` and update the Secret.
 2. If using aggregate-based tagging, add the host to an aggregate with `evacuable=true`.
 3. If using heartbeat verification, configure the heartbeat sender on the new host.
-4. No InstanceHA restart is needed — the agent discovers new hosts automatically on its next poll.
+4. No InstanceHA restart is needed -- the agent discovers new hosts automatically on its next poll.
 
 ### Tuning Detection Speed vs. False Positives
 
 - **Faster detection**: Lower `DELTA` (minimum 10s) and `POLL` (minimum 15s). Risk: transient network issues may trigger false evacuations.
 - **Fewer false positives**: Raise `DELTA` (up to 300s) and enable `CHECK_HEARTBEAT` for dual-channel verification. Risk: longer time before instances are recovered.
 - A reasonable starting point for production is `DELTA: 30` with `POLL: 45` and `CHECK_HEARTBEAT: true`.
+
+### Transient Network Failures
+
+When a network disruption occurs (switch reboot, spanning tree reconvergence, brief routing flap), multiple compute nodes may appear down simultaneously even though the hardware is healthy. InstanceHA has a layered defense against acting on these false signals.
+
+The effectiveness of each gate depends on the size of the environment. The cliff detector uses a **percentage** threshold (`HEARTBEAT_CLIFF_THRESHOLD`, default 50%) -- it triggers when the percentage of heartbeat hosts that disappeared in a single cycle exceeds that value. This means the same 20-host ToR switch failure looks very different depending on cluster size:
+
+| Cluster size | 20 hosts lost | % of active heartbeats | Cliff triggers? (at 50%) |
+|-------------|---------------|----------------------|--------------------------|
+| 30 nodes | 20 of 30 | 67% | Yes |
+| 40 nodes | 20 of 40 | 50% | Yes (exactly at threshold) |
+| 60 nodes | 20 of 60 | 33% | **No** -- below threshold |
+| 200 nodes | 20 of 200 | 10% | **No** -- well below threshold |
+
+In small clusters, cliff detection is the primary defense against transient events. In large clusters, the percentage drop from a single switch failure may not reach the threshold -- but the global `THRESHOLD` and `MAX_HOSTS_PER_CYCLE` gates take over as the safety net. See [Tuning by cluster size](#tuning-by-cluster-size) below.
+
+**Timeline: ToR switch reboots in a 40-node cluster (affects 20 nodes for ~90 seconds)**
+
+This example uses a 40-node cluster with default settings (`POLL: 45`, `DELTA: 30`, `HEARTBEAT_CLIFF_THRESHOLD: 50`, `HEARTBEAT_CLIFF_MAX_CYCLES: 3`). All 40 nodes have active heartbeats. A ToR switch serving 20 nodes reboots.
+
+| Time | What happens | Gate |
+|------|-------------|------|
+| T+0s | Switch goes down. Heartbeat packets from 20 hosts stop arriving. Nova API may still report services as `up` (stale data within `DELTA`). | -- |
+| T+30s | Nova services exceed `DELTA` (30s) and are reported as `down`. InstanceHA detects 20 stale services. | Gate 2: all-stale check |
+| T+30s | Only 20 of 40 services are stale -- the all-services-stale circuit breaker does not fire. Processing continues. | |
+| T+30s | `_filter_reachable_hosts()` runs. The cliff detector sees that 20 of 40 previously active heartbeat hosts disappeared -- exactly 50%, meeting the cliff threshold. Fencing is skipped for this cycle. | Gate 3: cliff detection |
+| T+45s | Next poll cycle. Heartbeats still absent. Cliff detector fires again (consecutive count: 2 of 3). Fencing skipped. | Gate 3 |
+| T+90s | Switch comes back. Heartbeat packets resume. | -- |
+| T+90s | Next poll cycle. Nova services recover (within `DELTA`). Heartbeats are fresh. Cliff detector sees hosts returning -- consecutive cliff count resets to 0. No hosts are fenced. | -- |
+| **Result** | Zero false fencing operations. | |
+
+**What if the outage lasts longer than `HEARTBEAT_CLIFF_MAX_CYCLES * POLL`?**
+
+After 3 consecutive cliff detections (3 x 45s = ~135s with default settings), the cliff detector expires -- it assumes the loss is genuine, not transient. At this point, remaining defenses take over:
+
+1. **`THRESHOLD`** (default 50%): Blocks fencing when the percentage of post-filter failed hosts is **strictly greater than** the threshold (the check is `>`, not `>=`). In our 40-node example, 20/40 = 50% equals the default threshold and does **not** block -- fencing would proceed subject to the per-cycle cap. If 21 of 40 hosts were down (52.5%), the threshold would block fencing for that cycle.
+2. **`MAX_HOSTS_PER_CYCLE`** (default 10): Even when the threshold passes, only 10 hosts are fenced per cycle. The remaining hosts wait for the next cycle, giving more time for recovery.
+3. **Per-aggregate thresholds** (`instanceha:max_failures`): If the 20 hosts share a host aggregate (e.g., same rack), the per-aggregate limit can block fencing for that group independently.
+
+These gates are evaluated in sequence -- a host must pass all of them before fencing begins.
+
+**Key configuration knobs for network resilience**
+
+| Setting | Default | Effect on transient events |
+|---------|---------|---------------------------|
+| `HEARTBEAT_CLIFF_MAX_CYCLES` | 3 | How many cycles to wait before accepting mass heartbeat loss as genuine. Higher = more tolerant of long network events, but slower response to real failures. |
+| `HEARTBEAT_CLIFF_THRESHOLD` | 50% | Minimum drop percentage to trigger cliff detection. Lower = more sensitive to smaller disruptions. |
+| `MAX_HOSTS_PER_CYCLE` | 10 | Caps fencing throughput after cliff expires. Limits blast radius if the outage was genuine. |
+| `THRESHOLD` | 50% | Global percentage cap (`>` comparison). Blocks all fencing when failed percentage strictly exceeds the threshold. |
+| `HEARTBEAT_TIMEOUT` | 120s | How long a heartbeat is considered fresh. At the default 30s send interval, tolerates up to 3 consecutive lost packets before a host appears stale. Raise if heartbeat packets traverse a congested or lossy network. |
+| `K8S_API_CHECK_INTERVAL` | 15s | How often the K8s API reachability probe runs. 3 consecutive failures (3 x interval) block all fencing. On networks with intermittent K8s API latency, raising to 30-60s avoids flapping between reachable/unreachable states. |
+| `FENCING_TIMEOUT` | 30s | Per-request timeout for IPMI/Redfish fencing calls (Redfish retries up to 3 times). If the BMC management network is slow or lossy, fencing may time out even though the host is reachable -- raise toward 60-90s. Also raise `terminationGracePeriodSeconds` accordingly. |
+| `EVACUATION_RETRIES` | 5 | Max per-instance evacuation retry attempts. Each retry re-issues the evacuate API call. On a flaky Nova API, retries cover transient 500s; at large scale, lower to 3 to avoid piling up retry traffic. |
+
+#### Tuning by cluster size
+
+The defaults are designed for small-to-medium clusters (up to ~50 nodes). As the cluster grows, the percentage-based thresholds need adjustment because a single failure domain (rack, switch) represents a smaller fraction of the total. For clusters with 3-5 nodes, see also [instanceha_architecture.md -- Small Cluster Tuning](instanceha_architecture.md#small-cluster-tuning) for the detailed gate-by-gate impact analysis.
+
+**Small clusters (3-20 nodes)**
+
+A single switch or PDU can take down most or all of the cluster. The default `HEARTBEAT_CLIFF_THRESHOLD: 50` provides good coverage -- any event affecting more than half the heartbeat hosts triggers cliff detection. However, `THRESHOLD: 50` may be too generous: in a 10-node cluster, 50% allows fencing 5 hosts simultaneously, which could be the entire failure domain. Consider lowering it:
+
+```yaml
+THRESHOLD: "30"                      # 3 of 10 nodes -- limits blast radius in small clusters
+HEARTBEAT_CLIFF_THRESHOLD: "40"      # Triggers on 4+ of 10 hosts lost
+MAX_HOSTS_PER_CYCLE: "3"             # Fence at most 3 per cycle
+```
+
+**Medium clusters (20-100 nodes)**
+
+Defaults work well. A 40-node rack behind one ToR switch is 50% of an 80-node cluster, which triggers cliff detection and threshold protection. Adjust if your failure domains are smaller:
+
+```yaml
+# If racks have 20 nodes in a 100-node cluster (20% per rack):
+HEARTBEAT_CLIFF_THRESHOLD: "15"      # Triggers on 15%+ drop (15 of 100)
+THRESHOLD: "25"                      # Blocks fencing if 25+ hosts are down
+MAX_HOSTS_PER_CYCLE: "5"             # Conservative -- one rack over 4 cycles
+```
+
+**Large clusters (100+ nodes)**
+
+A single ToR switch affecting 20-40 nodes may only represent 5-10% of heartbeat hosts -- well below the default 50% cliff threshold. Cliff detection will **not** trigger, and these 20 hosts will proceed directly to the threshold and per-cycle cap gates. Lower the cliff threshold so it catches rack-level events:
+
+```yaml
+# 500-node cluster, 40-node racks:
+HEARTBEAT_CLIFF_THRESHOLD: "10"      # Triggers on 50+ hosts (10% of 500)
+HEARTBEAT_CLIFF_MAX_CYCLES: "5"      # 5 x 120s POLL = 10 min buffer
+THRESHOLD: "10"                      # Blocks if 50+ hosts down
+MAX_HOSTS_PER_CYCLE: "10"            # One rack over 4 cycles
+```
+
+See [Large-Scale Deployment (500+ Compute Nodes)](#large-scale-deployment-500-compute-nodes) for a complete configuration example.
+
+**General recommendations**
+
+- Enable `CHECK_HEARTBEAT` on a [dedicated network](#dedicated-heartbeat-network) separate from `internalapi`. This way, a Nova API network disruption does not also kill heartbeats -- the two detection channels fail independently.
+- Set `HEARTBEAT_CLIFF_MAX_CYCLES * POLL` to exceed your longest expected network reconvergence time. For example, if spanning tree reconvergence can take up to 5 minutes, use `HEARTBEAT_CLIFF_MAX_CYCLES: 7` with `POLL: 45` (315s coverage).
+- Set `HEARTBEAT_CLIFF_THRESHOLD` so that a single failure domain (rack, PDU, ToR switch) exceeds it. If your largest rack is 40 nodes in a 200-node cluster (20%), set the threshold to 15% so a full rack loss triggers cliff detection.
+- Do not raise `MAX_HOSTS_PER_CYCLE` above the size of your largest failure domain. If a rack has 40 nodes, `MAX_HOSTS_PER_CYCLE: 40` would fence the entire rack in one cycle after cliff expiry -- defeating the purpose.
+- Use per-aggregate thresholds (`instanceha:max_failures` metadata on host aggregates) as the innermost defense, especially when racks vary in size.
+
+#### Partial heartbeat loss (below cliff threshold)
+
+When heartbeat loss affects fewer hosts than the `HEARTBEAT_CLIFF_THRESHOLD` percentage, cliff detection does not trigger. Per-host heartbeat filtering still applies: `_filter_reachable_hosts()` excludes hosts whose individual heartbeats are fresh, so only hosts that lost both Nova API reporting and heartbeat proceed to fencing. `THRESHOLD` and `MAX_HOSTS_PER_CYCLE` remain as final backstops.
+
+If heartbeat packets are intermittently dropped (some arrive, some don't), hosts near the `HEARTBEAT_TIMEOUT` boundary may alternate between filtered and not-filtered across cycles. Raising `HEARTBEAT_TIMEOUT` widens the tolerance window:
+
+```yaml
+HEARTBEAT_TIMEOUT: "180"    # 5 missed packets (at 30s send interval) before declaring stale
+```
+
+#### BMC/management network isolation
+
+When the BMC network (IPMI/Redfish) is unreachable but the data plane is healthy, fencing commands time out. InstanceHA does not evacuate without confirmed power-off, so the host remains `forced_down=True, disabled_reason="instanceha evacuation"` until an operator intervenes.
+
+Indicators:
+- `InstanceEvacuationFailed` K8s events with fencing timeout messages
+- `instanceha_fencing_total{result="failed"}` counter increasing
+
+Relevant configuration:
+- `FENCING_TIMEOUT`: raise toward 60-90s if the BMC network has higher latency (also raise `terminationGracePeriodSeconds` accordingly).
+- Separate the BMC network from the data plane physically. If both share the same ToR switch, a single switch failure causes both a false detection and an inability to fence.
+- Monitor `instanceha_fencing_duration_seconds` to establish a baseline for BMC response times.
+
+#### Nova API or Keystone unreachability
+
+When the Nova API or Keystone is unreachable, behavior depends on when the failure occurs:
+
+- **Main poll loop**: `services.list()` fails with `Unauthorized` or `DiscoveryFailure`. InstanceHA enters exponential backoff, skipping fencing for up to 5 consecutive failures, then logs a critical error and keeps retrying. No hosts are fenced during this period.
+- **In-flight smart evacuation**: `_monitor_evacuation` has a separate `MAX_API_RETRIES` budget (10 attempts). After 10 consecutive failures, the evacuation for that instance is marked as failed. The host remains force-downed.
+- **Token refresh**: `keystoneauth1.Session` handles token refresh transparently. If Keystone is unreachable at refresh time, the next Nova API call fails with `Unauthorized`, entering the same backoff logic.
+
+Monitoring: `instanceha_poll_consecutive_failures` gauge and `instanceha_poll_cycle_total{result="error"}` counter. Alert on `instanceha_poll_consecutive_failures > 2` to catch connectivity issues before the retry budget is exhausted.
+
+### Large-Scale Deployment (500+ Compute Nodes)
+
+This section covers tuning InstanceHA for clusters with hundreds of compute nodes organized across multiple Nova cells. The example configuration targets a 1000-node cluster spread across 3 Nova cells (~333 nodes per cell), though the principles apply to any large deployment.
+
+**Design philosophy**: At large scale, the blast radius of a false positive is far worse than the latency of a slow recovery. Fencing 10 healthy hosts disrupts hundreds of VMs; recovering 10 genuinely failed hosts 5 minutes later disrupts nothing additional. Every threshold and rate limit below errs on the side of caution -- operators can always raise limits for specific failure domains using per-aggregate thresholds.
+
+#### Architecture Considerations
+
+InstanceHA runs as a single pod and polls the Nova API for all compute services across all cells. At 1000 nodes, the poll cycle must process 1000 service records, fetch aggregate memberships, and potentially issue fencing and evacuation commands -- all within a reasonable time budget. The key constraints are:
+
+- **Nova API latency**: `services.list(binary="nova-compute")` returns all 1000 services in a single call. Nova's `nova-manage cell_v2` maps cells transparently, so InstanceHA does not need per-cell configuration. However, cross-cell queries are slower -- expect 1-3 seconds per poll at this scale.
+- **Heartbeat processing**: The UDP listener processes heartbeat packets individually. At 1000 nodes with the default `HEARTBEAT_TIMEOUT: 120`, the listener handles ~8 packets/second (1000 nodes / 120 seconds). This is well within capacity -- the [heartbeat performance benchmarks](instanceha_heartbeat_performance.md) show the listener handles 5000+ packets/second.
+- **Fencing concurrency**: With `WORKERS: 4`, up to 4 hosts are fenced in parallel. Each fencing operation (IPMI/Redfish) takes 5-30 seconds. At large scale, a correlated failure (e.g., a rack power event taking down 20 nodes) will be fenced across multiple poll cycles due to `MAX_HOSTS_PER_CYCLE`.
+- **Detection latency during long cycles**: The main loop is synchronous -- it blocks on `_process_stale_services` until all fencing and evacuation completes before polling again. Cycles cannot overlap. However, a long cycle delays detection of new failures. With `WORKERS: 8` and `MAX_HOSTS_PER_CYCLE: 5`, a worst-case cycle runs ~30 seconds (5 fencing ops at 30s each, parallelized across 8 workers), plus evacuation. Any host that fails during this window won't be detected until the next poll.
+
+#### Recommended Configuration
+
+```yaml
+apiVersion: instanceha.openstack.org/v1beta1
+kind: InstanceHa
+metadata:
+  name: instanceha
+  namespace: openstack
+spec:
+  config:
+    # Detection timing
+    POLL: "120"                      # 2 min poll -- balances detection latency vs API load at scale
+    DELTA: "60"                      # 60s staleness -- tolerates cross-cell query lag
+
+    # Heartbeat (strongly recommended at scale)
+    CHECK_HEARTBEAT: "True"          # Dual-channel detection is essential at 1000 nodes
+    HEARTBEAT_TIMEOUT: "180"         # 3 minutes -- tolerates transient network blips at scale
+    HEARTBEAT_CLIFF_THRESHOLD: "15"  # 15% -- 150 simultaneous silent hosts is already a strong partition signal
+    HEARTBEAT_CLIFF_MAX_CYCLES: "5"  # 5 cycles (10 minutes at POLL=120) before accepting as genuine
+
+    # Safety thresholds
+    THRESHOLD: "10"                  # 10% -- at 1000 nodes, 100+ simultaneous failures is almost certainly an anomaly
+    MAX_HOSTS_PER_CYCLE: "5"         # Fence at most 5 hosts per cycle -- conservative, observable, interruptible
+    TAGGED_AGGREGATES: "True"        # Use aggregate-based host filtering
+
+    # Evacuation
+    SMART_EVACUATION: "True"         # Track migrations to completion -- essential for visibility at scale
+    WORKERS: "8"                     # 8 parallel fencing workers (up from default 4)
+    EVACUATION_RETRIES: "3"          # 3 retries per VM (lower than default 5 -- avoid piling up at scale)
+
+    # Security
+    FENCING_TIMEOUT: "30"            # 30s timeout per fencing command
+    SSL_VERIFY: "True"               # Always verify TLS in production
+```
+
+#### Why These Values
+
+**`POLL: 120`** -- At 1000 nodes, a poll cycle that triggers fencing and evacuation can take 60+ seconds (cross-cell service list query + aggregate lookups + fencing with `WORKERS: 8`). A 120-second interval ensures the previous cycle completes before the next one starts. The detection latency trade-off (up to POLL + DELTA = 3 minutes) is acceptable because heartbeat verification provides near-real-time detection independent of the poll interval, and at this scale, acting slightly slower but correctly is far better than acting fast on bad data.
+
+**`DELTA: 60`** -- Nova's `updated_at` timestamp for compute services can lag during cross-cell database queries, especially when cells are under load. A 60-second staleness window absorbs this variance. Combined with `POLL: 120`, worst-case detection time is ~3 minutes -- well within typical HA SLAs for infrastructure-level recovery.
+
+**`HEARTBEAT_CLIFF_THRESHOLD: 15`** -- At 1000 nodes, 15% means 150 hosts going silent simultaneously triggers cliff detection. In a cluster this large, even 50 simultaneous heartbeat losses would be unusual -- 150 is an extremely strong signal that the listener's network path is compromised, not that 150 physical servers died at the same instant. The default 50% (500 hosts) would essentially never trigger at this scale, making it useless as a safety gate.
+
+**`HEARTBEAT_CLIFF_MAX_CYCLES: 5`** -- At `POLL: 120`, 5 cycles = 10 minutes before the cliff detector gives up and accepts the state as genuine. This is long enough for most transient network events (spanning tree convergence, switch firmware upgrades, brief routing flaps) to resolve, while still bounded -- a genuine spine switch failure will be acted on within 10 minutes. **Important**: when the cliff expires, `MAX_HOSTS_PER_CYCLE` is the primary defense against fencing too many hosts at once. These two settings are mutually dependent -- do not raise `MAX_HOSTS_PER_CYCLE` without also ensuring `HEARTBEAT_CLIFF_MAX_CYCLES * POLL` exceeds your longest expected network reconvergence time. Values below 10 for `HEARTBEAT_CLIFF_THRESHOLD` are silently clamped to 10 (the ConfigManager minimum).
+
+**`THRESHOLD: 10`** -- At 1000 nodes, 10% allows up to 100 simultaneous failures. A single rack (~40 nodes) failing is 4% -- well under the threshold. Two racks failing simultaneously (80 nodes, 8%) still passes. But 100+ hosts being reported down at once is almost certainly a Nova API issue, a cell outage, or a network partition -- not a genuine failure of 100 physical servers. The per-aggregate thresholds (see below) provide finer-grained control within failure domains.
+
+**`MAX_HOSTS_PER_CYCLE: 5`** -- Deliberately conservative. At 1000 nodes, simultaneous correlated failures are expected (rack power events, switch failures, storage fabric issues), but the cost of fencing too many hosts on bad data far exceeds the cost of slower recovery for genuine failures. A 40-node rack failure takes 8 poll cycles (16 minutes at `POLL: 120`) to fully fence -- during which operators can observe the steady stream of `FencingRateLimited` events and confirm the failure is real. If recovery speed is critical for specific workloads, use per-aggregate thresholds to allow faster fencing within known failure domains rather than raising the global cap.
+
+**`WORKERS: 8`** -- With `MAX_HOSTS_PER_CYCLE: 5`, 8 workers process the entire batch in a single round of parallel fencing. The inner evacuation thread pool is capped at `MAX_TOTAL_EVACUATION_THREADS / WORKERS` = 32/8 = 4 concurrent evacuations per host (hardcoded constant, not configurable). At worst, 5 x 4 = 20 simultaneous evacuation requests -- well within what a production Nova deployment should handle.
+
+**`EVACUATION_RETRIES: 3`** -- At large scale, 5 retries per VM across 10 hosts with dozens of VMs each can create a long tail of retry traffic against the Nova API. 3 retries catches transient errors without piling up.
+
+#### Per-Aggregate Thresholds
+
+At 1000 nodes across 3 cells, use Nova host aggregates to model your failure domains (racks, rows, or cells). Set per-aggregate failure limits using aggregate metadata:
+
+```bash
+# Create aggregates per rack (example: 40 nodes per rack, 25 racks)
+openstack aggregate create --property evacuable=true --property instanceha:max_failures=5 rack-01
+openstack aggregate add host rack-01 compute-001.example.com
+# ... repeat for all hosts in the rack
+
+# Or per cell (example: ~333 nodes per cell)
+openstack aggregate create --property evacuable=true --property instanceha:max_failures=30 cell-1
+```
+
+The `instanceha:max_failures` metadata sets an absolute cap on how many hosts in that aggregate can be fenced in a single cycle. For rack-level aggregates with 40 nodes, a limit of 5 means InstanceHA will not fence more than ~12% of a rack at once -- matching the conservative global `MAX_HOSTS_PER_CYCLE`. For cell-level aggregates, a limit of 30 (~9% of 333 nodes) aligns with the global `THRESHOLD: 10` while providing per-cell granularity -- a single cell losing 30 hosts triggers the aggregate gate even if the global threshold hasn't been reached.
+
+Note that `instanceha:max_failures` and `MAX_HOSTS_PER_CYCLE` are independent gates -- both must pass for a host to be fenced. The effective per-cycle limit is the lower of the two.
+
+#### Monitoring at Scale
+
+At 1000 nodes, Prometheus alerting becomes critical. Key alerts to configure:
+
+```yaml
+# Alert if more than 20 hosts are fenced in a rolling 30-minute window
+- alert: InstanceHAMassFencing
+  expr: increase(instanceha_fencing_total[30m]) > 20
+  for: 0m
+  labels:
+    severity: critical
+
+# Alert if the rate limiter is hitting consistently (queued failures)
+- alert: InstanceHAFencingBacklog
+  expr: increase(instanceha_fencing_rate_limited_total[10m]) > 3
+  for: 0m
+  labels:
+    severity: warning
+
+# Alert if poll cycle is taking too long (Nova API under pressure)
+- alert: InstanceHAPollSlow
+  expr: histogram_quantile(0.95, rate(instanceha_poll_duration_seconds_bucket[5m])) > 30
+  for: 5m
+  labels:
+    severity: warning
+
+# Alert if all-services-stale fires (Nova API anomaly)
+- alert: InstanceHAAllServicesStale
+  expr: increase(instanceha_all_services_stale_total[5m]) > 0
+  for: 0m
+  labels:
+    severity: critical
+```
+
+#### Nova Cell Considerations
+
+InstanceHA is cell-unaware -- it queries the Nova API (which fans out to all cells) and operates on the unified service list. This means:
+
+- **Cell outages**: If a cell's database or message queue goes down, Nova may report all services in that cell as stale. The all-services-stale circuit breaker will not catch this (only ~333 of 1000 services are affected). The `THRESHOLD: 10` protects here -- 333 failures would be 33%, far exceeding the 10% threshold, so fencing is blocked for the entire cycle. Per-cell aggregates with `instanceha:max_failures` provide even tighter protection.
+- **Cell-specific maintenance**: Use Nova's host disable (`openstack compute service set --disable`) before taking a cell offline for maintenance. InstanceHA ignores disabled hosts.
+- **Cross-cell evacuation**: When a host in cell-1 is fenced, Nova's scheduler may place evacuated VMs in cell-2 or cell-3. This is normal -- the scheduler respects its own placement rules. InstanceHA does not control which cell receives evacuated VMs.
 
 ### Checking InstanceHA Health
 

--- a/docs/instanceha_heartbeat_performance.md
+++ b/docs/instanceha_heartbeat_performance.md
@@ -1,5 +1,7 @@
 # InstanceHA Heartbeat Performance at 1000-Node Scale
 
+> **Related docs**: [instanceha_guide.md -- Heartbeat Verification](instanceha_guide.md#heartbeat-verification) (operator setup) | [instanceha_architecture.md](instanceha_architecture.md) (internal design)
+
 ## Overview
 
 This document presents performance profiling results for the InstanceHA
@@ -18,7 +20,7 @@ measurements were taken using the benchmark script at
 | HEARTBEAT_TIMEOUT     | 120s            |
 | THRESHOLD             | 5% and 10%      |
 | POLL                  | 45s             |
-| HEARTBEAT_CLEANUP_THRESHOLD | 2000      |
+| UDP_CLEANUP_THRESHOLD | 2000      |
 
 ### HBV2 Packet Format
 
@@ -29,7 +31,7 @@ Each heartbeat packet carries HMAC-SHA256 authentication:
 | Magic     | 4 bytes | Network (BE)    |
 | Timestamp | 8 bytes | Network (BE)    |
 | Hostname  | 1-64 bytes | UTF-8        |
-| HMAC-SHA256 | 32 bytes | —            |
+| HMAC-SHA256 | 32 bytes | --            |
 
 Minimum packet size: 45 bytes. Typical packet for a hostname like
 `compute-0000`: 56 bytes. The HMAC is computed over everything except
@@ -127,11 +129,11 @@ it counts the number of hosts with a fresh heartbeat (within
 `HEARTBEAT_TIMEOUT`) by scanning all entries in the timestamp snapshot,
 and compares this count against the previous cycle's value. If the drop
 exceeds `HEARTBEAT_CLIFF_THRESHOLD` (default 50%) and the previous count
-was ≥ 3, fencing is skipped entirely for that cycle.
+was >= 3, fencing is skipped entirely for that cycle.
 
 This adds an O(n) pass over all timestamps (where n = total nodes, not
 just down hosts). At 1000 nodes this is a single dict iteration with one
-comparison per entry — well under 100 us and negligible compared to the
+comparison per entry -- well under 100 us and negligible compared to the
 Nova API call latency. The per-host filter logic that follows is
 unchanged.
 
@@ -203,7 +205,7 @@ The function-level CPU breakdown is consistent across both threshold
 values. Shown here for 10,000 iterations at the respective threshold
 limits:
 
-#### THRESHOLD=5% (50 down hosts, 10,000 iterations — 1.48s total)
+#### THRESHOLD=5% (50 down hosts, 10,000 iterations -- 1.48s total)
 
 | Function                  | % Time | Notes                          |
 |---------------------------|-------:|--------------------------------|
@@ -213,7 +215,7 @@ limits:
 | `dict.get`                |   4.6% | Timestamp lookup per host      |
 | `list.append`             |   4.1% | Building result lists          |
 
-#### THRESHOLD=10% (100 down hosts, 10,000 iterations — 2.64s total)
+#### THRESHOLD=10% (100 down hosts, 10,000 iterations -- 2.64s total)
 
 | Function                  | % Time | Notes                          |
 |---------------------------|-------:|--------------------------------|
@@ -235,7 +237,7 @@ acceptable overhead.
 Simulates 10 consecutive polling cycles with concurrent heartbeat
 packet arrival and increasing down-host counts.
 
-### THRESHOLD=5% (down hosts: 10 → 50)
+### THRESHOLD=5% (down hosts: 10 -> 50)
 
 | Cycle | Down Hosts | Fenced | Skipped | Filter Time |
 |------:|-----------:|-------:|--------:|------------:|
@@ -253,7 +255,7 @@ packet arrival and increasing down-host counts.
 - **Average filter time: 59 us**
 - **Maximum filter time: 144 us**
 
-### THRESHOLD=10% (down hosts: 10 → 55)
+### THRESHOLD=10% (down hosts: 10 -> 55)
 
 | Cycle | Down Hosts | Fenced | Skipped | Filter Time |
 |------:|-----------:|-------:|--------:|------------:|
@@ -324,7 +326,7 @@ heartbeat overhead is < 0.2% of total process memory.
 
 Each HBV2 heartbeat packet is ~56 bytes (4-byte magic + 8-byte timestamp
 + hostname + 32-byte HMAC). At 33 packets/second, the bandwidth is
-**~1.8 KB/s** — negligible on any network.
+**~1.8 KB/s** -- negligible on any network.
 
 ### Container Resource Limits
 

--- a/docs/instanceha_prometheus.md
+++ b/docs/instanceha_prometheus.md
@@ -1,8 +1,10 @@
 # InstanceHA Prometheus Monitoring Guide
 
+> **Related docs**: [instanceha_guide.md -- Prometheus Metrics](instanceha_guide.md#prometheus-metrics) (summary and auto-scraping) | [instanceha_architecture.md](instanceha_architecture.md) (internal design)
+
 ## Overview
 
-InstanceHA exposes Prometheus metrics at `:8080/metrics` on the workload pod, covering the full evacuation lifecycle: host failure detection, fencing, evacuation, recovery, and poll loop health. These metrics complement the Kubernetes Events emitted on the InstanceHa CR — events provide human-readable audit records, while metrics provide numeric time-series data suitable for dashboards, alerting, and capacity planning.
+InstanceHA exposes Prometheus metrics at `:8080/metrics` on the workload pod, covering the full evacuation lifecycle: host failure detection, fencing, evacuation, recovery, and poll loop health. These metrics complement the Kubernetes Events emitted on the InstanceHa CR -- events provide human-readable audit records, while metrics provide numeric time-series data suitable for dashboards, alerting, and capacity planning.
 
 The metrics are served by the `prometheus_client` Python library on the same HTTP server used for liveness and readiness probes. No sidecar or additional container is needed.
 
@@ -43,7 +45,7 @@ spec:
     secretName: my-custom-metrics-cert
 ```
 
-When the telemetry-operator is deployed, its `ScrapeConfig` automatically switches to `scheme: HTTPS` with the appropriate TLS configuration when `PrometheusTLS` is enabled — no manual changes are needed.
+When the telemetry-operator is deployed, its `ScrapeConfig` automatically switches to `scheme: HTTPS` with the appropriate TLS configuration when `PrometheusTLS` is enabled -- no manual changes are needed.
 
 ---
 
@@ -103,7 +105,7 @@ After applying the PodMonitor, verify that Prometheus has discovered the target:
 oc get podmonitor -n openstack instanceha-metrics
 
 # In the Prometheus UI (or via API), check the target is UP:
-# Targets page: Status → Targets → search for "instanceha"
+# Targets page: Status -> Targets -> search for "instanceha"
 
 # On OpenShift with user workload monitoring, query the user-workload Prometheus
 # (not the cluster Prometheus in openshift-monitoring):
@@ -148,15 +150,17 @@ Counters increase monotonically and reset to zero on pod restart.
 | `instanceha_evacuation_total` | `host`, `result` | Host-level evacuation operations. `result`: `started`, `succeeded`, `failed` |
 | `instanceha_instance_evacuation_total` | `host`, `result` | Per-instance evacuation operations (smart/orchestrated mode). `result`: `started`, `succeeded`, `failed` |
 | `instanceha_host_down_total` | `host` | Host-down detections (each poll cycle where a host is seen as down) |
-| `instanceha_host_reachable_total` | `host` | Hosts reported down by Nova but still reachable via heartbeat — fencing skipped |
+| `instanceha_host_reachable_total` | `host` | Hosts reported down by Nova but still reachable via heartbeat -- fencing skipped |
 | `instanceha_host_reenabled_total` | `host` | Hosts re-enabled after successful evacuation |
-| `instanceha_threshold_exceeded_total` | — | Evacuations skipped because the percentage of failed hosts exceeded the global threshold |
+| `instanceha_threshold_exceeded_total` | -- | Evacuations skipped because the percentage of failed hosts exceeded the global threshold |
 | `instanceha_aggregate_threshold_exceeded_total` | `aggregate` | Evacuations blocked for an aggregate due to per-aggregate `instanceha:max_failures` metadata threshold |
 | `instanceha_recovery_completed_total` | `host` | Full recovery workflows completed (fence + evacuate + recovery) |
 | `instanceha_processing_failed_total` | `host` | Unhandled exceptions during service processing |
-| `instanceha_orphaned_host_recovered_total` | — | Orphaned fenced hosts recovered during startup reconciliation |
+| `instanceha_orphaned_host_recovered_total` | -- | Orphaned fenced hosts recovered during startup reconciliation |
 | `instanceha_heartbeat_rejected_total` | `reason` | Heartbeat packets rejected. `reason`: `hmac_failed`, `timestamp_invalid` |
-| `instanceha_heartbeat_cliff_total` | — | Fencing skipped due to sudden heartbeat loss (possible network partition) |
+| `instanceha_heartbeat_cliff_total` | -- | Fencing skipped due to sudden heartbeat loss (possible network partition) |
+| `instanceha_fencing_rate_limited_total` | -- | Times fencing was capped by `MAX_HOSTS_PER_CYCLE` rate limit |
+| `instanceha_all_services_stale_total` | -- | Times fencing was skipped because all active services appeared stale |
 | `instanceha_poll_cycles_total` | `result` | Poll cycles executed. `result`: `success`, `error` |
 
 ### Gauges
@@ -174,6 +178,7 @@ Gauges represent current values that can go up or down.
 | Metric | Labels | Buckets (seconds) | Description |
 |--------|--------|-------------------|-------------|
 | `instanceha_instance_evacuation_duration_seconds` | `host` | 10, 30, 60, 120, 180, 300, 600 | Time from evacuation request to completion for individual instances |
+| `instanceha_poll_duration_seconds` | -- | 1, 5, 10, 30, 60, 120, 300 | Duration of each poll cycle |
 
 ---
 
@@ -254,7 +259,7 @@ spec:
               Evacuation has been blocked for hosts in this aggregate.
 
         # --- Critical: InstanceHA is down ---
-        # No successful poll cycles for 5 minutes — the agent is not functioning.
+        # No successful poll cycles for 5 minutes -- the agent is not functioning.
         - alert: InstanceHADown
           expr: rate(instanceha_poll_cycles_total{result="success"}[5m]) == 0
           for: 5m
@@ -296,14 +301,14 @@ spec:
               or insufficient capacity on target hosts.
 
         # --- Warning: K8s API unreachable (partition) ---
-        # The agent cannot reach the K8s API — fencing is blocked.
+        # The agent cannot reach the K8s API -- fencing is blocked.
         - alert: InstanceHAK8sPartition
           expr: instanceha_k8s_api_reachable == 0
           for: 1m
           labels:
             severity: warning
           annotations:
-            summary: "InstanceHA K8s API unreachable — possible network partition"
+            summary: "InstanceHA K8s API unreachable -- possible network partition"
             description: >-
               The InstanceHA pod cannot reach the Kubernetes API.
               Fencing is blocked to prevent split-brain evacuations.
@@ -317,7 +322,7 @@ spec:
           labels:
             severity: warning
           annotations:
-            summary: "Heartbeat cliff detected — possible network partition"
+            summary: "Heartbeat cliff detected -- possible network partition"
             description: >-
               InstanceHA detected a sudden drop in heartbeat hosts,
               suggesting the pod's network is partitioned rather than
@@ -348,7 +353,7 @@ oc apply -f instanceha-prometheusrule.yaml
 oc get prometheusrule -n openstack instanceha-alerts
 
 # Verify rules appear in Prometheus
-# Prometheus UI: Status → Rules → search for "instanceha"
+# Prometheus UI: Status -> Rules -> search for "instanceha"
 
 # Lint the rules file locally (optional)
 promtool check rules instanceha-prometheusrule.yaml
@@ -441,10 +446,13 @@ Expected output:
 # TYPE instanceha_orphaned_host_recovered_total counter
 # TYPE instanceha_heartbeat_rejected_total counter
 # TYPE instanceha_heartbeat_cliff_total counter
+# TYPE instanceha_fencing_rate_limited_total counter
+# TYPE instanceha_all_services_stale_total counter
 # TYPE instanceha_poll_consecutive_failures gauge
 # TYPE instanceha_hosts_processing gauge
 # TYPE instanceha_k8s_api_reachable gauge
 # TYPE instanceha_poll_cycles_total counter
+# TYPE instanceha_poll_duration_seconds histogram
 ```
 
 ### Test With Noop Fencing
@@ -513,7 +521,7 @@ To create this dashboard in Grafana:
 1. Create a new dashboard and add panels using the queries above.
 2. Set the data source to your Prometheus instance.
 3. Use `$namespace` as a template variable (filter: `label_values(instanceha_poll_cycles_total, namespace)`) to support multi-namespace deployments.
-4. Set the default time range to **Last 6 hours** — InstanceHA events are infrequent in healthy environments.
+4. Set the default time range to **Last 6 hours** -- InstanceHA events are infrequent in healthy environments.
 
 ---
 
@@ -545,7 +553,7 @@ time() - instanceha_poll_cycles_total{result="success"} @ end()
 
 ## Integration with telemetry-operator
 
-When the [telemetry-operator](https://github.com/openstack-k8s-operators/telemetry-operator) is deployed, it provisions a **separate Prometheus instance** via the Cluster Observability Operator (COO). This Prometheus is independent from OpenShift's built-in user workload monitoring — the two stacks coexist without conflict, but metrics live in different places:
+When the [telemetry-operator](https://github.com/openstack-k8s-operators/telemetry-operator) is deployed, it provisions a **separate Prometheus instance** via the Cluster Observability Operator (COO). This Prometheus is independent from OpenShift's built-in user workload monitoring -- the two stacks coexist without conflict, but metrics live in different places:
 
 | Stack | Prometheus instance | Query endpoint |
 |-------|-------------------|----------------|
@@ -554,7 +562,7 @@ When the [telemetry-operator](https://github.com/openstack-k8s-operators/telemet
 
 ### Automatic Discovery (default)
 
-The telemetry-operator **automatically discovers and scrapes InstanceHA metrics** — no manual configuration is required. The infra-operator creates a Kubernetes Service (`<instance-name>-metrics`) with the labels `metrics: enabled` and `service: instanceha`. The telemetry-operator's `MetricStorage` controller watches for Services with these labels and automatically generates a `ScrapeConfig` CR named `telemetry-instanceha` targeting port 8080.
+The telemetry-operator **automatically discovers and scrapes InstanceHA metrics** -- no manual configuration is required. The infra-operator creates a Kubernetes Service (`<instance-name>-metrics`) with the labels `metrics: enabled` and `service: instanceha`. The telemetry-operator's `MetricStorage` controller watches for Services with these labels and automatically generates a `ScrapeConfig` CR named `telemetry-instanceha` targeting port 8080.
 
 This works the same way as the OVN metrics integration. When a `MetricStorage` CR exists in the namespace:
 
@@ -588,14 +596,14 @@ spec:
 ### Which Approach to Use
 
 - **OpenShift user workload monitoring only** (no telemetry-operator): Use the PodMonitor approach from [Enabling Scraping](#enabling-scraping). This is simpler and uses automatic pod discovery.
-- **telemetry-operator deployed** (default): InstanceHA metrics are automatically scraped by the COO Prometheus alongside other OpenStack metrics (Ceilometer, RabbitMQ, node-exporter, OVN). No manual configuration needed. You can also deploy the PodMonitor simultaneously — it targets the OpenShift user workload Prometheus and does not conflict with the COO scrapeconfig.
+- **telemetry-operator deployed** (default): InstanceHA metrics are automatically scraped by the COO Prometheus alongside other OpenStack metrics (Ceilometer, RabbitMQ, node-exporter, OVN). No manual configuration needed. You can also deploy the PodMonitor simultaneously -- it targets the OpenShift user workload Prometheus and does not conflict with the COO scrapeconfig.
 - **Querying across both**: OpenShift's `thanos-querier` route aggregates the cluster and user workload Prometheus instances. The COO Prometheus is separate and must be queried directly at `metric-storage-prometheus.openstack.svc:9090`.
 
 ---
 
 ## References
 
-- [InstanceHA Operator Guide](instanceha_guide.md) — Full deployment and configuration reference
-- [InstanceHA Architecture](instanceha_architecture.md) — Internal architecture and event catalog
+- [InstanceHA Operator Guide](instanceha_guide.md) -- Full deployment and configuration reference
+- [InstanceHA Architecture](instanceha_architecture.md) -- Internal architecture and event catalog
 - [Prometheus Operator Documentation](https://prometheus-operator.dev/docs/getting-started/introduction/)
 - [PromQL Basics](https://prometheus.io/docs/prometheus/latest/querying/basics/)

--- a/templates/instanceha/bin/instanceha.py
+++ b/templates/instanceha/bin/instanceha.py
@@ -24,9 +24,15 @@ import hmac as hmac_mod
 import json
 import uuid
 from typing import Dict, Any, Optional, Union, List, Protocol, Tuple, Callable
+import ipaddress
 from collections import defaultdict
-from abc import ABC, abstractmethod
+from urllib.parse import urlparse
 
+from keystoneauth1 import loading as ksc_loading
+from keystoneauth1 import session as ksc_session
+from keystoneauth1.exceptions.discovery import DiscoveryFailure
+from novaclient import client as nova_client_mod
+from novaclient.exceptions import Conflict, NotFound, Forbidden, Unauthorized
 from prometheus_client import Counter, Gauge, Histogram, generate_latest, CONTENT_TYPE_LATEST
 
 
@@ -42,10 +48,9 @@ class NovaConnectionError(Exception):
 
 # Constants
 CACHE_TIMEOUT_SECONDS = 300
-KDUMP_CLEANUP_THRESHOLD = 2000
+UDP_CLEANUP_THRESHOLD = 2000
 KDUMP_CLEANUP_AGE_SECONDS = 300
 MAX_EVACUATION_TIMEOUT_SECONDS = 300
-FUTURE_RESULT_TIMEOUT_SECONDS = MAX_EVACUATION_TIMEOUT_SECONDS + 60
 INITIAL_EVACUATION_WAIT_SECONDS = 10
 EVACUATION_POLL_INTERVAL_SECONDS = 5
 EVACUATION_RETRY_WAIT_SECONDS = 5
@@ -64,14 +69,15 @@ FENCING_RETRY_DELAY_SECONDS = 1
 KDUMP_REENABLE_DELAY_SECONDS = 60
 MAX_NOVA_BACKOFF_SECONDS = 300
 MAX_CONSECUTIVE_FAILURES_READY = 3
+MIN_ACTIVE_SERVICES_FOR_STALE_CHECK = 3
 NOVA_API_TIMEOUT_SECONDS = 30
 MAX_TOTAL_EVACUATION_THREADS = 32
 HEARTBEAT_MAGIC_NUMBER = 0x48425632
 HEARTBEAT_HMAC_DIGEST_SIZE = 32
 HEARTBEAT_MIN_PACKET_SIZE = 4 + 8 + 1 + 32  # magic + timestamp + min hostname + HMAC
 DEFAULT_HEARTBEAT_PORT = 7411
-HEARTBEAT_CLEANUP_THRESHOLD = 2000
 HEARTBEAT_CLEANUP_AGE_SECONDS = 600
+_ALLOWED_HTTP_METHODS = frozenset({'get', 'post', 'patch', 'put', 'delete'})
 
 # Disabled reason markers
 LOCK_REASON_EVACUATION = "instanceha-evacuation"
@@ -169,6 +175,44 @@ HEARTBEAT_CLIFF_TOTAL = Counter(
     'instanceha_heartbeat_cliff_total',
     'Times fencing was skipped due to sudden heartbeat loss',
 )
+FENCING_RATE_LIMITED_TOTAL = Counter(
+    'instanceha_fencing_rate_limited_total',
+    'Times fencing was capped by MAX_HOSTS_PER_CYCLE rate limit',
+)
+ALL_SERVICES_STALE_TOTAL = Counter(
+    'instanceha_all_services_stale_total',
+    'Times fencing was skipped because all active services appeared stale',
+)
+POLL_DURATION_SECONDS = Histogram(
+    'instanceha_poll_duration_seconds',
+    'Duration of each poll cycle in seconds',
+    buckets=[1, 5, 10, 30, 60, 120, 300],
+)
+
+_HOST_LABELED_METRICS = [
+    FENCING_TOTAL, EVACUATION_TOTAL, INSTANCE_EVACUATION_TOTAL,
+    INSTANCE_EVACUATION_DURATION, HOST_DOWN_TOTAL, HOST_REACHABLE_TOTAL,
+    HOST_REENABLED_TOTAL, RECOVERY_COMPLETED_TOTAL, PROCESSING_FAILED_TOTAL,
+]
+
+
+def _prune_stale_metric_labels(active_hosts):
+    """Remove Prometheus label sets for hosts no longer in the service list."""
+    active = set(active_hosts)
+    for metric in _HOST_LABELED_METRICS:
+        label_names = metric._labelnames
+        host_idx = label_names.index('host') if 'host' in label_names else -1
+        if host_idx < 0:
+            continue
+        stale_keys = [
+            key for key in list(metric._metrics.keys())
+            if key[host_idx] not in active
+        ]
+        for key in stale_keys:
+            try:
+                metric.remove(*key)
+            except KeyError:
+                pass
 
 
 # Enums
@@ -200,6 +244,7 @@ class EvacuationResult:
     accepted: bool
     reason: str
     status_code: Optional[int] = None
+    request_id: Optional[str] = None
 
 
 @dataclass
@@ -253,11 +298,11 @@ _SECRET_PATTERNS = {
 
 def _sanitize_message(msg: str) -> str:
     """Strip credentials from a message string."""
-    for secret_word, pattern in _SECRET_PATTERNS.items():
-        if secret_word == 'json_password':
+    for pattern_name, pattern in _SECRET_PATTERNS.items():
+        if pattern_name == 'json_password':
             msg = pattern.sub(r'\1: "***"', msg)
         else:
-            msg = pattern.sub(f'{secret_word}=***', msg)
+            msg = pattern.sub(f'{pattern_name}=***', msg)
     return msg
 
 
@@ -281,7 +326,8 @@ def _interruptible_sleep(shutdown_event, seconds):
         time.sleep(seconds)
 
 
-def _retry_with_backoff(func, max_attempts, label, delay=FENCING_RETRY_DELAY_SECONDS):
+def _retry_with_backoff(func, max_attempts, label, delay=FENCING_RETRY_DELAY_SECONDS,
+                        shutdown_event=None):
     """Retry func with linear backoff. Returns func result on success, raises on final failure."""
     for attempt in range(max_attempts):
         try:
@@ -289,7 +335,7 @@ def _retry_with_backoff(func, max_attempts, label, delay=FENCING_RETRY_DELAY_SEC
         except Exception as e:
             if attempt < max_attempts - 1:
                 logging.warning('%s failed (attempt %d/%d): %s', label, attempt + 1, max_attempts, _sanitize_message(str(e)))
-                time.sleep(delay * (attempt + 1))
+                _interruptible_sleep(shutdown_event, delay * (attempt + 1))
             else:
                 logging.error('%s failed after %d attempts: %s', label, max_attempts, _sanitize_message(str(e)))
                 raise
@@ -318,9 +364,6 @@ def _try_validate(validator_func: Callable[[], bool], error_msg: str, context: s
 
 def validate_input(value: str, validation_type: str, context: str) -> bool:
     """Unified validation to prevent SSRF and injection attacks."""
-    from urllib.parse import urlparse
-    import ipaddress
-
     if not value:
         return False
 
@@ -388,7 +431,6 @@ def validate_inputs(validations: dict, context: str) -> bool:
 def _make_ssl_request(method: str, url: str, auth: tuple, timeout: int,
                       config_mgr: 'ConfigManager', session: requests.Session = None, **kwargs):
     """Make HTTP request with SSL configuration from config manager."""
-    _ALLOWED_HTTP_METHODS = frozenset({'get', 'post', 'patch', 'put', 'delete'})
     if method not in _ALLOWED_HTTP_METHODS:
         raise ValueError(f"Unsupported HTTP method: {method}")
 
@@ -413,10 +455,7 @@ def _wait_for_power_off(check_func: Callable[[], Optional[str]], timeout: int,
         if shutdown_event and shutdown_event.is_set():
             logging.warning("Shutdown requested, aborting power-off wait for %s", host_identifier)
             return False
-        if shutdown_event:
-            shutdown_event.wait(1)
-        else:
-            time.sleep(1)
+        _interruptible_sleep(shutdown_event, 1)
         power_state = check_func()
         if power_state == expected_state:
             logging.info("%s power off successful for %s", agent_type, host_identifier)
@@ -471,20 +510,6 @@ class OpenStackClient(Protocol):
     def flavors(self): ...
     def aggregates(self): ...
     def servers(self): ...
-
-
-class CloudConnectionProvider(ABC):
-    """Abstract interface for cloud connection management."""
-
-    @abstractmethod
-    def get_connection(self) -> Optional[OpenStackClient]:
-        """Get a connection to the cloud provider."""
-        pass
-
-    @abstractmethod
-    def create_connection(self) -> Optional[OpenStackClient]:
-        """Create a new connection to the cloud provider."""
-        pass
 
 
 AC_CREDENTIALS_PATH = "/secrets/ac-credentials"
@@ -589,6 +614,13 @@ class ConfigManager:
             except ValueError as e:
                 raise ConfigurationError(str(e))
 
+        if self.get_config_value('CHECK_HEARTBEAT'):
+            if self.get_config_value('HEARTBEAT_TIMEOUT') < self.get_config_value('DELTA'):
+                logging.warning(
+                    'HEARTBEAT_TIMEOUT (%ds) is less than DELTA (%ds) -- heartbeats will '
+                    'expire before Nova staleness is detected, reducing heartbeat effectiveness',
+                    self.get_config_value('HEARTBEAT_TIMEOUT'), self.get_config_value('DELTA'))
+
     def get_str(self, key: str, default: str = '') -> str:
         """Get a string configuration value with validation."""
         value = self.config.get(key, default)
@@ -673,6 +705,8 @@ class ConfigManager:
         'SKIP_SERVERS_WITH_NAME': ConfigItem('list', []),
         'EVACUATION_RETRIES': ConfigItem('int', DEFAULT_EVACUATION_RETRIES, 1, 20),
         'HEARTBEAT_CLIFF_THRESHOLD': ConfigItem('int', 50, 10, 100),
+        'HEARTBEAT_CLIFF_MAX_CYCLES': ConfigItem('int', 3, 1, 20),
+        'MAX_HOSTS_PER_CYCLE': ConfigItem('int', 10, 1, 100),
         'K8S_API_CHECK_INTERVAL': ConfigItem('int', 15, 5, 120),
     }
 
@@ -752,7 +786,7 @@ class ConfigManager:
 
 
 
-class InstanceHAService(CloudConnectionProvider):
+class InstanceHAService:
     """Main service class that encapsulates all InstanceHA functionality."""
 
     def __init__(self, config_manager: ConfigManager, cloud_client: Optional[OpenStackClient] = None):
@@ -776,30 +810,40 @@ class InstanceHAService(CloudConnectionProvider):
 
         # Threading
         self.health_check_thread = None
+        self._http_server = None
         self.udp_ip = ''
         self.shutdown_event = threading.Event()
 
-        # Kdump state (protected by kdump_lock — UDP listener writes concurrently)
+        # Kdump state (protected by kdump_lock -- UDP listener writes concurrently)
         self.kdump_lock = threading.Lock()
         self.kdump_hosts_timestamp = defaultdict(float)
         self.kdump_hosts_checking = defaultdict(float)
         self.kdump_listener_stop_event = threading.Event()
         self.kdump_fenced_hosts = set()
 
-        # Heartbeat state (protected by heartbeat_lock — UDP listener writes concurrently)
+        # Heartbeat state (protected by heartbeat_lock -- UDP listener writes concurrently)
         self.heartbeat_lock = threading.Lock()
         self.heartbeat_hosts_timestamp = defaultdict(float)
         self.heartbeat_listener_stop_event = threading.Event()
         self.heartbeat_listener_start_time = 0.0
         self.heartbeat_previous_active_count = 0
+        self.heartbeat_consecutive_cliff_cycles = 0
+        self.last_poll_time = time.monotonic()
+
         self.heartbeat_hmac_keys = self._load_heartbeat_hmac_keys()
         if self.heartbeat_hmac_keys:
             logging.info("Heartbeat HMAC authentication enabled with %d key(s)", len(self.heartbeat_hmac_keys))
+        elif self.config.get_config_value('CHECK_HEARTBEAT'):
+            logging.warning(
+                'CHECK_HEARTBEAT is enabled but no HMAC keys are configured -- '
+                'heartbeat packets will be rejected')
 
         # Host processing tracking
         self.hosts_processing = defaultdict(float)
         self.processing_lock = threading.Lock()
         self.reserved_hosts_lock = threading.Lock()
+
+        logging.debug("MAX_HOSTS_PER_CYCLE=%d", self.config.get_config_value('MAX_HOSTS_PER_CYCLE'))
 
         logging.info("InstanceHA service initialized successfully")
 
@@ -907,7 +951,6 @@ class InstanceHAService(CloudConnectionProvider):
 
         # Early return if no tagged resources
         if not ((images_enabled and evac_images) or (flavors_enabled and evac_flavors)):
-            logging.info("No tagged resources found - evacuating all servers")
             return True
 
         # Check matches
@@ -931,7 +974,7 @@ class InstanceHAService(CloudConnectionProvider):
 
     def _get_cached_evacuable(self, cache_attr: str, config_key: str,
                               fetch_func: Callable, connection=None) -> List:
-        """Generic cache-aside pattern: check config → check cache → fetch → store."""
+        """Generic cache-aside pattern: check config -> check cache -> fetch -> store."""
         if not self.config.get_config_value(config_key):
             return []
         if connection is None:
@@ -1131,7 +1174,7 @@ class InstanceHAService(CloudConnectionProvider):
                 except Exception as e:
                     logging.warning("Failed to get servers for host %s: %s", service.host, e)
                     logging.debug('Exception traceback:', exc_info=True)
-                    # Don't cache empty — treat query failure as "might have servers"
+                    # Don't cache empty -- treat query failure as "might have servers"
                     # so the host is not incorrectly skipped during evacuation
                     host_servers[service.host] = None
 
@@ -1152,13 +1195,19 @@ class InstanceHAService(CloudConnectionProvider):
         if images is None:
             images = self.get_evacuable_images()
 
+        images_enabled = self.config.get_config_value('TAGGED_IMAGES')
+        flavors_enabled = self.config.get_config_value('TAGGED_FLAVORS')
+        if ((images_enabled or flavors_enabled)
+                and not ((images_enabled and images) or (flavors_enabled and flavors))):
+            logging.info("No tagged resources found -- evacuating all servers")
+
         services_with_evacuable = []
 
         for service in services:
             servers = host_servers_cache.get(service.host)
 
             if servers is None:
-                # Query failed — assume host has evacuable servers (fail safe)
+                # Query failed -- assume host has evacuable servers (fail safe)
                 services_with_evacuable.append(service)
                 logging.warning("Server query failed for %s, assuming evacuable", service.host)
                 continue
@@ -1211,7 +1260,7 @@ class InstanceHAService(CloudConnectionProvider):
                     if consecutive_failures >= max_failures:
                         if self.k8s_api_reachable:
                             logging.warning(
-                                "K8s API unreachable for %d consecutive checks — "
+                                "K8s API unreachable for %d consecutive checks -- "
                                 "possible network partition, marking not ready",
                                 consecutive_failures)
                             self.k8s_api_reachable = False
@@ -1253,13 +1302,22 @@ class InstanceHAService(CloudConnectionProvider):
                     self._respond(200, CONTENT_TYPE_LATEST, generate_latest())
                     return
 
-                if service_instance.hash_update_successful:
-                    self._respond(200, "text/plain", service_instance.current_hash)
-                else:
+                if not service_instance.hash_update_successful:
                     self._respond(500, "text/plain", b"Error: Hash not updated properly.")
+                    return
+
+                poll_interval = service_instance.config.get_config_value('POLL')
+                staleness = time.monotonic() - service_instance.last_poll_time
+                if service_instance.ready and staleness > poll_interval * 3:
+                    self._respond(500, "text/plain",
+                                  f"Main loop stale ({staleness:.0f}s since last poll)".encode())
+                    return
+
+                self._respond(200, "text/plain", service_instance.current_hash)
 
         try:
             server = HTTPServer(('', HEALTH_CHECK_PORT), HealthHandler)
+            self._http_server = server
             tls_cert = os.getenv('METRICS_TLS_CERT')
             tls_key = os.getenv('METRICS_TLS_KEY')
             if tls_cert and tls_key:
@@ -1286,7 +1344,7 @@ class InstanceHAService(CloudConnectionProvider):
 
     def refresh_evacuable_cache(self, connection=None, force=False, cache_timeout=CACHE_TIMEOUT_SECONDS):
         """Refresh evacuable flavors and images cache with intelligent timing."""
-        current_time = time.time()
+        current_time = time.monotonic()
 
         with self._cache_lock:
             cache_age = current_time - self._cache_timestamp
@@ -1449,9 +1507,9 @@ def _udp_listener(service, port, label, magic_numbers, min_packet_size,
 
                     try:
                         with lock:
-                            timestamps[hostname] = time.time()
+                            timestamps[hostname] = time.monotonic()
                             if len(timestamps) > cleanup_threshold:
-                                cutoff = time.time() - cleanup_age_seconds
+                                cutoff = time.monotonic() - cleanup_age_seconds
                                 to_remove = [k for k, v in timestamps.items() if v < cutoff]
                                 for k in to_remove:
                                     del timestamps[k]
@@ -1480,7 +1538,7 @@ def _kdump_udp_listener(service: 'InstanceHAService') -> None:
         lock=service.kdump_lock,
         timestamps=service.kdump_hosts_timestamp,
         stop_event=service.kdump_listener_stop_event,
-        cleanup_threshold=KDUMP_CLEANUP_THRESHOLD,
+        cleanup_threshold=UDP_CLEANUP_THRESHOLD,
         cleanup_age_seconds=KDUMP_CLEANUP_AGE_SECONDS,
         resolve_hostname=_resolve_hostname_dns,
     )
@@ -1490,7 +1548,7 @@ def _heartbeat_udp_listener(service: 'InstanceHAService') -> None:
     """Background UDP listener for host heartbeat messages."""
     def on_start():
         with service.heartbeat_lock:
-            service.heartbeat_listener_start_time = time.time()
+            service.heartbeat_listener_start_time = time.monotonic()
 
     def resolve_with_hmac(data, address, label):
         return _resolve_hostname_packet(data, address, label, hmac_keys=service.heartbeat_hmac_keys)
@@ -1504,7 +1562,7 @@ def _heartbeat_udp_listener(service: 'InstanceHAService') -> None:
         lock=service.heartbeat_lock,
         timestamps=service.heartbeat_hosts_timestamp,
         stop_event=service.heartbeat_listener_stop_event,
-        cleanup_threshold=HEARTBEAT_CLEANUP_THRESHOLD,
+        cleanup_threshold=UDP_CLEANUP_THRESHOLD,
         cleanup_age_seconds=HEARTBEAT_CLEANUP_AGE_SECONDS,
         resolve_hostname=resolve_with_hmac,
         log_level=logging.DEBUG,
@@ -1556,12 +1614,14 @@ def _get_evacuable_servers(connection, host, service) -> List:
 
     skip_names = service.config.get_config_value('SKIP_SERVERS_WITH_NAME')
     if skip_names:
-        skipped = [s for s in servers if _should_skip_server(s, skip_names)]
+        kept, skipped = [], []
+        for s in servers:
+            (skipped if _should_skip_server(s, skip_names) else kept).append(s)
         if skipped:
             logging.info("Skipping %d server(s) matching name filter %s: %s",
                         len(skipped), skip_names,
                         ', '.join(s.id for s in skipped))
-        servers = [s for s in servers if not _should_skip_server(s, skip_names)]
+        servers = kept
 
     if flavors or images:
         logging.debug("Filtering images and flavors: %s %s", repr(flavors), repr(images))
@@ -1643,8 +1703,8 @@ def _run_concurrent(func, items, max_workers, item_id_func, log_prefix=""):
             item = future_to_item[future]
             item_id = item_id_func(item)
             try:
-                if not future.result(timeout=FUTURE_RESULT_TIMEOUT_SECONDS):
-                    logging.error('%s%s failed', log_prefix, item_id)
+                if not future.result(timeout=MAX_EVACUATION_TIMEOUT_SECONDS + 60):
+                    logging.warning('%s%s failed', log_prefix, item_id)
                     all_succeeded = False
                 else:
                     logging.info('%s%s succeeded', log_prefix, item_id)
@@ -1660,7 +1720,7 @@ def _run_concurrent(func, items, max_workers, item_id_func, log_prefix=""):
 
 def _concurrent_evacuate(connection, evacuables, service, host, service_id, target_host=None) -> bool:
     """Evacuate concurrently, optionally with priority-ordered phases."""
-    orchestrated = service.config.get_config_value('ORCHESTRATED_RESTART') is True
+    orchestrated = service.config.get_config_value('ORCHESTRATED_RESTART')
     phases = _build_evacuation_groups(evacuables) if orchestrated else [evacuables]
     total_phases = len(phases)
     max_retries = service.config.get_config_value('EVACUATION_RETRIES')
@@ -1708,9 +1768,11 @@ def _traditional_evacuate(connection, evacuables, host, target_host=None) -> boo
         if hasattr(server, 'id'):
             response = _server_evacuate(connection, server.id, target_host=target_host, server_obj=server)
             if response.accepted:
-                logging.debug("Evacuated %s from %s: %s", response.uuid, host, response.reason)
+                logging.debug("Evacuated %s from %s: %s (nova-req: %s)",
+                              response.uuid, host, response.reason, response.request_id)
             else:
-                logging.warning("Evacuation of %s on %s failed: %s", response.uuid, host, response.reason)
+                logging.warning("Evacuation of %s on %s failed: %s (nova-req: %s)",
+                                response.uuid, host, response.reason, response.request_id)
                 all_succeeded = False
         else:
             logging.error("Could not evacuate instance: %s", server.to_dict())
@@ -1729,15 +1791,22 @@ def _host_evacuate(connection, failed_service, service, target_host=None) -> boo
 
     _interruptible_sleep(service.shutdown_event, service.config.get_config_value('DELAY'))
 
-    if service.config.get_config_value('ORCHESTRATED_RESTART') is True or service.config.get_config_value('SMART_EVACUATION'):
+    if service.config.get_config_value('ORCHESTRATED_RESTART') or service.config.get_config_value('SMART_EVACUATION'):
         return _concurrent_evacuate(connection, evacuables, service, host, failed_service.id, target_host=target_host)
     else:
         return _traditional_evacuate(connection, evacuables, host, target_host=target_host)
 
 
+def _extract_request_id(obj):
+    """Extract the Nova request ID from a TupleWithMeta or novaclient exception."""
+    request_ids = getattr(obj, 'request_ids', None)
+    if request_ids:
+        return request_ids[0]
+    return getattr(obj, 'request_id', None)
+
+
 def _server_evacuate(connection, server, target_host=None, server_obj=None) -> EvacuationResult:
     """Evacuate a single server instance, returning EvacuationResult."""
-    from novaclient.exceptions import Conflict, NotFound, Forbidden, Unauthorized
     success = False
     error_message = ""
     resp_status_code = None
@@ -1752,13 +1821,18 @@ def _server_evacuate(connection, server, target_host=None, server_obj=None) -> E
             except Exception as e:
                 logging.warning("Failed to reset task_state for %s: %s", server, e)
 
+    request_id = None
+
     try:
         if target_host:
             logging.info("Evacuating instance %s to target host %s", server, target_host)
-            response, _ = connection.servers.evacuate(server=server, host=target_host)
+            result = connection.servers.evacuate(server=server, host=target_host)
         else:
             logging.info("Evacuating instance %s", server)
-            response, _ = connection.servers.evacuate(server=server)
+            result = connection.servers.evacuate(server=server)
+
+        request_id = _extract_request_id(result)
+        response, _ = result
 
         if response is None:
             error_message = "No response received while evacuating instance"
@@ -1772,20 +1846,25 @@ def _server_evacuate(connection, server, target_host=None, server_obj=None) -> E
                     error_message = response.reason or "Evacuation initiated successfully"
             else:
                 error_message = response.reason or f"Evacuation failed with status {response.status_code}"
-    except NotFound:
+    except NotFound as e:
         resp_status_code = 404
+        request_id = _extract_request_id(e)
         error_message = f"Instance {server} not found"
     except Conflict as e:
         resp_status_code = 409
+        request_id = _extract_request_id(e)
         error_message = f"Conflict while evacuating instance {server}: {e}"
-    except Forbidden:
+    except Forbidden as e:
         resp_status_code = 403
+        request_id = _extract_request_id(e)
         error_message = f"Access denied while evacuating instance {server}"
-    except Unauthorized:
+    except Unauthorized as e:
         resp_status_code = 401
+        request_id = _extract_request_id(e)
         error_message = f"Authentication failed while evacuating instance {server}"
     except Exception as e:
         resp_status_code = getattr(e, 'http_status', None)
+        request_id = _extract_request_id(e)
         error_message = f"Error while evacuating instance {server}: {e}"
 
     return EvacuationResult(
@@ -1793,6 +1872,7 @@ def _server_evacuate(connection, server, target_host=None, server_obj=None) -> E
         accepted=success,
         reason=error_message,
         status_code=resp_status_code,
+        request_id=request_id,
     )
 
 
@@ -1868,10 +1948,11 @@ def _monitor_evacuation(connection, server_id, response_uuid, start_time,
                     connection.servers.reset_state(server_id, 'error')
                     retry_result = _server_evacuate(connection, server_id)
                     if retry_result.accepted:
-                        response_uuid = retry_result.uuid
-                        logging.info("Re-issued evacuation for %s as %s", server_id, response_uuid)
+                        logging.info("Re-issued evacuation for %s (nova-req: %s)",
+                                     server_id, retry_result.request_id)
                     else:
-                        logging.warning("Re-issue of evacuation for %s failed: %s", server_id, retry_result.reason)
+                        logging.warning("Re-issue of evacuation for %s failed: %s (nova-req: %s)",
+                                        server_id, retry_result.reason, retry_result.request_id)
                 except Exception as retry_err:
                     logging.warning("Failed to re-issue evacuation for %s: %s", server_id, retry_err)
                 _interruptible_sleep(shutdown_event, EVACUATION_RETRY_WAIT_SECONDS)
@@ -1912,7 +1993,7 @@ def _server_evacuate_future(connection, server, target_host=None,
     try:
         connection.servers.lock(server.id, reason=LOCK_REASON_EVACUATION)
     except Exception:
-        logging.debug("Could not lock server %s (may already be locked)", server.id)
+        logging.warning("Could not lock server %s (may already be locked)", server.id)
 
     try:
         _emit_k8s_event(source_host, 'InstanceEvacuationStarted',
@@ -1922,20 +2003,22 @@ def _server_evacuate_future(connection, server, target_host=None,
         response = _server_evacuate(connection, server.id, target_host=target_host, server_obj=server)
 
         if not response.accepted and response.status_code in (409, 500) and target_host:
-            logging.warning("Evacuation of %s to %s failed with %s, retrying without target host",
-                            server.id, target_host, response.status_code)
+            logging.warning("Evacuation of %s to %s failed with %s (nova-req: %s), retrying without target host",
+                            server.id, target_host, response.status_code, response.request_id)
             response = _server_evacuate(connection, server.id, server_obj=server)
 
         if not response.accepted:
-            logging.warning("Evacuation of %s on %s failed: %s",
-                           response.uuid, server.id, _sanitize_message(str(response.reason)))
+            logging.warning("Evacuation of %s on %s failed: %s (nova-req: %s)",
+                           response.uuid, server.id,
+                           _sanitize_message(str(response.reason)), response.request_id)
             _emit_k8s_event(source_host, 'InstanceEvacuationFailed',
-                            f'Instance {server.id} evacuation failed: {_sanitize_message(str(response.reason))}',
+                            f'Instance {server.id} evacuation failed: {response.reason}'
+                            f' (nova-req: {response.request_id})',
                             event_type='Warning')
             INSTANCE_EVACUATION_TOTAL.labels(host=source_host, result='failed').inc()
             return False
 
-        logging.debug("Starting evacuation of %s", response.uuid)
+        logging.info("Evacuation accepted for %s (nova-req: %s)", response.uuid, response.request_id)
         _interruptible_sleep(shutdown_event, INITIAL_EVACUATION_WAIT_SECONDS)
 
         result = _monitor_evacuation(connection, server.id, response.uuid, start_time,
@@ -1976,7 +2059,7 @@ def _server_evacuate_future(connection, server, target_host=None,
     except Exception as e:
         _safe_log_exception(f"Unexpected error during evacuation of server {server.id}", e, include_traceback=True)
         _emit_k8s_event(source_host, 'InstanceEvacuationFailed',
-                        f'Instance {server.id} evacuation error: {_sanitize_message(str(e))}',
+                        f'Instance {server.id} evacuation error: {e}',
                         event_type='Warning')
         INSTANCE_EVACUATION_TOTAL.labels(host=source_host, result='failed').inc()
         return False
@@ -1990,17 +2073,12 @@ def _server_evacuate_future(connection, server, target_host=None,
 def _nova_login(plugin_name: str, auth_kwargs: dict, region_name: str,
                 ca_bundle: Optional[str] = None) -> OpenStackClient:
     """Create and return Nova client connection. Raises NovaConnectionError on failure."""
-    from keystoneauth1 import loading
-    from keystoneauth1 import session as ksc_session
-    from keystoneauth1.exceptions.discovery import DiscoveryFailure
-    from novaclient import client
-    from novaclient.exceptions import Unauthorized
     try:
-        loader = loading.get_plugin_loader(plugin_name)
+        loader = ksc_loading.get_plugin_loader(plugin_name)
         auth = loader.load_from_options(**auth_kwargs)
         verify = ca_bundle if ca_bundle else True
         session = ksc_session.Session(auth=auth, verify=verify, timeout=NOVA_API_TIMEOUT_SECONDS)
-        nova = client.Client("2.73", session=session, region_name=region_name)
+        nova = nova_client_mod.Client("2.73", session=session, region_name=region_name)
         nova.versions.get_current()
         logging.info("Nova login successful (%s)", plugin_name)
         return nova
@@ -2035,7 +2113,6 @@ def nova_login_ac(credentials: ACLoginCredentials, ca_bundle: Optional[str] = No
 
 def _handle_nova_exception(operation: str, service_info: str, e: Exception, is_critical: bool = True) -> bool:
     """Handle Nova API exceptions with consistent logging."""
-    from novaclient.exceptions import NotFound, Conflict
     nova_exception_messages = {
         NotFound: "Resource not found",
         Conflict: "Conflicting operation",
@@ -2088,14 +2165,14 @@ def _check_kdump(stale_services: List[Any], service: InstanceHAService) -> Tuple
     logging.info("Checking %d hosts for kdump activity", len(stale_services))
     kdump_fenced = []
     waiting = []
-    current_time = time.time()
+    current_time = time.monotonic()
     kdump_timeout = service.config.get_config_value('KDUMP_TIMEOUT')
 
-    # Kdump state machine per host (under lock — UDP listener writes timestamps concurrently):
-    # State 1: Fresh down host (check_start==0) → start waiting, set check_start=now
-    # State 2: Waiting (check_start > 0, time < timeout) → continue waiting
-    # State 3a: Kdump received (last_msg within timeout) → mark fenced, evacuate immediately
-    # State 3b: Timeout expired (time >= timeout) → no kdump received, evacuate normally
+    # Kdump state machine per host (under lock -- UDP listener writes timestamps concurrently):
+    # State 1: Fresh down host (check_start==0) -> start waiting, set check_start=now
+    # State 2: Waiting (check_start > 0, time < timeout) -> continue waiting
+    # State 3a: Kdump received (last_msg within timeout) -> mark fenced, evacuate immediately
+    # State 3b: Timeout expired (time >= timeout) -> no kdump received, evacuate normally
     with service.kdump_lock:
         for svc in stale_services:
             hostname = _extract_hostname(svc.host)
@@ -2157,7 +2234,9 @@ def _host_enable(connection, nova_service, reenable: bool = False, service=None)
         )
         logging.info('Host %s is now enabled', nova_service.host)
         return True
-    except Exception:
+    except Exception as e:
+        logging.error('Failed to re-enable host %s after %d attempts: %s',
+                      nova_service.host, MAX_ENABLE_RETRIES, e)
         return False
 
 
@@ -2222,6 +2301,9 @@ def _redfish_reset(url, user, passwd, timeout, action, config_mgr, shutdown_even
 
     # Retry logic for transient failures
     for attempt in range(MAX_FENCING_RETRIES):
+        if shutdown_event and shutdown_event.is_set():
+            logging.warning("Shutdown requested, aborting Redfish reset for %s", safe_url)
+            return False
         try:
             response = _make_ssl_request('post', reset_url, (user, passwd), timeout,
                                         config_mgr, json=payload, headers=headers)
@@ -2252,7 +2334,7 @@ def _redfish_reset(url, user, passwd, timeout, action, config_mgr, shutdown_even
                                 "Redfish reset: %s rejected with %d while server is OFF "
                                 "(attempt %d/%d), server may not be ready yet, retrying...",
                                 action, response.status_code, attempt + 1, MAX_FENCING_RETRIES)
-                            time.sleep(FENCING_RETRY_DELAY_SECONDS * (attempt + 1))
+                            _interruptible_sleep(shutdown_event, FENCING_RETRY_DELAY_SECONDS * (attempt + 1))
                             continue
                         else:
                             logging.error(
@@ -2274,7 +2356,7 @@ def _redfish_reset(url, user, passwd, timeout, action, config_mgr, shutdown_even
                 # Transient server errors - retry
                 logging.warning("Redfish reset failed: server error %d (attempt %d/%d), retrying...",
                               response.status_code, attempt + 1, MAX_FENCING_RETRIES)
-                time.sleep(FENCING_RETRY_DELAY_SECONDS * (attempt + 1))
+                _interruptible_sleep(shutdown_event, FENCING_RETRY_DELAY_SECONDS * (attempt + 1))
                 continue
             else:
                 logging.error("Redfish reset failed: status %d for %s", response.status_code, safe_url)
@@ -2284,7 +2366,7 @@ def _redfish_reset(url, user, passwd, timeout, action, config_mgr, shutdown_even
             # Network errors - retry
             if attempt < MAX_FENCING_RETRIES - 1:
                 logging.warning("Redfish reset network error (attempt %d/%d), retrying...", attempt + 1, MAX_FENCING_RETRIES)
-                time.sleep(FENCING_RETRY_DELAY_SECONDS * (attempt + 1))
+                _interruptible_sleep(shutdown_event, FENCING_RETRY_DELAY_SECONDS * (attempt + 1))
                 continue
             else:
                 _safe_log_exception(f"Redfish reset failed for {safe_url}", e)
@@ -2356,10 +2438,7 @@ def _bmh_wait_for_power_off(get_url, headers, cacert, host, timeout, poll_interv
             if service.shutdown_event and service.shutdown_event.is_set():
                 logging.warning("Shutdown requested, aborting power-off wait for %s", host)
                 return False
-            if service.shutdown_event:
-                service.shutdown_event.wait(poll_interval)
-            else:
-                time.sleep(poll_interval)
+            _interruptible_sleep(service.shutdown_event, poll_interval)
 
             try:
                 response = session.get(get_url, headers=headers, verify=cacert, timeout=request_timeout)
@@ -2382,7 +2461,7 @@ def _bmh_wait_for_power_off(get_url, headers, cacert, host, timeout, poll_interv
                 if not power_status:
                     logging.info("BMH power off confirmed for %s", host)
                     return True
-            except (KeyError, Exception) as e:
+            except Exception as e:
                 logging.warning("Error parsing power status for %s: %s, continuing to wait", host, e)
                 continue
 
@@ -2421,6 +2500,7 @@ def _execute_ipmi_fence(host, action, fencing_data, timeout, shutdown_event=None
             lambda: subprocess.run(cmd, timeout=timeout, env=env, capture_output=True, text=True, check=True),
             MAX_FENCING_RETRIES,
             f'IPMI {action} for {host}',
+            shutdown_event=shutdown_event,
         )
     except Exception as e:
         _safe_log_exception(f"IPMI {action} failed for {host}", e)
@@ -2537,11 +2617,6 @@ def _host_fence(host, action, service):
     except Exception as e:
         logging.error("Fencing failed for %s: %s", host, e)
         return False
-
-
-def _get_nova_connection(service):
-    """Establish a connection to Nova using service configuration."""
-    return _establish_nova_connection(service, fatal=False)
 
 
 def _enable_matching_reserved_host(conn, failed_service, reserved_hosts, service,
@@ -2738,7 +2813,8 @@ def _check_k8s_api_reachable():
 
 
 def _emit_k8s_event(host, reason, message, event_type='Normal'):
-    """Emit a Kubernetes Event on the InstanceHA CR."""
+    """Emit a Kubernetes Event on the InstanceHA CR. Message is auto-sanitized."""
+    message = _sanitize_message(message)
     token, namespace = _get_k8s_credentials()
     if not token:
         logging.debug("K8s credentials not available, skipping event emission")
@@ -2804,6 +2880,7 @@ def _execute_step(step_name, step_func, host_name, *args, **kwargs):
         return result
     except Exception as e:
         logging.error("%s failed for %s: %s", step_name, host_name, e)
+        logging.debug("Exception traceback:", exc_info=True)
         return False
 
 
@@ -2817,11 +2894,14 @@ def process_service(failed_service, reserved_hosts, resume, service) -> bool:
     hostname = _extract_hostname(host_name)
     reserved_hosts = reserved_hosts or []
 
-    logging.info("Processing service %s (resume=%s)", host_name, resume)
+    if resume:
+        logging.info("Resuming evacuation for %s", host_name)
+    else:
+        logging.info("Starting recovery for %s (fence + evacuate)", host_name)
 
     with track_host_processing(service, hostname):
         try:
-            conn = _get_nova_connection(service)
+            conn = _establish_nova_connection(service, fatal=False)
             if not conn:
                 logging.error("Nova connection failed for %s", host_name)
                 return False
@@ -2902,7 +2982,7 @@ def process_service(failed_service, reserved_hosts, resume, service) -> bool:
         except Exception as e:
             logging.error("Service processing failed for %s: %s", host_name, e)
             _emit_k8s_event(host_name, 'ProcessingFailed',
-                            f'Service processing failed: {_sanitize_message(str(e))}',
+                            f'Service processing failed: {e}',
                             event_type='Warning')
             PROCESSING_FAILED_TOTAL.labels(host=host_name).inc()
             return False
@@ -2917,9 +2997,7 @@ def _initialize_service(config_mgr):
         sys.exit(1)
 
     # Start health check server
-    health_check_thread = threading.Thread(target=service.start_health_check_server)
-    health_check_thread.daemon = True
-    health_check_thread.start()
+    service.start_health_check_server()
 
     # Start K8s API connectivity monitor
     service.start_k8s_health_check()
@@ -2937,7 +3015,7 @@ def _initialize_service(config_mgr):
         heartbeat_thread.start()
     else:
         logging.warning(
-            'CHECK_HEARTBEAT is disabled — fencing decisions rely solely on Nova service '
+            'CHECK_HEARTBEAT is disabled -- fencing decisions rely solely on Nova service '
             'timestamps. Enable heartbeat checking for split-brain protection.')
 
     return service
@@ -2999,10 +3077,13 @@ def _categorize_services(services: List[Any], target_date: datetime) -> tuple:
 
     return compute_nodes, resume, reenable
 
-def _check_critical_services(services):
+def _check_critical_services(conn):
     """Check if critical Nova services are operational for evacuation."""
-    # Check if at least one scheduler is up
-    schedulers = [s for s in services if s.binary == 'nova-scheduler']
+    try:
+        schedulers = conn.services.list(binary="nova-scheduler")
+    except Exception:
+        logging.warning("Could not query nova-scheduler services, proceeding with evacuation")
+        return True, ""
     if schedulers and not any(s.state == 'up' for s in schedulers):
         return False, "All nova-scheduler services are down"
 
@@ -3117,7 +3198,7 @@ def _filter_reachable_hosts(service, compute_nodes):
         return compute_nodes, [], False
 
     heartbeat_timeout = service.config.get_config_value('HEARTBEAT_TIMEOUT')
-    current_time = time.time()
+    current_time = time.monotonic()
 
     with service.heartbeat_lock:
         listener_start_time = service.heartbeat_listener_start_time
@@ -3138,22 +3219,35 @@ def _filter_reachable_hosts(service, compute_nodes):
     cliff_detected = False
     if previous_active >= 3:
         threshold = service.config.get_config_value('HEARTBEAT_CLIFF_THRESHOLD')
+        max_cliff_cycles = service.config.get_config_value('HEARTBEAT_CLIFF_MAX_CYCLES')
         drop_percent = (previous_active - current_active) / previous_active * 100
         if drop_percent >= threshold:
-            cliff_detected = True
-            logging.error(
-                'Heartbeat cliff detected: %d→%d active hosts (%.1f%% drop, '
-                'threshold %d%%) — possible network partition, skipping fencing this cycle',
-                previous_active, current_active, drop_percent, threshold)
-            _emit_k8s_event('cluster', 'HeartbeatCliff',
-                            f'Sudden heartbeat loss: {previous_active}→{current_active} active hosts '
-                            f'({drop_percent:.1f}% drop) — skipping fencing',
-                            event_type='Warning')
-            HEARTBEAT_CLIFF_TOTAL.inc()
-            return [], list(compute_nodes), True
+            service.heartbeat_consecutive_cliff_cycles += 1
+            if service.heartbeat_consecutive_cliff_cycles >= max_cliff_cycles:
+                logging.error(
+                    'Heartbeat cliff persisted for %d consecutive cycles -- '
+                    'accepting current state as genuine failure (%d->%d active hosts)',
+                    service.heartbeat_consecutive_cliff_cycles, previous_active, current_active)
+                _emit_k8s_event('cluster', 'HeartbeatCliffExpired',
+                                f'Cliff detection expired after {service.heartbeat_consecutive_cliff_cycles} cycles -- '
+                                f'proceeding with fencing ({previous_active}->{current_active} active hosts)',
+                                event_type='Warning')
+            else:
+                cliff_detected = True
+                logging.error(
+                    'Heartbeat cliff detected: %d->%d active hosts (%.1f%% drop, '
+                    'threshold %d%%, cycle %d/%d) -- possible network partition, skipping fencing this cycle',
+                    previous_active, current_active, drop_percent, threshold,
+                    service.heartbeat_consecutive_cliff_cycles, max_cliff_cycles)
+                _emit_k8s_event('cluster', 'HeartbeatCliff',
+                                f'Sudden heartbeat loss: {previous_active}->{current_active} active hosts '
+                                f'({drop_percent:.1f}% drop, cycle {service.heartbeat_consecutive_cliff_cycles}/{max_cliff_cycles}) -- skipping fencing',
+                                event_type='Warning')
+                HEARTBEAT_CLIFF_TOTAL.inc()
+                return [], list(compute_nodes), True
 
-    if not cliff_detected:
-        service.heartbeat_previous_active_count = current_active
+    service.heartbeat_previous_active_count = current_active
+    service.heartbeat_consecutive_cliff_cycles = 0
 
     unreachable = []
     skipped = []
@@ -3165,7 +3259,7 @@ def _filter_reachable_hosts(service, compute_nodes):
         if last_heartbeat > 0 and (current_time - last_heartbeat) <= heartbeat_timeout:
             skipped.append(svc)
             logging.warning(
-                'Host %s reported down by Nova but heartbeat received %.1fs ago — '
+                'Host %s reported down by Nova but heartbeat received %.1fs ago -- '
                 'skipping fencing (likely nova-compute crash)',
                 svc.host, current_time - last_heartbeat)
         else:
@@ -3186,124 +3280,151 @@ def _process_stale_services(conn, service, services, compute_nodes, to_resume):
     # Filter out hosts already being processed
     compute_nodes, to_resume, marked_hostnames, current_time = _filter_processing_hosts(service, compute_nodes, to_resume)
 
-    if not (compute_nodes or to_resume):
-        _cleanup_filtered_hosts(service, marked_hostnames, set(), current_time)
-        return
+    final_hostnames = set()
+    try:
+        if not (compute_nodes or to_resume):
+            return
 
-    # Filter out hosts still reachable via heartbeat
-    stale_count = len(compute_nodes)
-    heartbeat_skipped = []
-    cliff_detected = False
-    if service.config.get_config_value('CHECK_HEARTBEAT'):
-        compute_nodes, heartbeat_skipped, cliff_detected = _filter_reachable_hosts(service, compute_nodes)
-        if not cliff_detected:
-            for svc in heartbeat_skipped:
-                _emit_k8s_event(svc.host, 'HostReachable',
-                                'Host reported down by Nova but still sending heartbeats — '
-                                'skipping fencing (likely nova-compute crash)',
-                                event_type='Warning')
-                HOST_REACHABLE_TOTAL.labels(host=svc.host).inc()
+        # Filter out hosts still reachable via heartbeat (before the all-stale check,
+        # so heartbeat data can disambiguate partial failures from Nova API issues)
+        stale_count = len(compute_nodes)
+        heartbeat_skipped = []
+        cliff_detected = False
+        if service.config.get_config_value('CHECK_HEARTBEAT'):
+            compute_nodes, heartbeat_skipped, cliff_detected = _filter_reachable_hosts(service, compute_nodes)
+            if not cliff_detected:
+                for svc in heartbeat_skipped:
+                    _emit_k8s_event(svc.host, 'HostReachable',
+                                    'Host reported down by Nova but still sending heartbeats -- '
+                                    'skipping fencing (likely nova-compute crash)',
+                                    event_type='Warning')
+                    HOST_REACHABLE_TOTAL.labels(host=svc.host).inc()
+
+        logging.info(
+            'Fencing decision: %d stale, %d heartbeat-alive, %d to fence, cliff=%s',
+            stale_count, len(heartbeat_skipped), len(compute_nodes), cliff_detected)
+
+        # Sanity check: if every active service still appears stale after heartbeat
+        # filtering, the data source is likely wrong. Only trigger when there are
+        # enough active services for this to be meaningful (>=3), since small
+        # clusters (2 nodes) can legitimately have all hosts down.
+        active_services = [s for s in services if 'disabled' not in s.status and not s.forced_down]
+        if compute_nodes and len(active_services) >= MIN_ACTIVE_SERVICES_FOR_STALE_CHECK and len(compute_nodes) >= len(active_services):
+            logging.critical(
+                'ALL %d active compute services appear stale -- this is almost certainly '
+                'a Nova API or infrastructure issue, not a genuine failure of every host. '
+                'Skipping fencing this cycle.',
+                len(active_services))
+            _emit_k8s_event('cluster', 'AllServicesStale',
+                            f'All {len(active_services)} active compute services appear stale -- '
+                            'skipping fencing (likely Nova API issue)',
+                            event_type='Warning')
+            ALL_SERVICES_STALE_TOTAL.inc()
+            return
 
         if not (compute_nodes or to_resume):
-            logging.info(
-                'Fencing decision: %d stale, %d heartbeat-alive, %d to fence, cliff=%s',
-                stale_count, len(heartbeat_skipped), len(compute_nodes), cliff_detected)
-            _cleanup_filtered_hosts(service, marked_hostnames, set(), current_time)
             return
 
-    logging.info(
-        'Fencing decision: %d stale, %d heartbeat-alive, %d to fence, cliff=%s',
-        stale_count, len(heartbeat_skipped), len(compute_nodes), cliff_detected)
+        if compute_nodes:
+            logging.warning('The following computes are down: %s', [svc.host for svc in compute_nodes])
+            for svc in compute_nodes:
+                _emit_k8s_event(svc.host, 'HostDown',
+                                'Compute host detected as down', event_type='Warning')
+                HOST_DOWN_TOTAL.labels(host=svc.host).inc()
 
-    if compute_nodes:
-        logging.warning('The following computes are down: %s', [svc.host for svc in compute_nodes])
-        for svc in compute_nodes:
-            _emit_k8s_event(svc.host, 'HostDown',
-                            'Compute host detected as down', event_type='Warning')
-            HOST_DOWN_TOTAL.labels(host=svc.host).inc()
-
-    # Fetch aggregates once per poll cycle to avoid redundant API calls
-    aggregates = None
-    if service.config.get_config_value('TAGGED_AGGREGATES'):
-        try:
-            aggregates = conn.aggregates.list()
-        except Exception as e:
-            logging.warning("Failed to fetch aggregates: %s", e)
-
-    # Prepare resources for evacuation
-    compute_nodes, reserved_hosts, images, flavors = _prepare_evacuation_resources(
-        conn, service, services, compute_nodes, aggregates=aggregates)
-
-    # Check evacuation threshold
-    if services and compute_nodes:
-        # When TAGGED_AGGREGATES is enabled, calculate threshold against evacuable hosts only
+        # Fetch aggregates once per poll cycle to avoid redundant API calls
+        aggregates = None
         if service.config.get_config_value('TAGGED_AGGREGATES'):
-            total_evacuable = _count_evacuable_hosts(conn, service, services, aggregates=aggregates)
-            threshold_percent = (len(compute_nodes) / total_evacuable * 100) if total_evacuable > 0 else 0
-        else:
-            active_services = [s for s in services if 'disabled' not in s.status and not s.forced_down]
-            threshold_percent = (len(compute_nodes) / len(active_services)) * 100 if active_services else 0
+            try:
+                aggregates = conn.aggregates.list()
+            except Exception as e:
+                logging.warning("Failed to fetch aggregates: %s", e)
 
-        threshold = service.config.get_config_value('THRESHOLD')
-        if threshold_percent > threshold:
-            logging.error('Number of impacted computes (%.1f%%) exceeds threshold (%d%%). Not evacuating.', threshold_percent, threshold)
-            _emit_k8s_event('cluster', 'ThresholdExceeded',
-                            f'Impacted computes ({threshold_percent:.1f}%) exceed threshold ({threshold}%%), evacuation skipped',
+        # Prepare resources for evacuation
+        compute_nodes, reserved_hosts, images, flavors = _prepare_evacuation_resources(
+            conn, service, services, compute_nodes, aggregates=aggregates)
+
+        # Check evacuation threshold
+        if services and compute_nodes:
+            # When TAGGED_AGGREGATES is enabled, calculate threshold against evacuable hosts only
+            if service.config.get_config_value('TAGGED_AGGREGATES'):
+                total_evacuable = _count_evacuable_hosts(conn, service, services, aggregates=aggregates)
+                threshold_percent = (len(compute_nodes) / total_evacuable * 100) if total_evacuable > 0 else 0
+            else:
+                threshold_percent = (len(compute_nodes) / len(active_services)) * 100 if active_services else 0
+
+            threshold = service.config.get_config_value('THRESHOLD')
+            if threshold_percent > threshold:
+                logging.error('Number of impacted computes (%.1f%%) exceeds threshold (%d%%). Not evacuating.', threshold_percent, threshold)
+                _emit_k8s_event('cluster', 'ThresholdExceeded',
+                                f'Impacted computes ({threshold_percent:.1f}%) exceed threshold ({threshold}%%), evacuation skipped',
+                                event_type='Warning')
+                THRESHOLD_EXCEEDED_TOTAL.inc()
+                return
+
+        # Per-aggregate failure threshold check
+        if compute_nodes and isinstance(aggregates, list) and service.config.get_config_value('TAGGED_AGGREGATES'):
+            compute_nodes, agg_blocked = _filter_by_aggregate_threshold(
+                compute_nodes, aggregates, service)
+            if agg_blocked:
+                logging.warning('Blocked %d host(s) due to per-aggregate threshold: %s',
+                               len(agg_blocked), [svc.host for svc in agg_blocked])
+            if not compute_nodes and not to_resume:
+                logging.warning('All compute nodes blocked by per-aggregate thresholds')
+                return
+
+        # Per-cycle rate limit: cap how many hosts can be fenced in one poll cycle
+        max_per_cycle = service.config.get_config_value('MAX_HOSTS_PER_CYCLE')
+        if isinstance(max_per_cycle, int) and max_per_cycle > 0 and len(compute_nodes) > max_per_cycle:
+            deferred = compute_nodes[max_per_cycle:]
+            compute_nodes = compute_nodes[:max_per_cycle]
+            logging.warning(
+                '%d hosts detected down, capping to %d (MAX_HOSTS_PER_CYCLE). '
+                'Deferred %d host(s) to next cycle: %s. '
+                'Increase MAX_HOSTS_PER_CYCLE if this cap is unexpected.',
+                len(compute_nodes) + len(deferred), max_per_cycle,
+                len(deferred), [svc.host for svc in deferred])
+            _emit_k8s_event('cluster', 'FencingRateLimited',
+                            f'Capped fencing to {max_per_cycle} hosts this cycle, '
+                            f'deferred {len(deferred)} host(s) to next cycle',
                             event_type='Warning')
-            THRESHOLD_EXCEEDED_TOTAL.inc()
-            _cleanup_filtered_hosts(service, marked_hostnames, set(), current_time)
-            return
+            FENCING_RATE_LIMITED_TOTAL.inc()
 
-    # Per-aggregate failure threshold check
-    if compute_nodes and isinstance(aggregates, list) and service.config.get_config_value('TAGGED_AGGREGATES'):
-        compute_nodes, agg_blocked = _filter_by_aggregate_threshold(
-            compute_nodes, aggregates, service)
-        if agg_blocked:
-            logging.warning('Blocked %d host(s) due to per-aggregate threshold: %s',
-                           len(agg_blocked), [svc.host for svc in agg_blocked])
-        if not compute_nodes and not to_resume:
-            logging.warning('All compute nodes blocked by per-aggregate thresholds')
-            _cleanup_filtered_hosts(service, marked_hostnames, set(), current_time)
-            return
+        # Process evacuations
+        if not service.config.get_config_value('DISABLED'):
+            # Check if critical services are operational
+            can_evacuate, error_msg = _check_critical_services(conn)
+            if not can_evacuate:
+                logging.error('Cannot evacuate: %s. Skipping evacuation.', error_msg)
+                return
 
-    # Process evacuations
-    if not service.config.get_config_value('DISABLED'):
-        # Check if critical services are operational
-        can_evacuate, error_msg = _check_critical_services(services)
-        if not can_evacuate:
-            logging.error('Cannot evacuate: %s. Skipping evacuation.', error_msg)
-            _cleanup_filtered_hosts(service, marked_hostnames, set(), current_time)
-            return
+            if service.config.get_config_value('CHECK_KDUMP'):
+                to_evacuate, kdump_fenced = _check_kdump(compute_nodes, service)
+            else:
+                to_evacuate = compute_nodes
+                kdump_fenced = []
 
-        if service.config.get_config_value('CHECK_KDUMP'):
-            to_evacuate, kdump_fenced = _check_kdump(compute_nodes, service)
+            workers = service.config.get_config_value('WORKERS')
+            poll_interval = service.config.get_config_value('POLL')
+            for batch_name, batch, resume in [
+                ('new evacuations', to_evacuate, False),
+                ('kdump-fenced', kdump_fenced, True),
+                ('resumed', to_resume, True),
+            ]:
+                if not batch:
+                    continue
+                _run_concurrent(
+                    lambda svc, _resume=resume: process_service(svc, reserved_hosts, _resume, service),
+                    batch,
+                    workers,
+                    lambda svc: f"{svc.host} ({batch_name})",
+                )
+
+            final_hostnames = {_extract_hostname(svc.host) for svc in to_evacuate + kdump_fenced + to_resume}
         else:
-            to_evacuate = compute_nodes
-            kdump_fenced = []
-
-        workers = service.config.get_config_value('WORKERS')
-        poll_interval = service.config.get_config_value('POLL')
-        for batch_name, batch, resume in [
-            ('new evacuations', to_evacuate, False),
-            ('kdump-fenced', kdump_fenced, True),
-            ('resumed', to_resume, True),
-        ]:
-            if not batch:
-                continue
-            _run_concurrent(
-                lambda svc, _resume=resume: process_service(svc, reserved_hosts, _resume, service),
-                batch,
-                workers,
-                lambda svc: f"{svc.host} ({batch_name})",
-            )
-
-        # Clean up any hosts that were marked but filtered out before processing
-        # (process_service cleans up hosts it processes, so we only need to clean up filtered ones)
-        final_hostnames = {_extract_hostname(svc.host) for svc in to_evacuate + kdump_fenced + to_resume}
+            logging.info('InstanceHA DISABLED is true, not evacuating')
+    finally:
         _cleanup_filtered_hosts(service, marked_hostnames, final_hostnames, current_time)
-    else:
-        logging.info('InstanceHA DISABLED is true, not evacuating')
-        _cleanup_filtered_hosts(service, marked_hostnames, set(), current_time)
 
 def _get_evacuable_hosts_from_aggregates(conn, service, aggregates=None):
     """Build set of hosts in evacuable aggregates."""
@@ -3426,7 +3547,7 @@ def _process_reenabling(conn, service, to_reenable) -> None:
                 hostname = _extract_hostname(svc.host)
                 with service.kdump_lock:
                     last_kdump = service.kdump_hosts_timestamp.get(hostname, 0)
-                time_since_kdump = time.time() - last_kdump if last_kdump > 0 else float('inf')
+                time_since_kdump = time.monotonic() - last_kdump if last_kdump > 0 else float('inf')
                 if time_since_kdump < KDUMP_REENABLE_DELAY_SECONDS:
                     logging.info('%s waiting for kdump to complete (%.0fs since last message, waiting for %ds)', svc.host, time_since_kdump, KDUMP_REENABLE_DELAY_SECONDS)
                     continue
@@ -3474,7 +3595,7 @@ def _reconcile_orphaned_hosts(conn):
             try:
                 disable_reason = _make_disable_reason(DISABLED_REASON_EVACUATION, " (recovered)")
                 conn.services.disable_log_reason(svc.id, disable_reason)
-                logging.warning("Recovered orphaned fenced host %s — marked for evacuation resume", svc.host)
+                logging.warning("Recovered orphaned fenced host %s -- marked for evacuation resume", svc.host)
                 _emit_k8s_event(svc.host, 'OrphanedHostRecovered',
                                 'Recovered orphaned fenced host, marked for evacuation resume',
                                 event_type='Warning')
@@ -3542,21 +3663,21 @@ def main():
         service.shutdown_event.set()
         service.kdump_listener_stop_event.set()
         service.heartbeat_listener_stop_event.set()
+        if service._http_server:
+            threading.Thread(target=service._http_server.shutdown, daemon=True).start()
 
     signal.signal(signal.SIGTERM, _sigterm_handler)
 
     consecutive_failures = 0
 
-    from novaclient.exceptions import Unauthorized
-    from keystoneauth1.exceptions.discovery import DiscoveryFailure
-
     while not service.shutdown_event.is_set():
         service.update_health_hash()
         poll_interval = service.config.get_config_value('POLL')
+        poll_start_time = time.monotonic()
 
         try:
             if not service.k8s_api_reachable:
-                logging.warning("Skipping fencing — K8s API unreachable (possible network partition)")
+                logging.warning("Skipping fencing -- K8s API unreachable (possible network partition)")
                 service.shutdown_event.wait(poll_interval)
                 continue
 
@@ -3577,9 +3698,15 @@ def main():
             stale_count = len(compute_nodes_list)
             if not service.ready:
                 service.ready = True
-                logging.info("Readiness probe active — first poll cycle completed")
-            logging.info("Poll cycle completed: %d compute services, %d stale, next poll in %ds",
-                         len(services), stale_count, poll_interval)
+                logging.info("Readiness probe active -- first poll cycle completed")
+                _emit_k8s_event('cluster', 'ServiceStarted',
+                                'InstanceHA ready -- first poll cycle completed')
+            poll_duration = time.monotonic() - poll_start_time
+            POLL_DURATION_SECONDS.observe(poll_duration)
+            logging.info("Poll cycle completed: %d compute services, %d stale, %.1fs duration, next poll in %ds",
+                         len(services), stale_count, poll_duration, poll_interval)
+            service.last_poll_time = time.monotonic()
+            _prune_stale_metric_labels(svc.host for svc in services)
             consecutive_failures = 0
             POLL_CONSECUTIVE_FAILURES.set(0)
             POLL_CYCLE_TOTAL.labels(result='success').inc()
@@ -3591,13 +3718,13 @@ def main():
             new_conn = _establish_nova_connection(service, fatal=False)
             if new_conn:
                 conn = new_conn
-            continue
+            continue  # backoff wait already performed by _handle_poll_failure
 
         except Exception as e:
             consecutive_failures = _handle_poll_failure(
                 service, consecutive_failures, poll_interval,
                 "Failed to query Nova API", e, include_traceback=True)
-            continue
+            continue  # backoff wait already performed by _handle_poll_failure
 
         service.shutdown_event.wait(poll_interval)
 

--- a/test/instanceha/benchmark_heartbeat.py
+++ b/test/instanceha/benchmark_heartbeat.py
@@ -33,7 +33,7 @@ from unittest.mock import Mock
 import logging
 logging.disable(logging.CRITICAL)
 
-import conftest  # noqa: F401
+from conftest import make_mock_config  # noqa: F401
 import instanceha
 
 logging.disable(logging.CRITICAL)
@@ -53,9 +53,7 @@ def _find_free_port():
 
 
 def _make_service(heartbeat_timeout=120):
-    mock_config = Mock()
-    mock_config.get_config_value.return_value = heartbeat_timeout
-    service = instanceha.InstanceHAService(mock_config)
+    service = instanceha.InstanceHAService(make_mock_config(HEARTBEAT_TIMEOUT=heartbeat_timeout))
     service.heartbeat_hosts_timestamp.clear()
     service.udp_ip = '127.0.0.1'
     service.heartbeat_hmac_keys = [_TEST_HMAC_KEY]
@@ -105,7 +103,7 @@ def _start_listener(service, port):
             lock=service.heartbeat_lock,
             timestamps=service.heartbeat_hosts_timestamp,
             stop_event=service.heartbeat_listener_stop_event,
-            cleanup_threshold=instanceha.HEARTBEAT_CLEANUP_THRESHOLD,
+            cleanup_threshold=instanceha.UDP_CLEANUP_THRESHOLD,
             cleanup_age_seconds=instanceha.HEARTBEAT_CLEANUP_AGE_SECONDS,
             resolve_hostname=lambda data, addr, label: instanceha._resolve_hostname_packet(data, addr, label, hmac_keys=hmac_keys),
             on_start=on_start,

--- a/test/instanceha/conftest.py
+++ b/test/instanceha/conftest.py
@@ -76,6 +76,52 @@ if _abs_path not in sys.path:
 
 import instanceha  # noqa: E402
 
+# Default config values matching ConfigManager._config_map defaults
+_CONFIG_DEFAULTS = {
+    'EVACUABLE_TAG': 'evacuable',
+    'DELTA': 30,
+    'POLL': 45,
+    'THRESHOLD': 50,
+    'WORKERS': 4,
+    'DELAY': 0,
+    'LOGLEVEL': 'INFO',
+    'SMART_EVACUATION': False,
+    'RESERVED_HOSTS': False,
+    'FORCE_RESERVED_HOST_EVACUATION': False,
+    'TAGGED_IMAGES': True,
+    'TAGGED_FLAVORS': True,
+    'TAGGED_AGGREGATES': True,
+    'LEAVE_DISABLED': False,
+    'FORCE_ENABLE': False,
+    'CHECK_KDUMP': False,
+    'KDUMP_TIMEOUT': 30,
+    'CHECK_HEARTBEAT': False,
+    'HEARTBEAT_TIMEOUT': 120,
+    'DISABLED': False,
+    'SSL_VERIFY': True,
+    'FENCING_TIMEOUT': 30,
+    'HASH_INTERVAL': 60,
+    'ORCHESTRATED_RESTART': False,
+    'SKIP_SERVERS_WITH_NAME': [],
+    'EVACUATION_RETRIES': 5,
+    'HEARTBEAT_CLIFF_THRESHOLD': 50,
+    'HEARTBEAT_CLIFF_MAX_CYCLES': 3,
+    'MAX_HOSTS_PER_CYCLE': 10,
+    'K8S_API_CHECK_INTERVAL': 15,
+}
+
+
+def make_mock_config(**overrides):
+    """Create a Mock config manager that returns real defaults for get_config_value.
+
+    Any keyword argument overrides the default for that key.
+    Keys not in _CONFIG_DEFAULTS or overrides fall through to Mock's default behavior.
+    """
+    values = {**_CONFIG_DEFAULTS, **overrides}
+    mock_config = MagicMock()
+    mock_config.get_config_value = MagicMock(side_effect=lambda key: values.get(key, MagicMock()))
+    return mock_config
+
 
 @contextmanager
 def patch_pipeline(conn=None, fence=True, disable=True,
@@ -87,7 +133,7 @@ def patch_pipeline(conn=None, fence=True, disable=True,
     """
     if reserved is None:
         reserved = instanceha.ReservedHostResult(success=True, hostname=None)
-    with patch('instanceha._get_nova_connection', return_value=conn) as m_conn, \
+    with patch('instanceha._establish_nova_connection', return_value=conn) as m_conn, \
          patch('instanceha._host_fence', return_value=fence) as m_fence, \
          patch('instanceha._host_disable', return_value=disable) as m_disable, \
          patch('instanceha._manage_reserved_hosts', return_value=reserved) as m_reserved, \

--- a/test/instanceha/functional_test.py
+++ b/test/instanceha/functional_test.py
@@ -537,7 +537,7 @@ class TestBasicEvacuation(BaseTestCase):
         failed_service = [s for s in services if s.host == 'compute-0' and s.state == 'down'][0]
 
         # Test evacuation process - mock ALL the functions that interact with external systems
-        with patch('instanceha._get_nova_connection', return_value=self.env.mock_nova) as mock_get_conn:
+        with patch('instanceha._establish_nova_connection', return_value=self.env.mock_nova) as mock_get_conn:
             with patch('instanceha._host_fence', return_value=True) as mock_fence:
                 with patch('instanceha._host_disable', return_value=True) as mock_disable:
                     with patch('instanceha._manage_reserved_hosts', return_value=instanceha.ReservedHostResult(success=True, hostname=None)) as mock_reserved:
@@ -833,7 +833,7 @@ class TestLargeScaleEvacuableAggregates(BaseTestCase):
                         f"Expected 20 evacuable failed computes, got {len(evacuable_computes)}")
 
         # Step 8: Test reserved host management
-        with patch('instanceha._get_nova_connection', return_value=self.env.mock_nova):
+        with patch('instanceha._establish_nova_connection', return_value=self.env.mock_nova):
             with patch('instanceha._host_fence', return_value=True):
                 with patch('instanceha._host_disable', return_value=True):
                     with patch('instanceha._host_evacuate', return_value=True):
@@ -858,7 +858,7 @@ class TestLargeScaleEvacuableAggregates(BaseTestCase):
         # Step 10: Test full evacuation process with mocked external calls
         evacuation_results = []
 
-        with patch('instanceha._get_nova_connection', return_value=self.env.mock_nova):
+        with patch('instanceha._establish_nova_connection', return_value=self.env.mock_nova):
             with patch('instanceha._host_fence', return_value=True) as mock_fence:
                 with patch('instanceha._host_disable', return_value=True) as mock_disable:
                     with patch('instanceha._host_evacuate', return_value=True) as mock_evacuate:
@@ -975,7 +975,7 @@ class TestLargeScaleEvacuableAggregates(BaseTestCase):
         reserved_services = [s for s in services if 'reserved' in str(s.disabled_reason)]
 
         # Test that reserved host management can find matching aggregate
-        with patch('instanceha._get_nova_connection', return_value=self.env.mock_nova):
+        with patch('instanceha._establish_nova_connection', return_value=self.env.mock_nova):
             with patch('instanceha._enable_matching_reserved_host', return_value=instanceha.ReservedHostResult(success=True, hostname='reserved-agg1-01')) as mock_enable:
                 result = instanceha._manage_reserved_hosts(
                     self.env.mock_nova, failed_service, reserved_services, self.env.service
@@ -1024,7 +1024,7 @@ class TestLargeScaleEvacuableAggregates(BaseTestCase):
 
         # Test that reserved host management can find matching zone
         # Patch get_config_value to return False for TAGGED_AGGREGATES to force zone-based matching
-        with patch('instanceha._get_nova_connection', return_value=self.env.mock_nova):
+        with patch('instanceha._establish_nova_connection', return_value=self.env.mock_nova):
             original_get_config = self.env.service.config.get_config_value
             def mock_get_config(key):
                 if key == 'TAGGED_AGGREGATES':
@@ -1090,7 +1090,7 @@ class TestLargeScaleEvacuableAggregates(BaseTestCase):
         self.assertEqual(len(reserved_services), 2, "Should have 2 reserved hosts")
 
         # Test without mocking _enable_matching_reserved_host
-        with patch('instanceha._get_nova_connection', return_value=self.env.mock_nova):
+        with patch('instanceha._establish_nova_connection', return_value=self.env.mock_nova):
             result = instanceha._enable_matching_reserved_host(
                 self.env.mock_nova, failed_service, reserved_services,
                 self.env.service, instanceha.MatchType.AGGREGATE
@@ -1139,7 +1139,7 @@ class TestLargeScaleEvacuableAggregates(BaseTestCase):
         reserved_services = [s for s in services if 'reserved' in str(s.disabled_reason)]
 
         # Test without mocking
-        with patch('instanceha._get_nova_connection', return_value=self.env.mock_nova):
+        with patch('instanceha._establish_nova_connection', return_value=self.env.mock_nova):
             result = instanceha._enable_matching_reserved_host(
                 self.env.mock_nova, failed_service, reserved_services,
                 self.env.service, instanceha.MatchType.AGGREGATE
@@ -1194,7 +1194,7 @@ class TestLargeScaleEvacuableAggregates(BaseTestCase):
         reserved_services = [s for s in services if 'reserved' in str(s.disabled_reason)]
 
         # Test the full flow: manage reserved hosts + evacuation
-        with patch('instanceha._get_nova_connection', return_value=self.env.mock_nova):
+        with patch('instanceha._establish_nova_connection', return_value=self.env.mock_nova):
             # Manage reserved hosts (should enable the reserved host and return its name)
             result = instanceha._manage_reserved_hosts(
                 self.env.mock_nova, failed_service, reserved_services, self.env.service
@@ -1275,7 +1275,7 @@ class TestLargeScaleEvacuableAggregates(BaseTestCase):
         failed_service = [s for s in services if s.host == failed_host][0]
         reserved_services = [s for s in services if 'reserved' in str(s.disabled_reason)]
 
-        with patch('instanceha._get_nova_connection', return_value=self.env.mock_nova):
+        with patch('instanceha._establish_nova_connection', return_value=self.env.mock_nova):
             # Manage reserved hosts
             result = instanceha._manage_reserved_hosts(
                 self.env.mock_nova, failed_service, reserved_services, self.env.service
@@ -1336,7 +1336,7 @@ class TestLargeScaleEvacuableAggregates(BaseTestCase):
         failed_service = [s for s in services if s.host == failed_host][0]
         reserved_services = []  # No reserved hosts
 
-        with patch('instanceha._get_nova_connection', return_value=self.env.mock_nova):
+        with patch('instanceha._establish_nova_connection', return_value=self.env.mock_nova):
             # Manage reserved hosts (should return success=True, target_host=None)
             result = instanceha._manage_reserved_hosts(
                 self.env.mock_nova, failed_service, reserved_services, self.env.service
@@ -1400,7 +1400,7 @@ class TestLargeScaleEvacuableAggregates(BaseTestCase):
         reserved_services = [s for s in services if 'reserved' in str(s.disabled_reason)]
 
         # Mock fencing and recovery since we're testing evacuation specifically
-        with patch('instanceha._get_nova_connection', return_value=self.env.mock_nova):
+        with patch('instanceha._establish_nova_connection', return_value=self.env.mock_nova):
             with patch('instanceha._host_fence', return_value=True):
                 with patch('instanceha._post_evacuation_recovery', return_value=True):
                     # Spy on evacuate to verify forced targeting
@@ -1478,7 +1478,7 @@ class TestLargeScaleEvacuableAggregates(BaseTestCase):
         migration_mock.status = 'completed'
         migration_mock.dest_host = reserved_host
 
-        with patch('instanceha._get_nova_connection', return_value=self.env.mock_nova):
+        with patch('instanceha._establish_nova_connection', return_value=self.env.mock_nova):
             # Setup migration list to return completed migration
             self.env.mock_nova.migrations.list = Mock(return_value=[migration_mock])
 
@@ -1579,7 +1579,7 @@ class TestLargeScaleEvacuableAggregates(BaseTestCase):
             # THRESHOLD PROTECTION ACTIVATED: {failure_percentage}% > {threshold}%
 
             # Verify no evacuation functions would be called
-            with patch('instanceha._get_nova_connection', return_value=self.env.mock_nova):
+            with patch('instanceha._establish_nova_connection', return_value=self.env.mock_nova):
                 with patch('instanceha._host_fence', return_value=True) as mock_fence:
                     with patch('instanceha._host_disable', return_value=True) as mock_disable:
                         with patch('instanceha._host_evacuate', return_value=True) as mock_evacuate:
@@ -1703,7 +1703,7 @@ class TestResumeEvacuation(BaseTestCase):
                         f"Expected 10 VMs to resume evacuation (2 hosts × 5 VMs), got {total_vms_to_resume}")
 
         # Step 5: Test the resume evacuation process by calling the real process_service
-        with patch('instanceha._get_nova_connection', return_value=self.env.mock_nova):
+        with patch('instanceha._establish_nova_connection', return_value=self.env.mock_nova):
             with patch('instanceha._host_fence', return_value=True) as mock_fence:
                 with patch('instanceha._host_disable', return_value=True) as mock_disable:
                     with patch('instanceha._host_evacuate', return_value=True) as mock_evacuate:
@@ -2419,7 +2419,7 @@ class TestFencingRaceCondition(BaseTestCase):
         filtered_hosts_before = [svc.host for svc in compute_nodes]
 
         # Call _process_stale_services (this should filter out the host being processed)
-        with patch('instanceha._get_nova_connection', return_value=mock_conn), \
+        with patch('instanceha._establish_nova_connection', return_value=mock_conn), \
              patch('instanceha.process_service', return_value=True) as mock_process:
             instanceha._process_stale_services(mock_conn, self.env.service,
                                              self.env.mock_nova.services.list(),
@@ -2449,7 +2449,7 @@ class TestFencingRaceCondition(BaseTestCase):
         failed_service = Mock()
         failed_service.host = 'compute-0.example.com'
 
-        with patch('instanceha._get_nova_connection', return_value=Mock()), \
+        with patch('instanceha._establish_nova_connection', return_value=Mock()), \
              patch('instanceha._execute_step', return_value=True):
 
             # Call process_service
@@ -2485,7 +2485,7 @@ class TestFencingRaceCondition(BaseTestCase):
         mock_conn = Mock()
 
         # Call _process_stale_services which should trigger cleanup
-        with patch('instanceha._get_nova_connection', return_value=mock_conn), \
+        with patch('instanceha._establish_nova_connection', return_value=mock_conn), \
              patch('instanceha.process_service', return_value=True):
             instanceha._process_stale_services(mock_conn, self.env.service,
                                              self.env.mock_nova.services.list(),
@@ -2520,9 +2520,10 @@ class TestFencingRaceCondition(BaseTestCase):
         # Mock connection
         from unittest.mock import Mock, patch
         mock_conn = Mock()
+        mock_conn.services.list.return_value = []
 
         # Call _process_stale_services
-        with patch('instanceha._get_nova_connection', return_value=mock_conn), \
+        with patch('instanceha._establish_nova_connection', return_value=mock_conn), \
              patch('instanceha.process_service', return_value=True) as mock_process:
             instanceha._process_stale_services(mock_conn, self.env.service,
                                              self.env.mock_nova.services.list(),

--- a/test/instanceha/integration_test.py
+++ b/test/instanceha/integration_test.py
@@ -26,7 +26,7 @@ import concurrent.futures
 # Suppress warnings during testing
 logging.getLogger().setLevel(logging.CRITICAL)
 
-import conftest  # noqa: F401
+from conftest import make_mock_config  # noqa: F401
 import instanceha
 
 
@@ -395,21 +395,11 @@ class TestEvacuationWorkflow(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         self.mock_env = MockOpenStackEnvironment()
-        self.mock_config = Mock()
-        # Set up get_config_value with side_effect for all config keys
-        config_values = {
-            'EVACUABLE_TAG': 'evacuable',
-            'TAGGED_IMAGES': False,
-            'TAGGED_FLAVORS': False,
-            'TAGGED_AGGREGATES': False,
-            'RESERVED_HOSTS': False,
-            'THRESHOLD': 50,
-            'DISABLED': False,
-            'CHECK_KDUMP': False,
-            'POLL': 30,
-            'FENCING_TIMEOUT': 30
-        }
-        self.mock_config.get_config_value = Mock(side_effect=lambda key: config_values.get(key, 30))
+        self.mock_config = make_mock_config(
+            TAGGED_IMAGES=False, TAGGED_FLAVORS=False,
+            TAGGED_AGGREGATES=False, RESERVED_HOSTS=False,
+            POLL=30,
+        )
 
     def test_complete_evacuation_workflow(self):
         """Test complete evacuation workflow from start to finish."""
@@ -472,20 +462,11 @@ class TestEvacuationWorkflow(unittest.TestCase):
 
     def test_evacuation_with_flavor_tagging(self):
         """Test evacuation with flavor-based tagging."""
-        # Update the config dictionary to enable flavor tagging
-        config_values = {
-            'EVACUABLE_TAG': 'evacuable',
-            'TAGGED_IMAGES': False,
-            'TAGGED_FLAVORS': True,  # Enable flavor tagging
-            'TAGGED_AGGREGATES': False,
-            'RESERVED_HOSTS': False,
-            'THRESHOLD': 50,
-            'DISABLED': False,
-            'CHECK_KDUMP': False,
-            'POLL': 30,
-            'FENCING_TIMEOUT': 30
-        }
-        self.mock_config.get_config_value = Mock(side_effect=lambda key: config_values.get(key, 30))
+        self.mock_config = make_mock_config(
+            TAGGED_IMAGES=False, TAGGED_FLAVORS=True,
+            TAGGED_AGGREGATES=False, RESERVED_HOSTS=False,
+            POLL=30,
+        )
 
         # Setup host with mixed servers
         failed_host = 'compute-01'
@@ -511,20 +492,11 @@ class TestEvacuationWorkflow(unittest.TestCase):
 
     def test_evacuation_with_aggregate_filtering(self):
         """Test evacuation with aggregate-based filtering."""
-        # Update the config dictionary to enable aggregate tagging
-        config_values = {
-            'EVACUABLE_TAG': 'evacuable',
-            'TAGGED_IMAGES': False,
-            'TAGGED_FLAVORS': False,
-            'TAGGED_AGGREGATES': True,  # Enable aggregate tagging
-            'RESERVED_HOSTS': False,
-            'THRESHOLD': 50,
-            'DISABLED': False,
-            'CHECK_KDUMP': False,
-            'POLL': 30,
-            'FENCING_TIMEOUT': 30
-        }
-        self.mock_config.get_config_value = Mock(side_effect=lambda key: config_values.get(key, 30))
+        self.mock_config = make_mock_config(
+            TAGGED_IMAGES=False, TAGGED_FLAVORS=False,
+            TAGGED_AGGREGATES=True, RESERVED_HOSTS=False,
+            POLL=30,
+        )
 
         # Setup aggregates
         evacuable_agg = self.mock_env.add_aggregate(
@@ -562,14 +534,7 @@ class TestReenablingWorkflow(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         self.mock_env = MockOpenStackEnvironment()
-        self.mock_config = Mock()
-        # Set up get_config_value with default values
-        config_values = {
-            'FORCE_ENABLE': False,
-            'LEAVE_DISABLED': False,
-            'FENCING_TIMEOUT': 30
-        }
-        self.mock_config.get_config_value = Mock(side_effect=lambda key: config_values.get(key, 30))
+        self.mock_config = make_mock_config()
 
     def test_reenable_services_with_completed_migrations(self):
         """Test re-enabling services with completed migrations."""
@@ -614,13 +579,7 @@ class TestReenablingWorkflow(unittest.TestCase):
 
     def test_force_reenable_services(self):
         """Test force re-enabling of services."""
-        # Update config to enable FORCE_ENABLE
-        config_values = {
-            'FORCE_ENABLE': True,
-            'LEAVE_DISABLED': False,
-            'FENCING_TIMEOUT': 30
-        }
-        self.mock_config.get_config_value = Mock(side_effect=lambda key: config_values.get(key, 30))
+        self.mock_config = make_mock_config(FORCE_ENABLE=True)
 
         service_to_reenable = self.mock_env.add_compute_service(
             'compute-01', state='up', status='enabled', forced_down=True
@@ -640,12 +599,7 @@ class TestReenablingWorkflow(unittest.TestCase):
         Test FORCE_ENABLE + LEAVE_DISABLED interaction.
         LEAVE_DISABLED should take precedence and filter out instanceha-evacuated services.
         """
-        config_values = {
-            'FORCE_ENABLE': True,
-            'LEAVE_DISABLED': True,
-            'FENCING_TIMEOUT': 30
-        }
-        self.mock_config.get_config_value = Mock(side_effect=lambda key: config_values.get(key, 30))
+        self.mock_config = make_mock_config(FORCE_ENABLE=True, LEAVE_DISABLED=True)
 
         instanceha_evacuated = self.mock_env.add_compute_service(
             'compute-01', state='up', status='disabled', forced_down=False,
@@ -705,22 +659,7 @@ class TestReenablingWorkflow(unittest.TestCase):
 
     def test_disabled_service_reenabled_when_up(self):
         """Test that disabled services ARE re-enabled when they come back up."""
-        # Enable FORCE_ENABLE to skip migration checking
-        config_values = {
-            'EVACUABLE_TAG': 'evacuable',
-            'TAGGED_IMAGES': False,
-            'TAGGED_FLAVORS': False,
-            'TAGGED_AGGREGATES': False,
-            'RESERVED_HOSTS': False,
-            'THRESHOLD': 50,
-            'DISABLED': False,
-            'CHECK_KDUMP': False,
-            'POLL': 30,
-            'FENCING_TIMEOUT': 30,
-            'FORCE_ENABLE': True,  # Skip migration checks
-            'LEAVE_DISABLED': False  # Allow re-enabling
-        }
-        self.mock_config.get_config_value = Mock(side_effect=lambda key: config_values.get(key, 30))
+        self.mock_config = make_mock_config(FORCE_ENABLE=True)
 
         # Service is disabled (evacuation complete) and has come back up
         service_disabled_up = self.mock_env.add_compute_service(
@@ -760,15 +699,7 @@ class TestPerformanceAndScaling(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         self.mock_env = MockOpenStackEnvironment()
-        self.mock_config = Mock()
-        self.mock_config.get_evacuable_tag.return_value = 'evacuable'
-        self.mock_config.is_tagged_images_enabled.return_value = False
-        self.mock_config.is_tagged_flavors_enabled.return_value = False
-        self.mock_config.is_tagged_aggregates_enabled.return_value = False
-        self.mock_config.is_reserved_hosts_enabled.return_value = False
-        self.mock_config.get_threshold.return_value = 30  # Lower threshold to allow processing
-        self.mock_config.is_disabled.return_value = False
-        self.mock_config.get_config_value.return_value = 30  # Default FENCING_TIMEOUT
+        self.mock_config = make_mock_config(THRESHOLD=30)
 
     def test_large_scale_evacuation_performance(self):
         """Test evacuation performance with large number of hosts."""
@@ -868,15 +799,7 @@ class TestErrorHandlingAndRecovery(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         self.mock_env = MockOpenStackEnvironment()
-        self.mock_config = Mock()
-        self.mock_config.get_evacuable_tag.return_value = 'evacuable'
-        self.mock_config.is_tagged_images_enabled.return_value = False
-        self.mock_config.is_tagged_flavors_enabled.return_value = False
-        self.mock_config.is_tagged_aggregates_enabled.return_value = False
-        self.mock_config.is_reserved_hosts_enabled.return_value = False
-        self.mock_config.get_threshold.return_value = 50
-        self.mock_config.is_disabled.return_value = False
-        self.mock_config.get_config_value.return_value = 30  # Default FENCING_TIMEOUT
+        self.mock_config = make_mock_config()
 
     def test_nova_api_failure_handling(self):
         """Test handling of Nova API failures."""

--- a/test/instanceha/test_config_features.py
+++ b/test/instanceha/test_config_features.py
@@ -10,7 +10,7 @@ import unittest
 from unittest.mock import Mock, patch, MagicMock
 from datetime import datetime, timedelta
 
-import conftest  # noqa: F401
+from conftest import make_mock_config  # noqa: F401
 import instanceha
 
 
@@ -118,6 +118,7 @@ class TestDisabledConfig(unittest.TestCase):
 
         services = [mock_failed_service, Mock(status='enabled', forced_down=False), Mock(status='enabled', forced_down=False)]
         compute_nodes = [mock_failed_service]
+        mock_conn.services.list.return_value = []
 
         with patch('instanceha._filter_processing_hosts', return_value=(compute_nodes, [], set(['test-host']), 0)):
             with patch('instanceha._prepare_evacuation_resources', return_value=(compute_nodes, [], [], [])):
@@ -141,10 +142,7 @@ class TestForceEnableConfig(unittest.TestCase):
     def test_force_enable_true_bypasses_migration_check(self):
         """Test that FORCE_ENABLE=True bypasses migration completion check."""
         mock_conn = Mock()
-        mock_config = Mock()
-        mock_config.get_config_value = Mock(side_effect=lambda key: {'LEAVE_DISABLED': False, 'FORCE_ENABLE': True}.get(key, False))
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config(FORCE_ENABLE=True))
 
         mock_svc = Mock()
         mock_svc.host = 'test-host.example.com'
@@ -165,10 +163,7 @@ class TestForceEnableConfig(unittest.TestCase):
     def test_force_enable_false_waits_for_migrations(self):
         """Test that FORCE_ENABLE=False waits for migration completion."""
         mock_conn = Mock()
-        mock_config = Mock()
-        mock_config.get_config_value = Mock(side_effect=lambda key: {'LEAVE_DISABLED': False, 'FORCE_ENABLE': False}.get(key, False))
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
 
         mock_svc = Mock()
         mock_svc.host = 'test-host.example.com'
@@ -189,10 +184,7 @@ class TestForceEnableConfig(unittest.TestCase):
     def test_force_enable_still_respects_kdump_delay(self):
         """Test that FORCE_ENABLE=True still respects kdump re-enable delay."""
         mock_conn = Mock()
-        mock_config = Mock()
-        mock_config.get_config_value = Mock(side_effect=lambda key: {'LEAVE_DISABLED': False, 'FORCE_ENABLE': True}.get(key, False))
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config(FORCE_ENABLE=True))
         service.kdump_hosts_timestamp['test-host'] = __import__('time').time() - 30  # 30s ago (< 60s)
 
         mock_svc = Mock()
@@ -209,10 +201,7 @@ class TestForceEnableConfig(unittest.TestCase):
     def test_force_enable_with_completed_migrations(self):
         """Test that FORCE_ENABLE=True works normally when migrations are complete."""
         mock_conn = Mock()
-        mock_config = Mock()
-        mock_config.get_config_value = Mock(side_effect=lambda key: {'LEAVE_DISABLED': False, 'FORCE_ENABLE': True}.get(key, False))
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config(FORCE_ENABLE=True))
 
         mock_svc = Mock()
         mock_svc.host = 'test-host.example.com'
@@ -232,10 +221,7 @@ class TestForceEnableConfig(unittest.TestCase):
     def test_force_enable_handles_forced_down_correctly(self):
         """Test that FORCE_ENABLE correctly handles forced_down hosts in two stages."""
         mock_conn = Mock()
-        mock_config = Mock()
-        mock_config.get_config_value = Mock(side_effect=lambda key: {'LEAVE_DISABLED': False, 'FORCE_ENABLE': True}.get(key, False))
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config(FORCE_ENABLE=True))
 
         # Service is forced_down and disabled, but state is still down
         mock_svc = Mock()
@@ -253,10 +239,7 @@ class TestForceEnableConfig(unittest.TestCase):
     def test_force_enable_respects_service_state_down(self):
         """Test that FORCE_ENABLE still checks service state before enabling."""
         mock_conn = Mock()
-        mock_config = Mock()
-        mock_config.get_config_value = Mock(side_effect=lambda key: {'LEAVE_DISABLED': False, 'FORCE_ENABLE': True}.get(key, False))
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config(FORCE_ENABLE=True))
 
         # Service is disabled but still down (not ready for enable)
         mock_svc = Mock()
@@ -274,10 +257,7 @@ class TestForceEnableConfig(unittest.TestCase):
     def test_force_enable_with_error_migrations(self):
         """Test that FORCE_ENABLE ignores error state migrations."""
         mock_conn = Mock()
-        mock_config = Mock()
-        mock_config.get_config_value = Mock(side_effect=lambda key: {'LEAVE_DISABLED': False, 'FORCE_ENABLE': False}.get(key, False))
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
 
         mock_svc = Mock()
         mock_svc.host = 'test-host.example.com'
@@ -302,10 +282,7 @@ class TestForceEnableConfig(unittest.TestCase):
     def test_migration_query_parameters(self):
         """Test that migration query uses correct parameters."""
         mock_conn = Mock()
-        mock_config = Mock()
-        mock_config.get_config_value = Mock(side_effect=lambda key: {'LEAVE_DISABLED': False, 'FORCE_ENABLE': False}.get(key, False))
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
 
         mock_svc = Mock()
         mock_svc.host = 'test-host.example.com'
@@ -336,10 +313,7 @@ class TestLeaveDisabledConfig(unittest.TestCase):
     def test_leave_disabled_true_filters_instanceha_services(self):
         """Test that LEAVE_DISABLED=True filters instanceha-evacuated services from re-enable."""
         mock_conn = Mock()
-        mock_config = Mock()
-        mock_config.get_config_value = Mock(side_effect=lambda key: {'LEAVE_DISABLED': True}.get(key, False))
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config(LEAVE_DISABLED=True))
 
         # Service evacuated by instanceha
         instanceha_svc = Mock()
@@ -369,10 +343,7 @@ class TestLeaveDisabledConfig(unittest.TestCase):
     def test_leave_disabled_false_enables_all_services(self):
         """Test that LEAVE_DISABLED=False enables all services including instanceha-evacuated."""
         mock_conn = Mock()
-        mock_config = Mock()
-        mock_config.get_config_value = Mock(side_effect=lambda key: {'LEAVE_DISABLED': False}.get(key, False))
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
 
         # Service evacuated by instanceha
         instanceha_svc = Mock()
@@ -399,9 +370,7 @@ class TestTaggedAggregatesConfig(unittest.TestCase):
         mock_conn = Mock()
 
         # Create real InstanceHAService instance for proper _is_resource_evacuable behavior
-        mock_config = Mock()
-        mock_config.get_config_value = Mock(side_effect=lambda key: {'EVACUABLE_TAG': 'evacuable'}.get(key, 'evacuable'))
-        mock_service = instanceha.InstanceHAService(mock_config)
+        mock_service = instanceha.InstanceHAService(make_mock_config())
 
         # Create aggregates - one evacuable, one not
         evacuable_agg = Mock()
@@ -481,14 +450,7 @@ class TestDelayConfig(unittest.TestCase):
         """Test that DELAY=0 does not delay evacuation."""
         import time
         mock_conn = Mock()
-        mock_config = Mock()
-        config_values = {
-            'DELAY': 0,
-            'SMART_EVACUATION': False
-        }
-        mock_config.get_config_value = Mock(side_effect=lambda key: config_values.get(key, False))
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
 
         # Create a mock server to evacuate
         mock_server = Mock()
@@ -511,14 +473,7 @@ class TestDelayConfig(unittest.TestCase):
     def test_delay_non_zero_delays_evacuation(self):
         """Test that DELAY>0 delays evacuation by specified seconds."""
         mock_conn = Mock()
-        mock_config = Mock()
-        config_values = {
-            'DELAY': 5,  # 5 second delay
-            'SMART_EVACUATION': False
-        }
-        mock_config.get_config_value = Mock(side_effect=lambda key: config_values.get(key, False))
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config(DELAY=5))
 
         # Create a mock server to evacuate
         mock_server = Mock()
@@ -539,14 +494,7 @@ class TestDelayConfig(unittest.TestCase):
     def test_delay_with_smart_evacuation(self):
         """Test that DELAY works with SMART_EVACUATION enabled."""
         mock_conn = Mock()
-        mock_config = Mock()
-        config_values = {
-            'DELAY': 3,
-            'SMART_EVACUATION': True
-        }
-        mock_config.get_config_value = Mock(side_effect=lambda key: config_values.get(key, False))
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config(DELAY=3, SMART_EVACUATION=True))
 
         # Create a mock server to evacuate
         mock_server = Mock()
@@ -566,18 +514,12 @@ class TestDelayConfig(unittest.TestCase):
 
     def test_delay_boundary_values(self):
         """Test DELAY boundary values (min=0, max=300)."""
-        mock_config = Mock()
-
         # Test minimum value
-        config_values = {'DELAY': 0}
-        mock_config.get_config_value = Mock(side_effect=lambda key: config_values.get(key, 0))
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config(DELAY=0))
         self.assertEqual(service.config.get_config_value('DELAY'), 0)
 
         # Test maximum value
-        config_values = {'DELAY': 300}
-        mock_config.get_config_value = Mock(side_effect=lambda key: config_values.get(key, 0))
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config(DELAY=300))
         self.assertEqual(service.config.get_config_value('DELAY'), 300)
 
 
@@ -586,11 +528,7 @@ class TestHashIntervalConfig(unittest.TestCase):
 
     def test_hash_interval_default_value(self):
         """Test that HASH_INTERVAL defaults to 60 seconds."""
-        mock_config = Mock()
-        # Simulate default behavior
-        mock_config.get_config_value = Mock(return_value=60)
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
         hash_interval = service.config.get_config_value('HASH_INTERVAL')
 
         self.assertEqual(hash_interval, 60)
@@ -598,11 +536,7 @@ class TestHashIntervalConfig(unittest.TestCase):
     def test_hash_interval_prevents_frequent_updates(self):
         """Test that HASH_INTERVAL prevents hash updates too frequently."""
         import time
-        mock_config = Mock()
-        config_values = {'HASH_INTERVAL': 60}
-        mock_config.get_config_value = Mock(side_effect=lambda key: config_values.get(key, 60))
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
 
         # First hash update should succeed
         service.update_health_hash()
@@ -618,11 +552,7 @@ class TestHashIntervalConfig(unittest.TestCase):
 
     def test_hash_interval_allows_update_after_interval(self):
         """Test that hash updates after HASH_INTERVAL has elapsed."""
-        mock_config = Mock()
-        config_values = {'HASH_INTERVAL': 1}  # 1 second for testing
-        mock_config.get_config_value = Mock(side_effect=lambda key: config_values.get(key, 1))
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config(HASH_INTERVAL=1))
 
         # First hash update
         service.update_health_hash()
@@ -643,11 +573,7 @@ class TestHashIntervalConfig(unittest.TestCase):
 
     def test_hash_interval_custom_override(self):
         """Test that update_health_hash can override HASH_INTERVAL."""
-        mock_config = Mock()
-        config_values = {'HASH_INTERVAL': 60}
-        mock_config.get_config_value = Mock(side_effect=lambda key: config_values.get(key, 60))
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
 
         # First update with default interval (60s)
         service.update_health_hash()
@@ -664,27 +590,17 @@ class TestHashIntervalConfig(unittest.TestCase):
 
     def test_hash_interval_boundary_values(self):
         """Test HASH_INTERVAL boundary values (min=30, max=300)."""
-        mock_config = Mock()
-
         # Test minimum value
-        config_values = {'HASH_INTERVAL': 30}
-        mock_config.get_config_value = Mock(side_effect=lambda key: config_values.get(key, 30))
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config(HASH_INTERVAL=30))
         self.assertEqual(service.config.get_config_value('HASH_INTERVAL'), 30)
 
         # Test maximum value
-        config_values = {'HASH_INTERVAL': 300}
-        mock_config.get_config_value = Mock(side_effect=lambda key: config_values.get(key, 30))
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config(HASH_INTERVAL=300))
         self.assertEqual(service.config.get_config_value('HASH_INTERVAL'), 300)
 
     def test_hash_update_always_succeeds(self):
         """Test that hash update always succeeds (SHA-256 of timestamp is always unique)."""
-        mock_config = Mock()
-        config_values = {'HASH_INTERVAL': 0}  # Always allow updates
-        mock_config.get_config_value = Mock(side_effect=lambda key: config_values.get(key, 0))
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config(HASH_INTERVAL=0))
 
         # First update
         service.update_health_hash()
@@ -704,40 +620,47 @@ class TestCriticalServicesCheck(unittest.TestCase):
     def test_all_schedulers_down(self):
         """Test that check fails when all schedulers are down."""
         mock_conn = Mock()
-        services = [
+        mock_conn.services.list.return_value = [
             Mock(binary='nova-scheduler', state='down', host='controller-1'),
             Mock(binary='nova-scheduler', state='down', host='controller-2'),
-            Mock(binary='nova-compute', state='down', host='compute-1')
         ]
-        compute_nodes = [services[2]]
 
-        can_evacuate, error_msg = instanceha._check_critical_services(services)
+        can_evacuate, error_msg = instanceha._check_critical_services(mock_conn)
 
+        mock_conn.services.list.assert_called_once_with(binary="nova-scheduler")
         self.assertFalse(can_evacuate)
         self.assertIn('nova-scheduler', error_msg)
 
     def test_at_least_one_scheduler_up(self):
         """Test that check passes when at least one scheduler is up."""
-        services = [
+        mock_conn = Mock()
+        mock_conn.services.list.return_value = [
             Mock(binary='nova-scheduler', state='down', host='controller-1'),
             Mock(binary='nova-scheduler', state='up', host='controller-2'),
-            Mock(binary='nova-compute', state='down', host='compute-1')
         ]
 
-        can_evacuate, error_msg = instanceha._check_critical_services(services)
+        can_evacuate, error_msg = instanceha._check_critical_services(mock_conn)
 
         self.assertTrue(can_evacuate)
         self.assertEqual(error_msg, "")
 
     def test_no_schedulers_defined(self):
         """Test when no schedulers are in services list."""
-        services = [
-            Mock(binary='nova-compute', state='down', host='compute-1')
-        ]
+        mock_conn = Mock()
+        mock_conn.services.list.return_value = []
 
-        can_evacuate, error_msg = instanceha._check_critical_services(services)
+        can_evacuate, error_msg = instanceha._check_critical_services(mock_conn)
 
-        # Should allow evacuation if no schedulers are in the list
+        self.assertTrue(can_evacuate)
+        self.assertEqual(error_msg, "")
+
+    def test_query_failure_allows_evacuation(self):
+        """Test that Nova API failure is fail-open (allow evacuation)."""
+        mock_conn = Mock()
+        mock_conn.services.list.side_effect = Exception("connection refused")
+
+        can_evacuate, error_msg = instanceha._check_critical_services(mock_conn)
+
         self.assertTrue(can_evacuate)
         self.assertEqual(error_msg, "")
 

--- a/test/instanceha/test_coverage_gaps.py
+++ b/test/instanceha/test_coverage_gaps.py
@@ -964,6 +964,7 @@ class TestProcessStaleServicesSafety(unittest.TestCase):
     def test_no_evacuable_servers_after_filtering(self):
         service = self._make_service()
         conn = Mock()
+        conn.services.list.return_value = []
         svc1 = Mock(host='host-1', status='enabled', forced_down=False)
         service.get_hosts_with_servers_cached.return_value = {}
         service.filter_hosts_with_servers.return_value = []
@@ -1458,6 +1459,551 @@ class TestTraditionalModeWarning(unittest.TestCase):
             warning_calls = [c for c in mock_logging.warning.call_args_list
                            if 'Traditional evacuation mode' in str(c)]
             self.assertEqual(len(warning_calls), 0, "Should not warn when smart is enabled")
+
+
+# ============================================================================
+# _handle_poll_failure tests (M5)
+# ============================================================================
+
+class TestHandlePollFailure(unittest.TestCase):
+    """Tests for _handle_poll_failure backoff and readiness behavior."""
+
+    def _make_service(self):
+        svc = Mock()
+        svc.ready = True
+        svc.shutdown_event = Mock()
+        svc.shutdown_event.wait = Mock()
+        return svc
+
+    def test_increments_consecutive_failures(self):
+        service = self._make_service()
+        result = instanceha._handle_poll_failure(service, 0, 5, "Poll failed", Exception("err"))
+        self.assertEqual(result, 1)
+
+    def test_returns_incremented_count(self):
+        service = self._make_service()
+        result = instanceha._handle_poll_failure(service, 4, 5, "Poll failed", Exception("err"))
+        self.assertEqual(result, 5)
+
+    def test_deactivates_readiness_at_threshold(self):
+        service = self._make_service()
+        service.ready = True
+        instanceha._handle_poll_failure(
+            service, instanceha.MAX_CONSECUTIVE_FAILURES_READY - 1, 5, "Poll failed", Exception("err"))
+        self.assertFalse(service.ready)
+
+    def test_does_not_deactivate_readiness_below_threshold(self):
+        service = self._make_service()
+        service.ready = True
+        instanceha._handle_poll_failure(service, 0, 5, "Poll failed", Exception("err"))
+        self.assertTrue(service.ready)
+
+    def test_does_not_reactivate_readiness(self):
+        service = self._make_service()
+        service.ready = False
+        instanceha._handle_poll_failure(service, 0, 5, "Poll failed", Exception("err"))
+        self.assertFalse(service.ready)
+
+    def test_backoff_is_exponential(self):
+        service = self._make_service()
+        instanceha._handle_poll_failure(service, 1, 10, "Poll failed", Exception("err"))
+        wait_call = service.shutdown_event.wait.call_args[0][0]
+        # consecutive_failures becomes 2, so backoff = min(10 * 2^2, 300) = 40
+        self.assertEqual(wait_call, 40)
+
+    def test_backoff_capped_at_max(self):
+        service = self._make_service()
+        instanceha._handle_poll_failure(service, 20, 60, "Poll failed", Exception("err"))
+        wait_call = service.shutdown_event.wait.call_args[0][0]
+        self.assertLessEqual(wait_call, instanceha.MAX_NOVA_BACKOFF_SECONDS)
+
+    def test_uses_interruptible_wait(self):
+        service = self._make_service()
+        instanceha._handle_poll_failure(service, 0, 5, "Poll failed", Exception("err"))
+        service.shutdown_event.wait.assert_called_once()
+
+
+# ============================================================================
+# _retry_with_backoff tests (M6)
+# ============================================================================
+
+class TestRetryWithBackoff(unittest.TestCase):
+    """Tests for _retry_with_backoff retry logic."""
+
+    @patch('instanceha._interruptible_sleep')
+    def test_returns_on_first_success(self, mock_sleep):
+        result = instanceha._retry_with_backoff(lambda: 42, 3, "test")
+        self.assertEqual(result, 42)
+        mock_sleep.assert_not_called()
+
+    @patch('instanceha._interruptible_sleep')
+    def test_retries_on_failure_then_succeeds(self, mock_sleep):
+        attempts = [0]
+        def flaky():
+            attempts[0] += 1
+            if attempts[0] < 3:
+                raise RuntimeError("fail")
+            return "ok"
+        result = instanceha._retry_with_backoff(flaky, 3, "test")
+        self.assertEqual(result, "ok")
+        self.assertEqual(mock_sleep.call_count, 2)
+
+    @patch('instanceha._interruptible_sleep')
+    def test_raises_after_all_retries_exhausted(self, mock_sleep):
+        with self.assertRaises(RuntimeError):
+            instanceha._retry_with_backoff(lambda: (_ for _ in ()).throw(RuntimeError("fail")), 3, "test")
+        self.assertEqual(mock_sleep.call_count, 2)
+
+    @patch('instanceha._interruptible_sleep')
+    def test_delay_increases_linearly(self, mock_sleep):
+        calls = [0]
+        def always_fail():
+            calls[0] += 1
+            raise RuntimeError("fail")
+
+        with self.assertRaises(RuntimeError):
+            instanceha._retry_with_backoff(always_fail, 3, "test", delay=2)
+
+        delays = [c[0][1] for c in mock_sleep.call_args_list]
+        self.assertEqual(delays, [2, 4])  # delay*(attempt+1): 2*1, 2*2
+
+    @patch('instanceha._interruptible_sleep')
+    def test_single_attempt_no_retry(self, mock_sleep):
+        with self.assertRaises(RuntimeError):
+            instanceha._retry_with_backoff(lambda: (_ for _ in ()).throw(RuntimeError("fail")), 1, "test")
+        mock_sleep.assert_not_called()
+
+    @patch('instanceha._interruptible_sleep')
+    def test_shutdown_event_passed_through(self, mock_sleep):
+        sentinel = Mock()
+        calls = [0]
+        def fail_once():
+            calls[0] += 1
+            if calls[0] < 2:
+                raise RuntimeError("fail")
+            return True
+
+        instanceha._retry_with_backoff(fail_once, 3, "test", shutdown_event=sentinel)
+        mock_sleep.assert_called_once()
+        self.assertEqual(mock_sleep.call_args[0][0], sentinel)
+
+
+# ============================================================================
+# _run_concurrent tests (M7)
+# ============================================================================
+
+class TestRunConcurrent(unittest.TestCase):
+    """Tests for _run_concurrent concurrent execution wrapper."""
+
+    def test_all_succeed_returns_true(self):
+        result = instanceha._run_concurrent(
+            lambda x: True,
+            ['a', 'b', 'c'],
+            max_workers=2,
+            item_id_func=lambda x: x,
+        )
+        self.assertTrue(result)
+
+    def test_one_failure_returns_false(self):
+        def func(x):
+            if x == 'b':
+                return False
+            return True
+
+        result = instanceha._run_concurrent(func, ['a', 'b', 'c'], 2, lambda x: x)
+        self.assertFalse(result)
+
+    def test_exception_returns_false(self):
+        def func(x):
+            if x == 'b':
+                raise RuntimeError("boom")
+            return True
+
+        result = instanceha._run_concurrent(func, ['a', 'b', 'c'], 2, lambda x: x)
+        self.assertFalse(result)
+
+    def test_empty_items_returns_true(self):
+        result = instanceha._run_concurrent(lambda x: True, [], 2, lambda x: x)
+        self.assertTrue(result)
+
+    def test_timeout_logged_as_error(self):
+        import concurrent.futures
+        with patch.object(concurrent.futures.Future, 'result',
+                          side_effect=concurrent.futures.TimeoutError()):
+            with self.assertLogs(level='ERROR') as cm:
+                result = instanceha._run_concurrent(lambda x: True, ['a'], 1, lambda x: x)
+            self.assertFalse(result)
+            self.assertTrue(any('timed out' in msg for msg in cm.output))
+
+    def test_log_prefix_used(self):
+        with self.assertLogs(level='DEBUG') as cm:
+            instanceha._run_concurrent(lambda x: True, ['item1'], 1, lambda x: x, log_prefix="[test] ")
+        self.assertTrue(any('[test] item1 succeeded' in msg for msg in cm.output))
+
+    def test_item_id_func_applied(self):
+        items = [{'name': 'host-1'}, {'name': 'host-2'}]
+        with self.assertLogs(level='DEBUG') as cm:
+            instanceha._run_concurrent(lambda x: True, items, 2, lambda x: x['name'])
+        self.assertTrue(any('host-1 succeeded' in msg for msg in cm.output))
+
+
+# ============================================================================
+# Application Credential auth tests (M8)
+# ============================================================================
+
+class TestLoadACCredentials(unittest.TestCase):
+    """Tests for _load_ac_credentials file loading."""
+
+    @patch('builtins.open')
+    @patch('os.path.join', side_effect=lambda *a: '/'.join(a))
+    def test_loads_credentials_from_files(self, mock_join, mock_open):
+        mock_open.side_effect = [
+            unittest.mock.mock_open(read_data='my-ac-id').return_value,
+            unittest.mock.mock_open(read_data='my-ac-secret').return_value,
+        ]
+        result = instanceha._load_ac_credentials('https://keystone:5000/v3', 'regionOne')
+        self.assertIsNotNone(result)
+        self.assertEqual(result.application_credential_id, 'my-ac-id')
+        self.assertEqual(result.application_credential_secret, 'my-ac-secret')
+        self.assertEqual(result.auth_url, 'https://keystone:5000/v3')
+        self.assertEqual(result.region_name, 'regionOne')
+
+    @patch('builtins.open', side_effect=FileNotFoundError("not found"))
+    def test_returns_none_on_missing_files(self, mock_open):
+        result = instanceha._load_ac_credentials('https://keystone:5000/v3', 'regionOne')
+        self.assertIsNone(result)
+
+    @patch('builtins.open')
+    @patch('os.path.join', side_effect=lambda *a: '/'.join(a))
+    def test_returns_none_on_empty_credentials(self, mock_join, mock_open):
+        mock_open.side_effect = [
+            unittest.mock.mock_open(read_data='').return_value,
+            unittest.mock.mock_open(read_data='secret').return_value,
+        ]
+        result = instanceha._load_ac_credentials('https://keystone:5000/v3', 'regionOne')
+        self.assertIsNone(result)
+
+    @patch('builtins.open')
+    @patch('os.path.join', side_effect=lambda *a: '/'.join(a))
+    def test_strips_whitespace(self, mock_join, mock_open):
+        mock_open.side_effect = [
+            unittest.mock.mock_open(read_data='  my-id  \n').return_value,
+            unittest.mock.mock_open(read_data='  my-secret  \n').return_value,
+        ]
+        result = instanceha._load_ac_credentials('https://keystone:5000/v3', 'regionOne')
+        self.assertIsNotNone(result)
+        self.assertEqual(result.application_credential_id, 'my-id')
+        self.assertEqual(result.application_credential_secret, 'my-secret')
+
+
+class TestNovaLoginAC(unittest.TestCase):
+    """Tests for nova_login_ac Application Credential auth path."""
+
+    @patch('instanceha._nova_login')
+    def test_calls_nova_login_with_ac_auth(self, mock_login):
+        mock_login.return_value = Mock()
+        creds = instanceha.ACLoginCredentials(
+            auth_url='https://keystone:5000/v3',
+            application_credential_id='ac-id',
+            application_credential_secret='ac-secret',
+            region_name='regionOne',
+        )
+        result = instanceha.nova_login_ac(creds)
+        mock_login.assert_called_once_with(
+            "v3applicationcredential",
+            {
+                "auth_url": "https://keystone:5000/v3",
+                "application_credential_id": "ac-id",
+                "application_credential_secret": "ac-secret",
+            },
+            "regionOne",
+            None,
+        )
+        self.assertIsNotNone(result)
+
+    @patch('instanceha._nova_login')
+    def test_passes_ca_bundle(self, mock_login):
+        mock_login.return_value = Mock()
+        creds = instanceha.ACLoginCredentials(
+            auth_url='https://keystone:5000/v3',
+            application_credential_id='ac-id',
+            application_credential_secret='ac-secret',
+            region_name='regionOne',
+        )
+        instanceha.nova_login_ac(creds, ca_bundle='/etc/pki/ca-trust.crt')
+        self.assertEqual(mock_login.call_args[0][3], '/etc/pki/ca-trust.crt')
+
+    @patch('instanceha._nova_login', side_effect=instanceha.NovaConnectionError("auth failed"))
+    def test_propagates_connection_error(self, mock_login):
+        creds = instanceha.ACLoginCredentials(
+            auth_url='https://keystone:5000/v3',
+            application_credential_id='ac-id',
+            application_credential_secret='ac-secret',
+            region_name='regionOne',
+        )
+        with self.assertRaises(instanceha.NovaConnectionError):
+            instanceha.nova_login_ac(creds)
+
+
+# ============================================================================
+# Per-cycle rate limiter tests (MAX_HOSTS_PER_CYCLE)
+# ============================================================================
+
+class TestFencingRateLimiter(unittest.TestCase):
+    """Tests for MAX_HOSTS_PER_CYCLE rate limiting in _process_stale_services."""
+
+    def _make_service(self):
+        import threading
+        from collections import defaultdict
+        svc = Mock()
+        svc.config = Mock()
+        svc.config.get_config_value = Mock(side_effect=lambda key: {
+            'DISABLED': False, 'THRESHOLD': 50, 'CHECK_KDUMP': False,
+            'CHECK_HEARTBEAT': False,
+            'WORKERS': 2, 'POLL': 5, 'FENCING_TIMEOUT': 30,
+            'TAGGED_IMAGES': False, 'TAGGED_FLAVORS': False,
+            'TAGGED_AGGREGATES': False, 'RESERVED_HOSTS': False,
+            'MAX_HOSTS_PER_CYCLE': 3,
+        }.get(key, Mock()))
+        svc.processing_lock = threading.Lock()
+        svc.hosts_processing = defaultdict(float)
+        svc.refresh_evacuable_cache = Mock()
+        svc.get_hosts_with_servers_cached = Mock(return_value={})
+        svc.filter_hosts_with_servers = Mock(side_effect=lambda nodes, cache: nodes)
+        return svc
+
+    def _make_compute_svc(self, host):
+        svc = Mock()
+        svc.host = host
+        svc.status = 'enabled'
+        svc.forced_down = False
+        svc.state = 'down'
+        return svc
+
+    @patch('instanceha._emit_k8s_event')
+    @patch('instanceha._check_critical_services', return_value=(True, ""))
+    @patch('instanceha._execute_fence_operation', return_value=True)
+    def test_rate_limit_caps_hosts(self, mock_fence, _crit, _event):
+        """MAX_HOSTS_PER_CYCLE=3 caps fencing to 3 hosts when 5 are down."""
+        service = self._make_service()
+        conn = Mock()
+        stale_hosts = [self._make_compute_svc(f'host-{i}') for i in range(5)]
+        # Add healthy hosts so all-services-stale check doesn't fire
+        healthy_hosts = [self._make_compute_svc(f'healthy-{i}') for i in range(5)]
+        for h in healthy_hosts:
+            h.state = 'up'
+        all_services = stale_hosts + healthy_hosts
+        service.get_hosts_with_servers_cached.return_value = {
+            f'host-{i}': [f'server-{i}'] for i in range(5)
+        }
+
+        instanceha._process_stale_services(conn, service, all_services, stale_hosts, [])
+
+        fenced_hosts = [c[0][0] for c in mock_fence.call_args_list]
+        self.assertLessEqual(len(fenced_hosts), 3)
+
+    @patch('instanceha._emit_k8s_event')
+    @patch('instanceha._check_critical_services', return_value=(True, ""))
+    @patch('instanceha._execute_fence_operation', return_value=True)
+    def test_rate_limit_not_triggered_under_cap(self, mock_fence, _crit, mock_event):
+        """When hosts <= MAX_HOSTS_PER_CYCLE, no rate limiting occurs."""
+        service = self._make_service()
+        conn = Mock()
+        stale_hosts = [self._make_compute_svc(f'host-{i}') for i in range(2)]
+        healthy_hosts = [self._make_compute_svc(f'healthy-{i}') for i in range(5)]
+        for h in healthy_hosts:
+            h.state = 'up'
+        all_services = stale_hosts + healthy_hosts
+        service.get_hosts_with_servers_cached.return_value = {
+            f'host-{i}': [f'server-{i}'] for i in range(2)
+        }
+
+        instanceha._process_stale_services(conn, service, all_services, stale_hosts, [])
+
+        rate_events = [c for c in mock_event.call_args_list
+                       if len(c[0]) >= 2 and c[0][1] == 'FencingRateLimited']
+        self.assertEqual(len(rate_events), 0)
+
+    @patch('instanceha._emit_k8s_event')
+    @patch('instanceha._check_critical_services', return_value=(True, ""))
+    @patch('instanceha._execute_fence_operation', return_value=True)
+    def test_rate_limit_emits_event(self, mock_fence, _crit, mock_event):
+        """FencingRateLimited K8s event is emitted when the cap is hit."""
+        service = self._make_service()
+        conn = Mock()
+        stale_hosts = [self._make_compute_svc(f'host-{i}') for i in range(5)]
+        healthy_hosts = [self._make_compute_svc(f'healthy-{i}') for i in range(5)]
+        for h in healthy_hosts:
+            h.state = 'up'
+        all_services = stale_hosts + healthy_hosts
+        service.get_hosts_with_servers_cached.return_value = {
+            f'host-{i}': [f'server-{i}'] for i in range(5)
+        }
+
+        instanceha._process_stale_services(conn, service, all_services, stale_hosts, [])
+
+        rate_events = [c for c in mock_event.call_args_list
+                       if len(c[0]) >= 2 and c[0][1] == 'FencingRateLimited']
+        self.assertEqual(len(rate_events), 1)
+
+    @patch('instanceha._emit_k8s_event')
+    @patch('instanceha._check_critical_services', return_value=(True, ""))
+    @patch('instanceha._execute_fence_operation', return_value=True)
+    def test_rate_limit_increments_metric(self, mock_fence, _crit, _event):
+        """FENCING_RATE_LIMITED_TOTAL metric increments when rate limit fires."""
+        service = self._make_service()
+        conn = Mock()
+        stale_hosts = [self._make_compute_svc(f'host-{i}') for i in range(5)]
+        healthy_hosts = [self._make_compute_svc(f'healthy-{i}') for i in range(5)]
+        for h in healthy_hosts:
+            h.state = 'up'
+        all_services = stale_hosts + healthy_hosts
+        service.get_hosts_with_servers_cached.return_value = {
+            f'host-{i}': [f'server-{i}'] for i in range(5)
+        }
+
+        before = instanceha.FENCING_RATE_LIMITED_TOTAL._value.get()
+        instanceha._process_stale_services(conn, service, all_services, stale_hosts, [])
+        after = instanceha.FENCING_RATE_LIMITED_TOTAL._value.get()
+        self.assertEqual(after - before, 1)
+
+
+# ============================================================================
+# All-services-stale circuit breaker tests
+# ============================================================================
+
+class TestAllServicesStaleCircuitBreaker(unittest.TestCase):
+    """Tests for the all-services-stale safety check in _process_stale_services."""
+
+    def _make_service(self):
+        import threading
+        from collections import defaultdict
+        svc = Mock()
+        svc.config = Mock()
+        svc.config.get_config_value = Mock(side_effect=lambda key: {
+            'DISABLED': False, 'THRESHOLD': 50, 'CHECK_KDUMP': False,
+            'CHECK_HEARTBEAT': False,
+            'WORKERS': 2, 'POLL': 5, 'FENCING_TIMEOUT': 30,
+            'TAGGED_IMAGES': False, 'TAGGED_FLAVORS': False,
+            'TAGGED_AGGREGATES': False, 'RESERVED_HOSTS': False,
+            'MAX_HOSTS_PER_CYCLE': 10,
+        }.get(key, Mock()))
+        svc.processing_lock = threading.Lock()
+        svc.hosts_processing = defaultdict(float)
+        svc.refresh_evacuable_cache = Mock()
+        svc.get_hosts_with_servers_cached = Mock(return_value={})
+        svc.filter_hosts_with_servers = Mock(side_effect=lambda nodes, cache: nodes)
+        return svc
+
+    def _make_compute_svc(self, host, status='enabled', forced_down=False):
+        svc = Mock()
+        svc.host = host
+        svc.status = status
+        svc.forced_down = forced_down
+        svc.state = 'down'
+        return svc
+
+    @patch('instanceha._emit_k8s_event')
+    def test_all_stale_triggers_when_all_active_services_down(self, mock_event):
+        """When every active service is in compute_nodes, skip fencing."""
+        service = self._make_service()
+        conn = Mock()
+        hosts = [self._make_compute_svc(f'host-{i}') for i in range(5)]
+        all_services = list(hosts)
+
+        with patch('instanceha._execute_fence_operation') as mock_fence:
+            instanceha._process_stale_services(conn, service, all_services, hosts, [])
+            mock_fence.assert_not_called()
+
+        stale_events = [c for c in mock_event.call_args_list
+                        if len(c[0]) >= 2 and c[0][1] == 'AllServicesStale']
+        self.assertEqual(len(stale_events), 1)
+
+    @patch('instanceha._emit_k8s_event')
+    def test_all_stale_increments_metric(self, _event):
+        """ALL_SERVICES_STALE_TOTAL metric increments when circuit breaker fires."""
+        service = self._make_service()
+        conn = Mock()
+        hosts = [self._make_compute_svc(f'host-{i}') for i in range(5)]
+        all_services = list(hosts)
+
+        before = instanceha.ALL_SERVICES_STALE_TOTAL._value.get()
+        instanceha._process_stale_services(conn, service, all_services, hosts, [])
+        after = instanceha.ALL_SERVICES_STALE_TOTAL._value.get()
+        self.assertEqual(after - before, 1)
+
+    @patch('instanceha._emit_k8s_event')
+    @patch('instanceha._check_critical_services', return_value=(True, ""))
+    def test_all_stale_does_not_trigger_on_partial_failure(self, _crit, mock_event):
+        """When only a subset of active services are stale, circuit breaker does not fire."""
+        service = self._make_service()
+        conn = Mock()
+        stale_hosts = [self._make_compute_svc(f'host-{i}') for i in range(3)]
+        healthy_hosts = [self._make_compute_svc(f'host-{i}', status='enabled') for i in range(3, 8)]
+        all_services = stale_hosts + healthy_hosts
+        for h in healthy_hosts:
+            h.state = 'up'
+        service.get_hosts_with_servers_cached.return_value = {
+            f'host-{i}': [f'server-{i}'] for i in range(3)
+        }
+
+        instanceha._process_stale_services(conn, service, all_services, stale_hosts, [])
+
+        stale_events = [c for c in mock_event.call_args_list
+                        if len(c[0]) >= 2 and c[0][1] == 'AllServicesStale']
+        self.assertEqual(len(stale_events), 0, "AllServicesStale should NOT fire on partial failure")
+
+    @patch('instanceha._emit_k8s_event')
+    @patch('instanceha._check_critical_services', return_value=(True, ""))
+    def test_all_stale_skipped_with_2_active_services(self, _crit, mock_event):
+        """With only 2 active services, the >=3 minimum guard prevents the check."""
+        service = self._make_service()
+        conn = Mock()
+        hosts = [self._make_compute_svc(f'host-{i}') for i in range(2)]
+        all_services = list(hosts)
+        service.get_hosts_with_servers_cached.return_value = {
+            f'host-{i}': [f'server-{i}'] for i in range(2)
+        }
+
+        instanceha._process_stale_services(conn, service, all_services, hosts, [])
+
+        stale_events = [c for c in mock_event.call_args_list
+                        if len(c[0]) >= 2 and c[0][1] == 'AllServicesStale']
+        self.assertEqual(len(stale_events), 0, "AllServicesStale should NOT fire with <3 active services")
+
+    @patch('instanceha._emit_k8s_event')
+    def test_all_stale_excludes_disabled_services(self, mock_event):
+        """Disabled services don't count toward the active_services denominator."""
+        service = self._make_service()
+        conn = Mock()
+        stale_hosts = [self._make_compute_svc(f'host-{i}') for i in range(3)]
+        disabled_hosts = [self._make_compute_svc(f'host-{i}', status='disabled') for i in range(3, 5)]
+        all_services = stale_hosts + disabled_hosts
+
+        with patch('instanceha._execute_fence_operation') as mock_fence:
+            instanceha._process_stale_services(conn, service, all_services, stale_hosts, [])
+            mock_fence.assert_not_called()
+
+        stale_events = [c for c in mock_event.call_args_list
+                        if len(c[0]) >= 2 and c[0][1] == 'AllServicesStale']
+        self.assertEqual(len(stale_events), 1)
+
+    @patch('instanceha._emit_k8s_event')
+    def test_all_stale_excludes_forced_down_services(self, mock_event):
+        """Forced-down services don't count toward active_services."""
+        service = self._make_service()
+        conn = Mock()
+        stale_hosts = [self._make_compute_svc(f'host-{i}') for i in range(3)]
+        forced_hosts = [self._make_compute_svc(f'host-{i}', forced_down=True) for i in range(3, 5)]
+        all_services = stale_hosts + forced_hosts
+
+        with patch('instanceha._execute_fence_operation') as mock_fence:
+            instanceha._process_stale_services(conn, service, all_services, stale_hosts, [])
+            mock_fence.assert_not_called()
+
+        stale_events = [c for c in mock_event.call_args_list
+                        if len(c[0]) >= 2 and c[0][1] == 'AllServicesStale']
+        self.assertEqual(len(stale_events), 1)
 
 
 if __name__ == '__main__':

--- a/test/instanceha/test_fencing_agents.py
+++ b/test/instanceha/test_fencing_agents.py
@@ -677,7 +677,7 @@ class TestIPMIFencing(unittest.TestCase):
         mock_run.assert_called_once()
 
     @patch('instanceha.subprocess.run')
-    @patch('instanceha.time.sleep')
+    @patch('instanceha._interruptible_sleep')
     def test_ipmi_retry_on_timeout(self, mock_sleep, mock_run):
         """Test IPMI retries on TimeoutExpired."""
         # Mock timeout then success
@@ -705,7 +705,7 @@ class TestIPMIFencing(unittest.TestCase):
         self.assertEqual(mock_sleep.call_count, 2)  # Sleep between retries
 
     @patch('instanceha.subprocess.run')
-    @patch('instanceha.time.sleep')
+    @patch('instanceha._interruptible_sleep')
     def test_ipmi_retry_exhausted_timeout(self, mock_sleep, mock_run):
         """Test IPMI fails after max retries on TimeoutExpired."""
         # Mock always timing out
@@ -729,7 +729,7 @@ class TestIPMIFencing(unittest.TestCase):
         self.assertEqual(mock_sleep.call_count, 2)
 
     @patch('instanceha.subprocess.run')
-    @patch('instanceha.time.sleep')
+    @patch('instanceha._interruptible_sleep')
     def test_ipmi_retry_on_called_process_error(self, mock_sleep, mock_run):
         """Test IPMI retries on CalledProcessError."""
         # Mock error then success
@@ -757,7 +757,7 @@ class TestIPMIFencing(unittest.TestCase):
         self.assertEqual(mock_sleep.call_count, 2)
 
     @patch('instanceha.subprocess.run')
-    @patch('instanceha.time.sleep')
+    @patch('instanceha._interruptible_sleep')
     def test_ipmi_retry_exhausted_process_error(self, mock_sleep, mock_run):
         """Test IPMI fails after max retries on CalledProcessError."""
         # Mock always failing
@@ -1072,7 +1072,7 @@ class TestFencingRaceCondition(unittest.TestCase):
         failed_service = type('MockService', (), {'host': 'test-host.example.com'})()
 
         # Mock all dependencies to ensure success
-        with unittest.mock.patch('instanceha._get_nova_connection') as mock_conn, \
+        with unittest.mock.patch('instanceha._establish_nova_connection') as mock_conn, \
              unittest.mock.patch('instanceha._execute_step', return_value=True):
 
             # Call process_service
@@ -1091,7 +1091,7 @@ class TestFencingRaceCondition(unittest.TestCase):
         failed_service = type('MockService', (), {'host': 'test-host.example.com'})()
 
         # Mock dependencies to cause failure
-        with unittest.mock.patch('instanceha._get_nova_connection', return_value=None):
+        with unittest.mock.patch('instanceha._establish_nova_connection', return_value=None):
 
             # Call process_service (should fail due to no connection)
             result = instanceha.process_service(failed_service, [], False, self.service)
@@ -1125,6 +1125,7 @@ class TestFencingRaceCondition(unittest.TestCase):
 
         # Mock connection and services
         mock_conn = Mock()
+        mock_conn.services.list.return_value = []
         mock_services = [Mock(status='enabled', forced_down=False) for _ in range(10)]
 
         # Simulate filtering: hosts get filtered out (no servers)
@@ -1173,6 +1174,7 @@ class TestFencingRaceCondition(unittest.TestCase):
 
         # Mock services to simulate filtering that results in empty list
         mock_conn = Mock()
+        mock_conn.services.list.return_value = []
         mock_services = [Mock(status='enabled', forced_down=False) for _ in range(10)]
 
         # Simulate: host is marked, but then filtered out (e.g., no servers)

--- a/test/instanceha/test_heartbeat_detection.py
+++ b/test/instanceha/test_heartbeat_detection.py
@@ -20,7 +20,7 @@ from collections import defaultdict
 
 logging.getLogger().setLevel(logging.CRITICAL)
 
-import conftest  # noqa: F401
+from conftest import make_mock_config  # noqa: F401
 import instanceha
 
 logging.getLogger().setLevel(logging.CRITICAL)
@@ -156,9 +156,7 @@ class TestFilterReachableHosts(unittest.TestCase):
     """Test _filter_reachable_hosts heartbeat filtering logic."""
 
     def setUp(self):
-        mock_config = Mock()
-        mock_config.get_config_value.return_value = 120  # HEARTBEAT_TIMEOUT
-        self.service = instanceha.InstanceHAService(mock_config)
+        self.service = instanceha.InstanceHAService(make_mock_config())
         self.service.heartbeat_hosts_timestamp.clear()
 
     def _make_compute_svc(self, hostname):
@@ -182,10 +180,10 @@ class TestFilterReachableHosts(unittest.TestCase):
 
     def test_grace_period_listener_too_young(self):
         """All hosts bypass filtering when listener started less than HEARTBEAT_TIMEOUT ago."""
-        self.service.heartbeat_listener_start_time = time.time() - 10  # 10s ago, timeout is 120s
+        self.service.heartbeat_listener_start_time = time.monotonic() - 10  # 10s ago, timeout is 120s
 
         svc = self._make_compute_svc('compute-01')
-        self.service.heartbeat_hosts_timestamp['compute-01'] = time.time() - 5
+        self.service.heartbeat_hosts_timestamp['compute-01'] = time.monotonic() - 5
 
         unreachable, skipped, _ = instanceha._filter_reachable_hosts(self.service, [svc])
         # During grace period, all hosts pass through unfiltered
@@ -194,10 +192,10 @@ class TestFilterReachableHosts(unittest.TestCase):
 
     def test_recent_heartbeat_skips_fencing(self):
         """Host with recent heartbeat is skipped (not fenced)."""
-        self.service.heartbeat_listener_start_time = time.time() - 300  # Well past grace period
+        self.service.heartbeat_listener_start_time = time.monotonic() - 300  # Well past grace period
 
         svc = self._make_compute_svc('compute-01')
-        self.service.heartbeat_hosts_timestamp['compute-01'] = time.time() - 30  # 30s ago, within 120s timeout
+        self.service.heartbeat_hosts_timestamp['compute-01'] = time.monotonic() - 30  # 30s ago, within 120s timeout
 
         unreachable, skipped, _ = instanceha._filter_reachable_hosts(self.service, [svc])
         self.assertEqual(len(unreachable), 0)
@@ -206,10 +204,10 @@ class TestFilterReachableHosts(unittest.TestCase):
 
     def test_stale_heartbeat_allows_fencing(self):
         """Host with stale heartbeat (older than timeout) is fenced."""
-        self.service.heartbeat_listener_start_time = time.time() - 300
+        self.service.heartbeat_listener_start_time = time.monotonic() - 300
 
         svc = self._make_compute_svc('compute-01')
-        self.service.heartbeat_hosts_timestamp['compute-01'] = time.time() - 200  # 200s ago, beyond 120s timeout
+        self.service.heartbeat_hosts_timestamp['compute-01'] = time.monotonic() - 200  # 200s ago, beyond 120s timeout
 
         unreachable, skipped, _ = instanceha._filter_reachable_hosts(self.service, [svc])
         self.assertEqual(len(unreachable), 1)
@@ -217,7 +215,7 @@ class TestFilterReachableHosts(unittest.TestCase):
 
     def test_no_heartbeat_entry_allows_fencing(self):
         """Host with no heartbeat entry at all is fenced."""
-        self.service.heartbeat_listener_start_time = time.time() - 300
+        self.service.heartbeat_listener_start_time = time.monotonic() - 300
 
         svc = self._make_compute_svc('compute-01')
         # No entry in heartbeat_hosts_timestamp
@@ -228,15 +226,15 @@ class TestFilterReachableHosts(unittest.TestCase):
 
     def test_mixed_hosts(self):
         """Test with a mix of reachable and unreachable hosts."""
-        self.service.heartbeat_listener_start_time = time.time() - 300
+        self.service.heartbeat_listener_start_time = time.monotonic() - 300
 
         svcs = [self._make_compute_svc(f'compute-{i:02d}') for i in range(5)]
 
         # compute-00 and compute-02 have recent heartbeats
-        self.service.heartbeat_hosts_timestamp['compute-00'] = time.time() - 10
-        self.service.heartbeat_hosts_timestamp['compute-02'] = time.time() - 50
+        self.service.heartbeat_hosts_timestamp['compute-00'] = time.monotonic() - 10
+        self.service.heartbeat_hosts_timestamp['compute-02'] = time.monotonic() - 50
         # compute-01 has stale heartbeat
-        self.service.heartbeat_hosts_timestamp['compute-01'] = time.time() - 200
+        self.service.heartbeat_hosts_timestamp['compute-01'] = time.monotonic() - 200
         # compute-03 and compute-04 have no heartbeat entries
 
         unreachable, skipped, _ = instanceha._filter_reachable_hosts(self.service, svcs)
@@ -254,7 +252,7 @@ class TestHeartbeatCliffDetection(unittest.TestCase):
     def setUp(self):
         self.config = instanceha.ConfigManager()
         self.service = instanceha.InstanceHAService(self.config)
-        self.service.heartbeat_listener_start_time = time.time() - 300
+        self.service.heartbeat_listener_start_time = time.monotonic() - 300
 
     def _make_svc(self, host):
         svc = Mock()
@@ -262,7 +260,7 @@ class TestHeartbeatCliffDetection(unittest.TestCase):
         return svc
 
     def _set_active_heartbeats(self, hostnames, age=10):
-        now = time.time()
+        now = time.monotonic()
         with self.service.heartbeat_lock:
             for h in hostnames:
                 self.service.heartbeat_hosts_timestamp[h] = now - age
@@ -275,7 +273,7 @@ class TestHeartbeatCliffDetection(unittest.TestCase):
         with self.service.heartbeat_lock:
             self.service.heartbeat_hosts_timestamp.clear()
             for h in hosts[:2]:
-                self.service.heartbeat_hosts_timestamp[h] = time.time() - 10
+                self.service.heartbeat_hosts_timestamp[h] = time.monotonic() - 10
         unreachable, skipped, _ = instanceha._filter_reachable_hosts(self.service, svcs)
         self.assertEqual(len(unreachable), 0)
         self.assertEqual(len(skipped), 3)
@@ -307,7 +305,7 @@ class TestHeartbeatCliffDetection(unittest.TestCase):
         self.service.heartbeat_previous_active_count = 10
         with self.service.heartbeat_lock:
             self.service.heartbeat_hosts_timestamp.clear()
-            self.service.heartbeat_hosts_timestamp['compute-00'] = time.time() - 10
+            self.service.heartbeat_hosts_timestamp['compute-00'] = time.monotonic() - 10
         svcs = [self._make_svc('compute-01')]
         instanceha._filter_reachable_hosts(self.service, svcs)
         self.assertEqual(self.service.heartbeat_previous_active_count, 10)
@@ -342,11 +340,173 @@ class TestHeartbeatCliffDetection(unittest.TestCase):
         with self.service.heartbeat_lock:
             self.service.heartbeat_hosts_timestamp.clear()
             for h in hosts[:5]:
-                self.service.heartbeat_hosts_timestamp[h] = time.time() - 10
+                self.service.heartbeat_hosts_timestamp[h] = time.monotonic() - 10
         svcs = [self._make_svc(hosts[9])]
         unreachable, skipped, _ = instanceha._filter_reachable_hosts(self.service, svcs)
         self.assertEqual(len(unreachable), 0)
         self.assertEqual(len(skipped), 1)
+
+
+class TestHeartbeatCliffExpiry(unittest.TestCase):
+    """Tests for cliff detection expiry after HEARTBEAT_CLIFF_MAX_CYCLES."""
+
+    def setUp(self):
+        self.config = instanceha.ConfigManager()
+        self.service = instanceha.InstanceHAService(self.config)
+        self.service.heartbeat_listener_start_time = time.monotonic() - 300
+
+    def _make_svc(self, host):
+        svc = Mock()
+        svc.host = host
+        return svc
+
+    def _set_active_heartbeats(self, hostnames, age=10):
+        now = time.monotonic()
+        with self.service.heartbeat_lock:
+            for h in hostnames:
+                self.service.heartbeat_hosts_timestamp[h] = now - age
+
+    def _trigger_cliff(self, svcs):
+        """Trigger one cliff detection cycle. Returns the result."""
+        return instanceha._filter_reachable_hosts(self.service, svcs)
+
+    @patch('instanceha._emit_k8s_event')
+    def test_cliff_expires_after_max_cycles(self, _event):
+        """After HEARTBEAT_CLIFF_MAX_CYCLES consecutive cliff detections, fencing proceeds."""
+        hosts = [f'compute-{i:02d}' for i in range(10)]
+        self._set_active_heartbeats(hosts)
+        self.service.heartbeat_previous_active_count = 10
+        # Kill all heartbeats to trigger cliff
+        with self.service.heartbeat_lock:
+            self.service.heartbeat_hosts_timestamp.clear()
+        svcs = [self._make_svc('compute-99')]
+
+        max_cycles = self.config.get_config_value('HEARTBEAT_CLIFF_MAX_CYCLES')  # default 3
+
+        # Cycles 1 through max_cycles-1: cliff suppresses fencing
+        for cycle in range(max_cycles - 1):
+            unreachable, skipped, cliff = self._trigger_cliff(svcs)
+            self.assertEqual(len(unreachable), 0, f"Cycle {cycle+1} should suppress fencing")
+            self.assertTrue(cliff, f"Cycle {cycle+1} should report cliff_detected")
+            self.assertEqual(self.service.heartbeat_consecutive_cliff_cycles, cycle + 1)
+
+        # Cycle max_cycles: cliff expires, fencing proceeds
+        unreachable, skipped, cliff = self._trigger_cliff(svcs)
+        self.assertEqual(len(unreachable), 1, "After expiry, hosts should be fenced")
+        self.assertFalse(cliff, "After expiry, cliff_detected should be False")
+
+    @patch('instanceha._emit_k8s_event')
+    def test_cliff_counter_resets_after_expiry(self, _event):
+        """After cliff expiry, the consecutive counter resets to 0."""
+        hosts = [f'compute-{i:02d}' for i in range(10)]
+        self._set_active_heartbeats(hosts)
+        self.service.heartbeat_previous_active_count = 10
+        with self.service.heartbeat_lock:
+            self.service.heartbeat_hosts_timestamp.clear()
+        svcs = [self._make_svc('compute-99')]
+
+        max_cycles = self.config.get_config_value('HEARTBEAT_CLIFF_MAX_CYCLES')
+        for _ in range(max_cycles):
+            self._trigger_cliff(svcs)
+
+        self.assertEqual(self.service.heartbeat_consecutive_cliff_cycles, 0)
+
+    @patch('instanceha._emit_k8s_event')
+    def test_cliff_baseline_resets_after_expiry(self, _event):
+        """After cliff expiry, previous_active_count is reset to current_active."""
+        hosts = [f'compute-{i:02d}' for i in range(10)]
+        self._set_active_heartbeats(hosts)
+        self.service.heartbeat_previous_active_count = 10
+        # Keep only 2 heartbeats alive
+        with self.service.heartbeat_lock:
+            self.service.heartbeat_hosts_timestamp.clear()
+            self.service.heartbeat_hosts_timestamp['compute-00'] = time.monotonic() - 5
+            self.service.heartbeat_hosts_timestamp['compute-01'] = time.monotonic() - 5
+        svcs = [self._make_svc('compute-99')]
+
+        max_cycles = self.config.get_config_value('HEARTBEAT_CLIFF_MAX_CYCLES')
+        for _ in range(max_cycles):
+            self._trigger_cliff(svcs)
+
+        self.assertEqual(self.service.heartbeat_previous_active_count, 2)
+
+    @patch('instanceha._emit_k8s_event')
+    def test_cliff_counter_resets_on_non_cliff_cycle(self, _event):
+        """A normal (non-cliff) cycle resets the consecutive counter to 0."""
+        hosts = [f'compute-{i:02d}' for i in range(10)]
+        self._set_active_heartbeats(hosts)
+        self.service.heartbeat_previous_active_count = 10
+
+        # Trigger one cliff cycle
+        with self.service.heartbeat_lock:
+            self.service.heartbeat_hosts_timestamp.clear()
+        svcs = [self._make_svc('compute-99')]
+        self._trigger_cliff(svcs)
+        self.assertEqual(self.service.heartbeat_consecutive_cliff_cycles, 1)
+
+        # Restore heartbeats — next cycle is not a cliff
+        self._set_active_heartbeats(hosts)
+        self.service.heartbeat_previous_active_count = 10
+        svcs = [self._make_svc('compute-99')]
+        self._trigger_cliff(svcs)
+        self.assertEqual(self.service.heartbeat_consecutive_cliff_cycles, 0)
+
+    @patch('instanceha._emit_k8s_event')
+    def test_cliff_max_cycles_1_expires_immediately(self, _event):
+        """With HEARTBEAT_CLIFF_MAX_CYCLES=1, cliff expires on the first detection."""
+        original = self.service.config._config_map['HEARTBEAT_CLIFF_MAX_CYCLES']
+        try:
+            self.service.config._config_map['HEARTBEAT_CLIFF_MAX_CYCLES'] = instanceha.ConfigItem('int', 1, 1, 20)
+            hosts = [f'compute-{i:02d}' for i in range(10)]
+            self._set_active_heartbeats(hosts)
+            self.service.heartbeat_previous_active_count = 10
+            with self.service.heartbeat_lock:
+                self.service.heartbeat_hosts_timestamp.clear()
+            svcs = [self._make_svc('compute-99')]
+
+            unreachable, skipped, cliff = self._trigger_cliff(svcs)
+            self.assertEqual(len(unreachable), 1, "max_cycles=1 should expire immediately")
+            self.assertFalse(cliff)
+        finally:
+            self.service.config._config_map['HEARTBEAT_CLIFF_MAX_CYCLES'] = original
+
+    @patch('instanceha._emit_k8s_event')
+    def test_cliff_expiry_emits_event(self, mock_event):
+        """Cliff expiry emits a HeartbeatCliffExpired K8s event."""
+        hosts = [f'compute-{i:02d}' for i in range(10)]
+        self._set_active_heartbeats(hosts)
+        self.service.heartbeat_previous_active_count = 10
+        with self.service.heartbeat_lock:
+            self.service.heartbeat_hosts_timestamp.clear()
+        svcs = [self._make_svc('compute-99')]
+
+        max_cycles = self.config.get_config_value('HEARTBEAT_CLIFF_MAX_CYCLES')
+        for _ in range(max_cycles):
+            self._trigger_cliff(svcs)
+
+        event_calls = [c for c in mock_event.call_args_list if c[0][1] == 'HeartbeatCliffExpired']
+        self.assertEqual(len(event_calls), 1)
+
+    @patch('instanceha._emit_k8s_event')
+    def test_cliff_partial_recovery_resets_counter(self, _event):
+        """If heartbeats partially recover (no longer a cliff), counter resets even mid-sequence."""
+        hosts = [f'compute-{i:02d}' for i in range(10)]
+        self._set_active_heartbeats(hosts)
+        self.service.heartbeat_previous_active_count = 10
+
+        # Trigger 2 cliff cycles (one short of default max_cycles=3)
+        with self.service.heartbeat_lock:
+            self.service.heartbeat_hosts_timestamp.clear()
+        svcs = [self._make_svc('compute-99')]
+        self._trigger_cliff(svcs)
+        self._trigger_cliff(svcs)
+        self.assertEqual(self.service.heartbeat_consecutive_cliff_cycles, 2)
+
+        # Partial recovery: 9 out of 10 heartbeats return (10% drop, below 50% threshold)
+        # previous_active is still 10 (preserved during cliff), so 9/10 = 10% drop < 50%
+        self._set_active_heartbeats([f'compute-{i:02d}' for i in range(9)])
+        self._trigger_cliff(svcs)
+        self.assertEqual(self.service.heartbeat_consecutive_cliff_cycles, 0)
 
 
 class TestHeartbeatPort(unittest.TestCase):
@@ -399,7 +559,7 @@ class TestHeartbeatLockConcurrency(unittest.TestCase):
                 for i in range(50):
                     hostname = f'host-{thread_id}-{i}'
                     with self.service.heartbeat_lock:
-                        self.service.heartbeat_hosts_timestamp[hostname] = time.time()
+                        self.service.heartbeat_hosts_timestamp[hostname] = time.monotonic()
             except Exception as e:
                 errors.append(str(e))
 
@@ -420,7 +580,7 @@ class TestHeartbeatLockConcurrency(unittest.TestCase):
             try:
                 for i in range(100):
                     with self.service.heartbeat_lock:
-                        self.service.heartbeat_hosts_timestamp[f'host-{i}'] = time.time()
+                        self.service.heartbeat_hosts_timestamp[f'host-{i}'] = time.monotonic()
             except Exception as e:
                 errors.append(f'writer: {e}')
 

--- a/test/instanceha/test_heartbeat_scale.py
+++ b/test/instanceha/test_heartbeat_scale.py
@@ -22,7 +22,7 @@ from collections import defaultdict
 
 logging.getLogger().setLevel(logging.CRITICAL)
 
-import conftest  # noqa: F401
+from conftest import make_mock_config  # noqa: F401
 import instanceha
 
 logging.getLogger().setLevel(logging.CRITICAL)
@@ -35,9 +35,7 @@ class TestHeartbeatUDPThroughput(unittest.TestCase):
     """Test UDP listener can handle 1000 nodes sending heartbeats."""
 
     def setUp(self):
-        mock_config = Mock()
-        mock_config.get_config_value.return_value = 120
-        self.service = instanceha.InstanceHAService(mock_config)
+        self.service = instanceha.InstanceHAService(make_mock_config())
         self.service.heartbeat_hosts_timestamp.clear()
         self.service.udp_ip = '127.0.0.1'
         self.service.heartbeat_hmac_keys = [_TEST_HMAC_KEY]
@@ -70,7 +68,7 @@ class TestHeartbeatUDPThroughput(unittest.TestCase):
         def patched_listener():
             def on_start():
                 with self.service.heartbeat_lock:
-                    self.service.heartbeat_listener_start_time = time.time()
+                    self.service.heartbeat_listener_start_time = time.monotonic()
                 listener_started.set()
 
             hmac_keys = self.service.heartbeat_hmac_keys
@@ -84,7 +82,7 @@ class TestHeartbeatUDPThroughput(unittest.TestCase):
                 lock=self.service.heartbeat_lock,
                 timestamps=self.service.heartbeat_hosts_timestamp,
                 stop_event=self.service.heartbeat_listener_stop_event,
-                cleanup_threshold=instanceha.HEARTBEAT_CLEANUP_THRESHOLD,
+                cleanup_threshold=instanceha.UDP_CLEANUP_THRESHOLD,
                 cleanup_age_seconds=instanceha.HEARTBEAT_CLEANUP_AGE_SECONDS,
                 resolve_hostname=lambda data, addr, label: instanceha._resolve_hostname_packet(data, addr, label, hmac_keys=hmac_keys),
                 log_level=logging.DEBUG,
@@ -114,8 +112,8 @@ class TestHeartbeatUDPThroughput(unittest.TestCase):
             t.join(timeout=10)
 
         # Wait for listener to process all packets
-        deadline = time.time() + 10
-        while time.time() < deadline:
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
             with self.service.heartbeat_lock:
                 count = len(self.service.heartbeat_hosts_timestamp)
             if count >= NODE_COUNT:
@@ -150,7 +148,7 @@ class TestHeartbeatUDPThroughput(unittest.TestCase):
         def patched_listener():
             def on_start():
                 with self.service.heartbeat_lock:
-                    self.service.heartbeat_listener_start_time = time.time()
+                    self.service.heartbeat_listener_start_time = time.monotonic()
                 listener_started.set()
 
             hmac_keys = self.service.heartbeat_hmac_keys
@@ -164,7 +162,7 @@ class TestHeartbeatUDPThroughput(unittest.TestCase):
                 lock=self.service.heartbeat_lock,
                 timestamps=self.service.heartbeat_hosts_timestamp,
                 stop_event=self.service.heartbeat_listener_stop_event,
-                cleanup_threshold=instanceha.HEARTBEAT_CLEANUP_THRESHOLD,
+                cleanup_threshold=instanceha.UDP_CLEANUP_THRESHOLD,
                 cleanup_age_seconds=instanceha.HEARTBEAT_CLEANUP_AGE_SECONDS,
                 resolve_hostname=lambda data, addr, label: instanceha._resolve_hostname_packet(data, addr, label, hmac_keys=hmac_keys),
                 log_level=logging.DEBUG,
@@ -186,8 +184,8 @@ class TestHeartbeatUDPThroughput(unittest.TestCase):
         finally:
             sock.close()
 
-        deadline = time.time() + 10
-        while time.time() < deadline:
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
             with self.service.heartbeat_lock:
                 count = len(self.service.heartbeat_hosts_timestamp)
             if count >= NODE_COUNT:
@@ -209,11 +207,9 @@ class TestHeartbeatFilterPerformance(unittest.TestCase):
     """Test _filter_reachable_hosts performance at scale."""
 
     def setUp(self):
-        mock_config = Mock()
-        mock_config.get_config_value.return_value = 120
-        self.service = instanceha.InstanceHAService(mock_config)
+        self.service = instanceha.InstanceHAService(make_mock_config())
         self.service.heartbeat_hosts_timestamp.clear()
-        self.service.heartbeat_listener_start_time = time.time() - 300
+        self.service.heartbeat_listener_start_time = time.monotonic() - 300
 
     def _make_compute_svc(self, hostname):
         svc = Mock()
@@ -223,13 +219,13 @@ class TestHeartbeatFilterPerformance(unittest.TestCase):
     def test_1000_node_filter_performance(self):
         """Filter 10 down hosts against 1000-entry timestamp map in < 100ms."""
         for i in range(NODE_COUNT):
-            self.service.heartbeat_hosts_timestamp[f'compute-{i:04d}'] = time.time() - 10
+            self.service.heartbeat_hosts_timestamp[f'compute-{i:04d}'] = time.monotonic() - 10
 
         down_hosts = [self._make_compute_svc(f'compute-{i:04d}') for i in range(10)]
 
-        start = time.time()
+        start = time.monotonic()
         unreachable, skipped, _ = instanceha._filter_reachable_hosts(self.service, down_hosts)
-        elapsed_ms = (time.time() - start) * 1000
+        elapsed_ms = (time.monotonic() - start) * 1000
 
         self.assertEqual(len(skipped), 10)
         self.assertEqual(len(unreachable), 0)
@@ -240,9 +236,9 @@ class TestHeartbeatFilterPerformance(unittest.TestCase):
         """Worst case: all 1000 hosts are down with no heartbeats."""
         down_hosts = [self._make_compute_svc(f'compute-{i:04d}') for i in range(NODE_COUNT)]
 
-        start = time.time()
+        start = time.monotonic()
         unreachable, skipped, _ = instanceha._filter_reachable_hosts(self.service, down_hosts)
-        elapsed_ms = (time.time() - start) * 1000
+        elapsed_ms = (time.monotonic() - start) * 1000
 
         self.assertEqual(len(unreachable), NODE_COUNT)
         self.assertEqual(len(skipped), 0)
@@ -252,10 +248,10 @@ class TestHeartbeatFilterPerformance(unittest.TestCase):
     def test_filter_mixed_1000_hosts(self):
         """500 hosts with recent heartbeats, 500 without."""
         for i in range(500):
-            self.service.heartbeat_hosts_timestamp[f'compute-{i:04d}'] = time.time() - 10
+            self.service.heartbeat_hosts_timestamp[f'compute-{i:04d}'] = time.monotonic() - 10
 
         for i in range(500, NODE_COUNT):
-            self.service.heartbeat_hosts_timestamp[f'compute-{i:04d}'] = time.time() - 200
+            self.service.heartbeat_hosts_timestamp[f'compute-{i:04d}'] = time.monotonic() - 200
 
         down_hosts = [self._make_compute_svc(f'compute-{i:04d}') for i in range(NODE_COUNT)]
 
@@ -269,13 +265,11 @@ class TestHeartbeatCleanupAtScale(unittest.TestCase):
 
     def test_cleanup_above_threshold(self):
         """Populate entries exceeding threshold (half stale), verify cleanup works correctly."""
-        mock_config = Mock()
-        mock_config.get_config_value.return_value = 120
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
         service.heartbeat_hosts_timestamp.clear()
 
-        now = time.time()
-        half = instanceha.HEARTBEAT_CLEANUP_THRESHOLD
+        now = time.monotonic()
+        half = instanceha.UDP_CLEANUP_THRESHOLD
 
         for i in range(half + 1):
             service.heartbeat_hosts_timestamp[f'stale-{i:04d}'] = now - 700  # Older than 600s cleanup age
@@ -284,12 +278,12 @@ class TestHeartbeatCleanupAtScale(unittest.TestCase):
             service.heartbeat_hosts_timestamp[f'fresh-{i:04d}'] = now - 10
 
         total = len(service.heartbeat_hosts_timestamp)
-        self.assertGreater(total, instanceha.HEARTBEAT_CLEANUP_THRESHOLD)
+        self.assertGreater(total, instanceha.UDP_CLEANUP_THRESHOLD)
 
         # Simulate the cleanup logic from _udp_listener
         with service.heartbeat_lock:
-            if len(service.heartbeat_hosts_timestamp) > instanceha.HEARTBEAT_CLEANUP_THRESHOLD:
-                cutoff = time.time() - instanceha.HEARTBEAT_CLEANUP_AGE_SECONDS
+            if len(service.heartbeat_hosts_timestamp) > instanceha.UDP_CLEANUP_THRESHOLD:
+                cutoff = time.monotonic() - instanceha.HEARTBEAT_CLEANUP_AGE_SECONDS
                 to_remove = [k for k, v in service.heartbeat_hosts_timestamp.items() if v < cutoff]
                 for k in to_remove:
                     del service.heartbeat_hosts_timestamp[k]
@@ -300,22 +294,20 @@ class TestHeartbeatCleanupAtScale(unittest.TestCase):
 
     def test_no_cleanup_below_threshold(self):
         """Verify no cleanup happens when below the threshold."""
-        mock_config = Mock()
-        mock_config.get_config_value.return_value = 120
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
         service.heartbeat_hosts_timestamp.clear()
 
-        now = time.time()
-        count = instanceha.HEARTBEAT_CLEANUP_THRESHOLD - 1
+        now = time.monotonic()
+        count = instanceha.UDP_CLEANUP_THRESHOLD - 1
         for i in range(count):
             service.heartbeat_hosts_timestamp[f'stale-{i:04d}'] = now - 700
 
-        self.assertTrue(len(service.heartbeat_hosts_timestamp) <= instanceha.HEARTBEAT_CLEANUP_THRESHOLD)
+        self.assertTrue(len(service.heartbeat_hosts_timestamp) <= instanceha.UDP_CLEANUP_THRESHOLD)
 
         # Cleanup should NOT trigger
         with service.heartbeat_lock:
-            if len(service.heartbeat_hosts_timestamp) > instanceha.HEARTBEAT_CLEANUP_THRESHOLD:
-                cutoff = time.time() - instanceha.HEARTBEAT_CLEANUP_AGE_SECONDS
+            if len(service.heartbeat_hosts_timestamp) > instanceha.UDP_CLEANUP_THRESHOLD:
+                cutoff = time.monotonic() - instanceha.HEARTBEAT_CLEANUP_AGE_SECONDS
                 to_remove = [k for k, v in service.heartbeat_hosts_timestamp.items() if v < cutoff]
                 for k in to_remove:
                     del service.heartbeat_hosts_timestamp[k]
@@ -329,11 +321,9 @@ class TestConcurrentReadWriteAtScale(unittest.TestCase):
 
     def test_concurrent_writers_and_filter_readers(self):
         """1000 writer threads + 10 reader threads calling _filter_reachable_hosts."""
-        mock_config = Mock()
-        mock_config.get_config_value.return_value = 120
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
         service.heartbeat_hosts_timestamp.clear()
-        service.heartbeat_listener_start_time = time.time() - 300
+        service.heartbeat_listener_start_time = time.monotonic() - 300
 
         errors = []
 
@@ -341,7 +331,7 @@ class TestConcurrentReadWriteAtScale(unittest.TestCase):
             try:
                 hostname = f'compute-{thread_id:04d}'
                 with service.heartbeat_lock:
-                    service.heartbeat_hosts_timestamp[hostname] = time.time()
+                    service.heartbeat_hosts_timestamp[hostname] = time.monotonic()
             except Exception as e:
                 errors.append(f'writer-{thread_id}: {e}')
 
@@ -372,9 +362,7 @@ class TestConcurrentReadWriteAtScale(unittest.TestCase):
 
     def test_sustained_write_throughput(self):
         """Simulate sustained heartbeat rate: 1000 nodes * 10 heartbeats each."""
-        mock_config = Mock()
-        mock_config.get_config_value.return_value = 120
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
         service.heartbeat_hosts_timestamp.clear()
 
         errors = []
@@ -384,17 +372,17 @@ class TestConcurrentReadWriteAtScale(unittest.TestCase):
                 for iteration in range(10):
                     hostname = f'compute-{thread_id:04d}'
                     with service.heartbeat_lock:
-                        service.heartbeat_hosts_timestamp[hostname] = time.time()
+                        service.heartbeat_hosts_timestamp[hostname] = time.monotonic()
             except Exception as e:
                 errors.append(f'writer-{thread_id}: {e}')
 
-        start = time.time()
+        start = time.monotonic()
         threads = [threading.Thread(target=writer, args=(i,)) for i in range(NODE_COUNT)]
         for t in threads:
             t.start()
         for t in threads:
             t.join(timeout=30)
-        elapsed = time.time() - start
+        elapsed = time.monotonic() - start
 
         self.assertEqual(errors, [])
         self.assertEqual(len(service.heartbeat_hosts_timestamp), NODE_COUNT)

--- a/test/instanceha/test_helper_functions.py
+++ b/test/instanceha/test_helper_functions.py
@@ -14,7 +14,7 @@ from unittest.mock import Mock, patch, MagicMock
 from datetime import datetime
 from collections import defaultdict
 
-import conftest  # noqa: F401
+from conftest import make_mock_config  # noqa: F401
 import instanceha
 
 
@@ -23,8 +23,7 @@ class TestCleanupFilteredHosts(unittest.TestCase):
 
     def test_cleanup_filtered_hosts_basic(self):
         """Test basic cleanup of filtered hosts."""
-        mock_config = Mock()
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
 
         current_time = time.time()
 
@@ -50,8 +49,7 @@ class TestCleanupFilteredHosts(unittest.TestCase):
 
     def test_cleanup_filtered_hosts_empty_sets(self):
         """Test cleanup with empty sets."""
-        mock_config = Mock()
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
 
         current_time = time.time()
         marked_hostnames = set()
@@ -64,8 +62,7 @@ class TestCleanupFilteredHosts(unittest.TestCase):
 
     def test_cleanup_filtered_hosts_no_cleanup_needed(self):
         """Test cleanup when all marked hosts are finalized."""
-        mock_config = Mock()
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
 
         current_time = time.time()
         service.hosts_processing['host1'] = current_time
@@ -82,8 +79,7 @@ class TestCleanupFilteredHosts(unittest.TestCase):
 
     def test_cleanup_filtered_hosts_thread_safety(self):
         """Test that cleanup works correctly with threading lock."""
-        mock_config = Mock()
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
 
         current_time = time.time()
         service.hosts_processing['host1'] = current_time
@@ -106,9 +102,7 @@ class TestFilterProcessingHosts(unittest.TestCase):
 
     def test_filter_processing_hosts_basic(self):
         """Test basic filtering of hosts already being processed."""
-        mock_config = Mock()
-        mock_config.get_config_value = Mock(return_value=30)  # FENCING_TIMEOUT
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
 
         # Create mock services
         svc1 = Mock()
@@ -140,9 +134,7 @@ class TestFilterProcessingHosts(unittest.TestCase):
 
     def test_filter_processing_hosts_expired_entries(self):
         """Test that expired processing entries are cleaned up."""
-        mock_config = Mock()
-        mock_config.get_config_value = Mock(return_value=30)  # FENCING_TIMEOUT
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
 
         # Add an expired entry (more than max timeout + padding ago)
         old_time = time.monotonic() - 500  # Way in the past
@@ -160,9 +152,7 @@ class TestFilterProcessingHosts(unittest.TestCase):
 
     def test_filter_processing_hosts_marks_new_hosts(self):
         """Test that new hosts are marked as being processed."""
-        mock_config = Mock()
-        mock_config.get_config_value = Mock(return_value=30)
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
 
         svc1 = Mock()
         svc1.host = 'host1.example.com'
@@ -185,9 +175,7 @@ class TestFilterProcessingHosts(unittest.TestCase):
 
     def test_filter_processing_hosts_empty_lists(self):
         """Test filtering with empty lists."""
-        mock_config = Mock()
-        mock_config.get_config_value = Mock(return_value=30)
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
 
         result = instanceha._filter_processing_hosts(service, [], [])
         compute_filtered, resume_filtered, marked, current_time = result
@@ -198,9 +186,7 @@ class TestFilterProcessingHosts(unittest.TestCase):
 
     def test_filter_processing_hosts_resume_list(self):
         """Test filtering works correctly for resume list."""
-        mock_config = Mock()
-        mock_config.get_config_value = Mock(return_value=30)
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
 
         # Mark a host as being processed
         service.hosts_processing['resume-host'] = time.monotonic()
@@ -223,16 +209,9 @@ class TestPrepareEvacuationResources(unittest.TestCase):
     def test_prepare_evacuation_resources_basic(self):
         """Test basic resource preparation for evacuation."""
         mock_conn = Mock()
-        mock_config = Mock()
-        config_values = {
-            'RESERVED_HOSTS': False,
-            'TAGGED_IMAGES': False,
-            'TAGGED_FLAVORS': False,
-            'TAGGED_AGGREGATES': False
-        }
-        mock_config.get_config_value = Mock(side_effect=lambda key: config_values.get(key, False))
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config(
+            RESERVED_HOSTS=False, TAGGED_IMAGES=False,
+            TAGGED_FLAVORS=False, TAGGED_AGGREGATES=False))
 
         # Create mock services
         svc1 = Mock()
@@ -263,8 +242,7 @@ class TestPrepareEvacuationResources(unittest.TestCase):
     def test_prepare_evacuation_resources_empty_compute_nodes(self):
         """Test preparation with no compute nodes."""
         mock_conn = Mock()
-        mock_config = Mock()
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
 
         result = instanceha._prepare_evacuation_resources(mock_conn, service, [], [])
         nodes, reserved, images, flavors = result
@@ -277,16 +255,9 @@ class TestPrepareEvacuationResources(unittest.TestCase):
     def test_prepare_evacuation_resources_with_reserved_hosts(self):
         """Test resource preparation with RESERVED_HOSTS enabled."""
         mock_conn = Mock()
-        mock_config = Mock()
-        config_values = {
-            'RESERVED_HOSTS': True,
-            'TAGGED_IMAGES': False,
-            'TAGGED_FLAVORS': False,
-            'TAGGED_AGGREGATES': False
-        }
-        mock_config.get_config_value = Mock(side_effect=lambda key: config_values.get(key, False))
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config(
+            RESERVED_HOSTS=True, TAGGED_IMAGES=False,
+            TAGGED_FLAVORS=False, TAGGED_AGGREGATES=False))
 
         # Create services including reserved host
         svc1 = Mock()
@@ -316,16 +287,9 @@ class TestPrepareEvacuationResources(unittest.TestCase):
     def test_prepare_evacuation_resources_with_tagged_resources(self):
         """Test resource preparation with tagged images and flavors."""
         mock_conn = Mock()
-        mock_config = Mock()
-        config_values = {
-            'RESERVED_HOSTS': False,
-            'TAGGED_IMAGES': True,
-            'TAGGED_FLAVORS': True,
-            'TAGGED_AGGREGATES': False
-        }
-        mock_config.get_config_value = Mock(side_effect=lambda key: config_values.get(key, False))
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config(
+            RESERVED_HOSTS=False, TAGGED_IMAGES=True,
+            TAGGED_FLAVORS=True, TAGGED_AGGREGATES=False))
 
         # Create mock compute node
         svc1 = Mock()
@@ -356,16 +320,9 @@ class TestPrepareEvacuationResources(unittest.TestCase):
     def test_prepare_evacuation_resources_filters_no_servers(self):
         """Test that hosts without servers are filtered out."""
         mock_conn = Mock()
-        mock_config = Mock()
-        config_values = {
-            'RESERVED_HOSTS': False,
-            'TAGGED_IMAGES': False,
-            'TAGGED_FLAVORS': False,
-            'TAGGED_AGGREGATES': False
-        }
-        mock_config.get_config_value = Mock(side_effect=lambda key: config_values.get(key, False))
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config(
+            RESERVED_HOSTS=False, TAGGED_IMAGES=False,
+            TAGGED_FLAVORS=False, TAGGED_AGGREGATES=False))
 
         svc1 = Mock()
         svc1.host = 'host-with-servers'
@@ -394,10 +351,7 @@ class TestCountEvacuableHosts(unittest.TestCase):
     def test_count_evacuable_hosts_basic(self):
         """Test basic counting of evacuable hosts."""
         mock_conn = Mock()
-        mock_config = Mock()
-        mock_config.get_config_value = Mock(return_value='evacuable')
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
         service.evacuable_tag = 'evacuable'
 
         # Create mock aggregates
@@ -427,10 +381,7 @@ class TestCountEvacuableHosts(unittest.TestCase):
     def test_count_evacuable_hosts_no_aggregates(self):
         """Test counting when there are no aggregates."""
         mock_conn = Mock()
-        mock_config = Mock()
-        mock_config.get_config_value = Mock(return_value='evacuable')
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
         service.evacuable_tag = 'evacuable'
 
         mock_conn.aggregates.list.return_value = []
@@ -446,8 +397,7 @@ class TestCountEvacuableHosts(unittest.TestCase):
     def test_count_evacuable_hosts_exception_handling(self):
         """Test that exceptions are handled gracefully."""
         mock_conn = Mock()
-        mock_config = Mock()
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
 
         # Simulate exception when listing aggregates
         mock_conn.aggregates.list.side_effect = Exception("API Error")
@@ -464,10 +414,7 @@ class TestCountEvacuableHosts(unittest.TestCase):
     def test_count_evacuable_hosts_multiple_aggregates(self):
         """Test counting with hosts in multiple aggregates."""
         mock_conn = Mock()
-        mock_config = Mock()
-        mock_config.get_config_value = Mock(return_value='evacuable')
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
         service.evacuable_tag = 'evacuable'
 
         # Create overlapping aggregates

--- a/test/instanceha/test_ipv6_udp.py
+++ b/test/instanceha/test_ipv6_udp.py
@@ -21,7 +21,7 @@ from collections import defaultdict
 
 logging.getLogger().setLevel(logging.CRITICAL)
 
-import conftest  # noqa: F401
+from conftest import make_mock_config  # noqa: F401
 import instanceha
 
 logging.getLogger().setLevel(logging.CRITICAL)
@@ -87,9 +87,7 @@ class TestHeartbeatIPv6(unittest.TestCase):
     """Test heartbeat UDP listener receives packets over IPv6."""
 
     def setUp(self):
-        mock_config = Mock()
-        mock_config.get_config_value.return_value = 120
-        self.service = instanceha.InstanceHAService(mock_config)
+        self.service = instanceha.InstanceHAService(make_mock_config())
         self.service.heartbeat_hosts_timestamp.clear()
         self.service.heartbeat_listener_stop_event = threading.Event()
         self.service.udp_ip = '::1'
@@ -124,7 +122,7 @@ class TestHeartbeatIPv6(unittest.TestCase):
                 lock=self.service.heartbeat_lock,
                 timestamps=self.service.heartbeat_hosts_timestamp,
                 stop_event=self.service.heartbeat_listener_stop_event,
-                cleanup_threshold=instanceha.HEARTBEAT_CLEANUP_THRESHOLD,
+                cleanup_threshold=instanceha.UDP_CLEANUP_THRESHOLD,
                 cleanup_age_seconds=instanceha.HEARTBEAT_CLEANUP_AGE_SECONDS,
                 resolve_hostname=lambda data, addr, label: instanceha._resolve_hostname_packet(data, addr, label, hmac_keys=self.service.heartbeat_hmac_keys),
                 log_level=logging.DEBUG,
@@ -166,7 +164,7 @@ class TestHeartbeatIPv6(unittest.TestCase):
                 lock=self.service.heartbeat_lock,
                 timestamps=self.service.heartbeat_hosts_timestamp,
                 stop_event=self.service.heartbeat_listener_stop_event,
-                cleanup_threshold=instanceha.HEARTBEAT_CLEANUP_THRESHOLD,
+                cleanup_threshold=instanceha.UDP_CLEANUP_THRESHOLD,
                 cleanup_age_seconds=instanceha.HEARTBEAT_CLEANUP_AGE_SECONDS,
                 resolve_hostname=lambda data, addr, label: instanceha._resolve_hostname_packet(data, addr, label, hmac_keys=self.service.heartbeat_hmac_keys),
                 log_level=logging.DEBUG,
@@ -209,7 +207,7 @@ class TestHeartbeatIPv6(unittest.TestCase):
                 lock=self.service.heartbeat_lock,
                 timestamps=self.service.heartbeat_hosts_timestamp,
                 stop_event=self.service.heartbeat_listener_stop_event,
-                cleanup_threshold=instanceha.HEARTBEAT_CLEANUP_THRESHOLD,
+                cleanup_threshold=instanceha.UDP_CLEANUP_THRESHOLD,
                 cleanup_age_seconds=instanceha.HEARTBEAT_CLEANUP_AGE_SECONDS,
                 resolve_hostname=lambda data, addr, label: instanceha._resolve_hostname_packet(data, addr, label, hmac_keys=self.service.heartbeat_hmac_keys),
                 log_level=logging.DEBUG,
@@ -241,9 +239,7 @@ class TestKdumpIPv6(unittest.TestCase):
     """Test kdump UDP listener receives packets over IPv6."""
 
     def setUp(self):
-        mock_config = Mock()
-        mock_config.get_config_value.return_value = 30
-        self.service = instanceha.InstanceHAService(mock_config)
+        self.service = instanceha.InstanceHAService(make_mock_config())
         self.service.kdump_hosts_timestamp.clear()
         self.service.kdump_listener_stop_event = threading.Event()
         self.service.udp_ip = '::1'
@@ -280,7 +276,7 @@ class TestKdumpIPv6(unittest.TestCase):
                 lock=self.service.kdump_lock,
                 timestamps=self.service.kdump_hosts_timestamp,
                 stop_event=self.service.kdump_listener_stop_event,
-                cleanup_threshold=instanceha.KDUMP_CLEANUP_THRESHOLD,
+                cleanup_threshold=instanceha.UDP_CLEANUP_THRESHOLD,
                 cleanup_age_seconds=instanceha.KDUMP_CLEANUP_AGE_SECONDS,
                 resolve_hostname=self._mock_resolve,
                 on_start=listener_started.set,
@@ -325,7 +321,7 @@ class TestKdumpIPv6(unittest.TestCase):
                 lock=self.service.kdump_lock,
                 timestamps=self.service.kdump_hosts_timestamp,
                 stop_event=self.service.kdump_listener_stop_event,
-                cleanup_threshold=instanceha.KDUMP_CLEANUP_THRESHOLD,
+                cleanup_threshold=instanceha.UDP_CLEANUP_THRESHOLD,
                 cleanup_age_seconds=instanceha.KDUMP_CLEANUP_AGE_SECONDS,
                 resolve_hostname=counting_resolve,
                 on_start=listener_started.set,
@@ -366,7 +362,7 @@ class TestKdumpIPv6(unittest.TestCase):
                 lock=self.service.kdump_lock,
                 timestamps=self.service.kdump_hosts_timestamp,
                 stop_event=self.service.kdump_listener_stop_event,
-                cleanup_threshold=instanceha.KDUMP_CLEANUP_THRESHOLD,
+                cleanup_threshold=instanceha.UDP_CLEANUP_THRESHOLD,
                 cleanup_age_seconds=instanceha.KDUMP_CLEANUP_AGE_SECONDS,
                 resolve_hostname=self._mock_resolve,
                 on_start=listener_started.set,
@@ -397,9 +393,7 @@ class TestDualStackListener(unittest.TestCase):
     """Test that :: wildcard accepts both IPv4 and IPv6 packets."""
 
     def setUp(self):
-        mock_config = Mock()
-        mock_config.get_config_value.return_value = 120
-        self.service = instanceha.InstanceHAService(mock_config)
+        self.service = instanceha.InstanceHAService(make_mock_config())
         self.service.heartbeat_hosts_timestamp.clear()
         self.service.heartbeat_listener_stop_event = threading.Event()
         self.service.udp_ip = ''
@@ -430,7 +424,7 @@ class TestDualStackListener(unittest.TestCase):
                 lock=self.service.heartbeat_lock,
                 timestamps=self.service.heartbeat_hosts_timestamp,
                 stop_event=self.service.heartbeat_listener_stop_event,
-                cleanup_threshold=instanceha.HEARTBEAT_CLEANUP_THRESHOLD,
+                cleanup_threshold=instanceha.UDP_CLEANUP_THRESHOLD,
                 cleanup_age_seconds=instanceha.HEARTBEAT_CLEANUP_AGE_SECONDS,
                 resolve_hostname=lambda data, addr, label: instanceha._resolve_hostname_packet(data, addr, label, hmac_keys=self.service.heartbeat_hmac_keys),
                 log_level=logging.DEBUG,
@@ -476,7 +470,7 @@ class TestDualStackListener(unittest.TestCase):
                 lock=self.service.heartbeat_lock,
                 timestamps=self.service.heartbeat_hosts_timestamp,
                 stop_event=self.service.heartbeat_listener_stop_event,
-                cleanup_threshold=instanceha.HEARTBEAT_CLEANUP_THRESHOLD,
+                cleanup_threshold=instanceha.UDP_CLEANUP_THRESHOLD,
                 cleanup_age_seconds=instanceha.HEARTBEAT_CLEANUP_AGE_SECONDS,
                 resolve_hostname=lambda data, addr, label: instanceha._resolve_hostname_packet(data, addr, label, hmac_keys=self.service.heartbeat_hmac_keys),
                 log_level=logging.DEBUG,

--- a/test/instanceha/test_k8s_events.py
+++ b/test/instanceha/test_k8s_events.py
@@ -226,6 +226,24 @@ class TestEmitK8sEvent(unittest.TestCase):
 
         self.assertEqual(mock_post.call_args[1]['timeout'], 5)
 
+    @patch('instanceha.requests.post')
+    @patch('instanceha._get_k8s_credentials', return_value=('token123', 'openstack'))
+    @patch.dict(os.environ, {'INSTANCEHA_CR_NAME': 'instanceha', 'POD_NAME': 'instanceha-0'})
+    def test_auto_sanitizes_credentials_from_message(self, mock_creds, mock_post):
+        mock_response = Mock()
+        mock_response.status_code = 201
+        mock_post.return_value = mock_response
+
+        instanceha._emit_k8s_event(
+            'compute-0', 'FencingFailed',
+            'Error: password=hunter2 auth failed',
+            event_type='Warning',
+        )
+
+        event = mock_post.call_args[1]['json']
+        self.assertNotIn('hunter2', event['message'])
+        self.assertIn('***', event['message'])
+
 
 class TestProcessServiceEvents(unittest.TestCase):
     """Tests that process_service emits events at key lifecycle points."""
@@ -258,7 +276,7 @@ class TestProcessServiceEvents(unittest.TestCase):
     @patch('instanceha._manage_reserved_hosts')
     @patch('instanceha._host_disable', return_value=True)
     @patch('instanceha._host_fence', return_value=True)
-    @patch('instanceha._get_nova_connection')
+    @patch('instanceha._establish_nova_connection')
     def test_emits_events_on_successful_workflow(self, mock_conn, mock_fence,
                                                   mock_disable, mock_reserved,
                                                   mock_evacuate, mock_recovery,
@@ -281,7 +299,7 @@ class TestProcessServiceEvents(unittest.TestCase):
 
     @patch('instanceha._emit_k8s_event')
     @patch('instanceha._host_fence', return_value=False)
-    @patch('instanceha._get_nova_connection')
+    @patch('instanceha._establish_nova_connection')
     def test_emits_fencing_failed_event(self, mock_conn, mock_fence, mock_event):
         mock_conn.return_value = Mock()
         service = self._make_service()
@@ -300,7 +318,7 @@ class TestProcessServiceEvents(unittest.TestCase):
     @patch('instanceha._manage_reserved_hosts')
     @patch('instanceha._host_disable', return_value=True)
     @patch('instanceha._host_fence', return_value=True)
-    @patch('instanceha._get_nova_connection')
+    @patch('instanceha._establish_nova_connection')
     def test_emits_evacuation_failed_event(self, mock_conn, mock_fence,
                                            mock_disable, mock_reserved,
                                            mock_evacuate, mock_event):
@@ -322,7 +340,7 @@ class TestProcessServiceEvents(unittest.TestCase):
     @patch('instanceha._host_evacuate', return_value=True)
     @patch('instanceha._manage_reserved_hosts')
     @patch('instanceha._host_disable', return_value=True)
-    @patch('instanceha._get_nova_connection')
+    @patch('instanceha._establish_nova_connection')
     def test_skips_fencing_events_on_resume(self, mock_conn, mock_disable,
                                             mock_reserved, mock_evacuate,
                                             mock_recovery, mock_event):
@@ -340,7 +358,7 @@ class TestProcessServiceEvents(unittest.TestCase):
         self.assertIn('EvacuationStarted', event_reasons)
 
     @patch('instanceha._emit_k8s_event')
-    @patch('instanceha._get_nova_connection', side_effect=Exception("boom"))
+    @patch('instanceha._establish_nova_connection', side_effect=Exception("boom"))
     def test_emits_processing_failed_on_exception(self, mock_conn, mock_event):
         service = self._make_service()
         failed_svc = self._make_failed_service()

--- a/test/instanceha/test_kdump_detection.py
+++ b/test/instanceha/test_kdump_detection.py
@@ -30,7 +30,7 @@ from io import StringIO
 # Suppress configuration warnings during testing
 logging.getLogger().setLevel(logging.CRITICAL)
 
-import conftest  # noqa: F401
+from conftest import make_mock_config  # noqa: F401
 import instanceha
 
 # Re-suppress logging after import (instanceha sets its own level)
@@ -50,10 +50,7 @@ class TestKdumpFunctionality(unittest.TestCase):
         self.mock_service.config.get_udp_port.return_value = 7410
 
         # Create a mock service for kdump testing with proper config
-        mock_config = Mock()
-        mock_config.get_config_value.return_value = 10  # KDUMP_TIMEOUT
-        mock_config.get_workers.return_value = 4
-        self.mock_service_instance = instanceha.InstanceHAService(mock_config)
+        self.mock_service_instance = instanceha.InstanceHAService(make_mock_config(KDUMP_TIMEOUT=10))
         self.mock_service_instance.kdump_hosts_timestamp.clear()
 
     def tearDown(self):
@@ -83,7 +80,7 @@ class TestKdumpFunctionality(unittest.TestCase):
         mock_service1.host = 'compute-01.example.com'
 
         # Set recent kdump timestamp
-        self.mock_service_instance.kdump_hosts_timestamp['compute-01'] = time.time() - 5
+        self.mock_service_instance.kdump_hosts_timestamp['compute-01'] = time.monotonic() - 5
 
         to_evacuate, kdump_fenced = instanceha._check_kdump([mock_service1], self.mock_service_instance)
         self.assertEqual(len(to_evacuate), 0)  # Host should NOT be in to_evacuate (kdump-fenced separately)
@@ -123,13 +120,13 @@ class TestKdumpFunctionality(unittest.TestCase):
     def test_kdump_timestamp_cleanup(self):
         """Test automatic cleanup of old kdump timestamps."""
         # Add old timestamps
-        old_time = time.time() - 400  # Older than 300s cleanup threshold
+        old_time = time.monotonic() - 400  # Older than 300s cleanup threshold
         self.mock_service_instance.kdump_hosts_timestamp['old-host'] = old_time
-        self.mock_service_instance.kdump_hosts_timestamp['recent-host'] = time.time()
+        self.mock_service_instance.kdump_hosts_timestamp['recent-host'] = time.monotonic()
 
         # Simulate cleanup logic
         if len(self.mock_service_instance.kdump_hosts_timestamp) > 0:  # Simplified condition for test
-            cutoff = time.time() - 300
+            cutoff = time.monotonic() - 300
             old_keys = [k for k, v in self.mock_service_instance.kdump_hosts_timestamp.items() if v < cutoff]
             for k in old_keys:
                 del self.mock_service_instance.kdump_hosts_timestamp[k]
@@ -147,11 +144,11 @@ class TestKdumpFunctionality(unittest.TestCase):
         services = [mock_service1, mock_service2]
 
         # Create a service instance for this test
-        mock_service_instance = instanceha.InstanceHAService(Mock())
+        mock_service_instance = instanceha.InstanceHAService(make_mock_config())
         mock_service_instance.config = self.mock_service.config
 
         # First host has kdump message, second does not
-        mock_service_instance.kdump_hosts_timestamp['compute-01'] = time.time() - 5
+        mock_service_instance.kdump_hosts_timestamp['compute-01'] = time.monotonic() - 5
 
         to_evacuate, kdump_fenced = instanceha._check_kdump(services, mock_service_instance)
 
@@ -169,11 +166,11 @@ class TestKdumpFunctionality(unittest.TestCase):
         mock_service.host = 'compute-01.example.com'
 
         # Create a service instance for this test
-        mock_service_instance = instanceha.InstanceHAService(Mock())
+        mock_service_instance = instanceha.InstanceHAService(make_mock_config())
         mock_service_instance.config = self.mock_service.config
 
         # Set checking timestamp beyond timeout (default 30s) - simulates waiting period expired
-        mock_service_instance.kdump_hosts_checking['compute-01'] = time.time() - 35
+        mock_service_instance.kdump_hosts_checking['compute-01'] = time.monotonic() - 35
 
         to_evacuate, kdump_fenced = instanceha._check_kdump([mock_service], mock_service_instance)
         self.assertEqual(len(to_evacuate), 1)  # Host should be evacuated (timeout expired, no kdump)
@@ -191,7 +188,7 @@ class TestKdumpFunctionality(unittest.TestCase):
 
         # Mark host as kdump fenced — power-on should be skipped
         # because the host is still dumping memory
-        mock_service_instance = instanceha.InstanceHAService(Mock())
+        mock_service_instance = instanceha.InstanceHAService(make_mock_config())
         mock_service_instance.config.get_config_value.return_value = False
         mock_service_instance.kdump_fenced_hosts.add('compute-01')
 
@@ -210,7 +207,7 @@ class TestKdumpFunctionality(unittest.TestCase):
         mock_service_obj.id = 'service-123'
         mock_service_obj.status = 'disabled'
 
-        mock_service_instance = instanceha.InstanceHAService(Mock())
+        mock_service_instance = instanceha.InstanceHAService(make_mock_config())
         mock_service_instance.config.get_config_value.return_value = False
 
         with patch('instanceha._host_fence', return_value=True) as mock_fence:
@@ -222,16 +219,16 @@ class TestKdumpFunctionality(unittest.TestCase):
 
     def test_kdump_fenced_hosts_cleanup_on_recovery(self):
         """Test that kdump_hosts_checking is cleaned up after recovery for kdump-fenced hosts."""
-        mock_service_instance = instanceha.InstanceHAService(Mock())
+        mock_service_instance = instanceha.InstanceHAService(make_mock_config())
         mock_service_instance.config.get_config_value.return_value = False
 
         # Two kdump-fenced hosts; only compute-01 will be recovered
         mock_service_instance.kdump_fenced_hosts.add('compute-01')
         mock_service_instance.kdump_fenced_hosts.add('compute-02')
-        mock_service_instance.kdump_hosts_timestamp['compute-01'] = time.time()
-        mock_service_instance.kdump_hosts_timestamp['compute-02'] = time.time()
-        mock_service_instance.kdump_hosts_checking['compute-01'] = time.time()
-        mock_service_instance.kdump_hosts_checking['compute-02'] = time.time()
+        mock_service_instance.kdump_hosts_timestamp['compute-01'] = time.monotonic()
+        mock_service_instance.kdump_hosts_timestamp['compute-02'] = time.monotonic()
+        mock_service_instance.kdump_hosts_checking['compute-01'] = time.monotonic()
+        mock_service_instance.kdump_hosts_checking['compute-02'] = time.monotonic()
 
         mock_conn = Mock()
         mock_service_obj = Mock()
@@ -253,7 +250,7 @@ class TestKdumpFunctionality(unittest.TestCase):
         mock_service.id = 'service-123'
         mock_service.host = 'compute-01.example.com'
 
-        mock_service_instance = instanceha.InstanceHAService(Mock())
+        mock_service_instance = instanceha.InstanceHAService(make_mock_config())
         mock_service_instance.kdump_fenced_hosts.add('compute-01')
 
         result = instanceha._host_disable(mock_conn, mock_service, mock_service_instance)
@@ -267,14 +264,9 @@ class TestKdumpFunctionality(unittest.TestCase):
     def test_kdump_reenable_delay_recent_message(self):
         """Test that re-enablement is delayed when kdump messages are recent."""
         mock_conn = Mock()
-        mock_config = Mock()
-        mock_config.get_config_value.side_effect = lambda key: {
-            'LEAVE_DISABLED': False, 'FORCE_ENABLE': False,
-        }.get(key, Mock())
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
         # 30s ago — under the 60s kdump cooldown threshold
-        service.kdump_hosts_timestamp['compute-01'] = time.time() - 30
+        service.kdump_hosts_timestamp['compute-01'] = time.monotonic() - 30
 
         mock_svc = Mock()
         mock_svc.host = 'compute-01.example.com'
@@ -293,14 +285,9 @@ class TestKdumpFunctionality(unittest.TestCase):
     def test_kdump_reenable_allowed_after_delay(self):
         """Test that re-enablement proceeds after 60s delay from last kdump message."""
         mock_conn = Mock()
-        mock_config = Mock()
-        mock_config.get_config_value.side_effect = lambda key: {
-            'LEAVE_DISABLED': False, 'FORCE_ENABLE': False,
-        }.get(key, Mock())
-
-        service = instanceha.InstanceHAService(mock_config)
+        service = instanceha.InstanceHAService(make_mock_config())
         # 65s ago — past the 60s kdump cooldown threshold
-        service.kdump_hosts_timestamp['compute-01'] = time.time() - 65
+        service.kdump_hosts_timestamp['compute-01'] = time.monotonic() - 65
 
         mock_svc = Mock()
         mock_svc.host = 'compute-01.example.com'
@@ -324,9 +311,9 @@ class TestKdumpFunctionality(unittest.TestCase):
         mock_service.host = 'compute-01.example.com'
         mock_service.disabled_reason = 'instanceha evacuation (kdump): 2025-01-01'
 
-        service_instance = instanceha.InstanceHAService(Mock())
+        service_instance = instanceha.InstanceHAService(make_mock_config())
         service_instance.kdump_fenced_hosts.add('compute-01')
-        service_instance.kdump_hosts_timestamp['compute-01'] = time.time()
+        service_instance.kdump_hosts_timestamp['compute-01'] = time.monotonic()
 
         result = instanceha._host_enable(mock_conn, mock_service, reenable=True, service=service_instance)
 
@@ -401,13 +388,10 @@ class TestKdumpIntegration(unittest.TestCase):
         services = [mock_service1, mock_service2]
 
         # Create a service instance for this test
-        mock_config = Mock()
-        mock_config.get_config_value.return_value = 10  # KDUMP_TIMEOUT
-        mock_config.get_workers.return_value = 4
-        mock_service_instance = instanceha.InstanceHAService(mock_config)
+        mock_service_instance = instanceha.InstanceHAService(make_mock_config(KDUMP_TIMEOUT=10))
 
         # Simulate one host kdumping, one not
-        mock_service_instance.kdump_hosts_timestamp['compute-01'] = time.time() - 5
+        mock_service_instance.kdump_hosts_timestamp['compute-01'] = time.monotonic() - 5
 
         to_evacuate, kdump_fenced = instanceha._check_kdump(services, mock_service_instance)
 
@@ -421,11 +405,11 @@ class TestKdumpIntegration(unittest.TestCase):
         """Test thread safety of kdump operations."""
         # Simulate concurrent access to kdump_hosts_timestamp
         # Create a service instance for this test
-        mock_service_instance = instanceha.InstanceHAService(Mock())
+        mock_service_instance = instanceha.InstanceHAService(make_mock_config())
 
         def update_timestamp(host_id):
             for i in range(10):
-                mock_service_instance.kdump_hosts_timestamp[f'host-{host_id}-{i}'] = time.time()
+                mock_service_instance.kdump_hosts_timestamp[f'host-{host_id}-{i}'] = time.monotonic()
 
         threads = []
         for i in range(3):
@@ -442,21 +426,21 @@ class TestKdumpIntegration(unittest.TestCase):
     def test_kdump_memory_management(self):
         """Test memory management and cleanup."""
         # Create a service instance for this test
-        mock_service_instance = instanceha.InstanceHAService(Mock())
+        mock_service_instance = instanceha.InstanceHAService(make_mock_config())
 
         # Add many old entries
-        old_time = time.time() - 400
+        old_time = time.monotonic() - 400
         for i in range(150):
             mock_service_instance.kdump_hosts_timestamp[f'old-host-{i}'] = old_time
 
         # Add some recent entries
-        recent_time = time.time()
+        recent_time = time.monotonic()
         for i in range(10):
             mock_service_instance.kdump_hosts_timestamp[f'recent-host-{i}'] = recent_time
 
         # Simulate cleanup when > 100 entries
         if len(mock_service_instance.kdump_hosts_timestamp) > 100:
-            cutoff = time.time() - 300
+            cutoff = time.monotonic() - 300
             old_keys = [k for k, v in mock_service_instance.kdump_hosts_timestamp.items() if v < cutoff]
             for k in old_keys:
                 del mock_service_instance.kdump_hosts_timestamp[k]
@@ -473,10 +457,10 @@ class TestKdumpIntegration(unittest.TestCase):
         failed_service.forced_down = False
         failed_service.status = 'enabled'
 
-        mock_service_instance = instanceha.InstanceHAService(Mock())
+        mock_service_instance = instanceha.InstanceHAService(make_mock_config())
         mock_service_instance.kdump_fenced_hosts.add('compute-01')
 
-        with unittest.mock.patch('instanceha._get_nova_connection') as mock_conn_func, \
+        with unittest.mock.patch('instanceha._establish_nova_connection') as mock_conn_func, \
              unittest.mock.patch('instanceha._host_fence') as mock_fence, \
              unittest.mock.patch('instanceha._host_disable') as mock_disable, \
              unittest.mock.patch('instanceha._manage_reserved_hosts', return_value=instanceha.ReservedHostResult(success=True, hostname=None)), \
@@ -506,9 +490,9 @@ class TestKdumpIntegration(unittest.TestCase):
         failed_service.forced_down = True
         failed_service.status = 'disabled'
 
-        mock_service_instance = instanceha.InstanceHAService(Mock())
+        mock_service_instance = instanceha.InstanceHAService(make_mock_config())
 
-        with unittest.mock.patch('instanceha._get_nova_connection') as mock_conn_func, \
+        with unittest.mock.patch('instanceha._establish_nova_connection') as mock_conn_func, \
              unittest.mock.patch('instanceha._host_fence') as mock_fence, \
              unittest.mock.patch('instanceha._host_disable') as mock_disable, \
              unittest.mock.patch('instanceha._manage_reserved_hosts', return_value=instanceha.ReservedHostResult(success=True, hostname=None)), \
@@ -537,9 +521,9 @@ class TestKdumpIntegration(unittest.TestCase):
         failed_service.forced_down = False
         failed_service.status = 'enabled'
 
-        mock_service_instance = instanceha.InstanceHAService(Mock())
+        mock_service_instance = instanceha.InstanceHAService(make_mock_config())
 
-        with unittest.mock.patch('instanceha._get_nova_connection') as mock_conn_func, \
+        with unittest.mock.patch('instanceha._establish_nova_connection') as mock_conn_func, \
              unittest.mock.patch('instanceha._host_fence') as mock_fence, \
              unittest.mock.patch('instanceha._host_disable') as mock_disable, \
              unittest.mock.patch('instanceha._manage_reserved_hosts', return_value=instanceha.ReservedHostResult(success=True, hostname=None)), \
@@ -570,9 +554,9 @@ class TestKdumpIntegration(unittest.TestCase):
         failed_service.forced_down = True
         failed_service.status = 'enabled'  # Edge case: forced_down but not disabled
 
-        mock_service_instance = instanceha.InstanceHAService(Mock())
+        mock_service_instance = instanceha.InstanceHAService(make_mock_config())
 
-        with unittest.mock.patch('instanceha._get_nova_connection') as mock_conn_func, \
+        with unittest.mock.patch('instanceha._establish_nova_connection') as mock_conn_func, \
              unittest.mock.patch('instanceha._host_disable') as mock_disable, \
              unittest.mock.patch('instanceha._manage_reserved_hosts', return_value=instanceha.ReservedHostResult(success=True, hostname=None)), \
              unittest.mock.patch('instanceha._host_evacuate', return_value=True), \
@@ -598,7 +582,7 @@ class TestKdumpIntegration(unittest.TestCase):
         failed_service.id = 'service-123'
         failed_service.status = 'enabled'
 
-        mock_service_instance = instanceha.InstanceHAService(Mock())
+        mock_service_instance = instanceha.InstanceHAService(make_mock_config())
         mock_service_instance.config.get_config_value.return_value = False
 
         # Service status='enabled' simulates a stale cached object — the host was
@@ -625,7 +609,7 @@ class TestKdumpIntegration(unittest.TestCase):
         failed_service.id = 'service-123'
         failed_service.status = 'disabled'
 
-        mock_service_instance = instanceha.InstanceHAService(Mock())
+        mock_service_instance = instanceha.InstanceHAService(make_mock_config())
         mock_service_instance.config.get_config_value.return_value = False
         mock_service_instance.kdump_fenced_hosts.add('compute-01')
 

--- a/test/instanceha/test_thread_safety.py
+++ b/test/instanceha/test_thread_safety.py
@@ -37,7 +37,7 @@ class TestKdumpLock(unittest.TestCase):
                 for i in range(50):
                     hostname = f'host-{thread_id}-{i}'
                     with self.service.kdump_lock:
-                        self.service.kdump_hosts_timestamp[hostname] = time.time()
+                        self.service.kdump_hosts_timestamp[hostname] = time.monotonic()
             except Exception as e:
                 errors.append(str(e))
 
@@ -57,7 +57,7 @@ class TestKdumpLock(unittest.TestCase):
 
         with self.service.kdump_lock:
             for i in range(100):
-                self.service.kdump_hosts_timestamp[f'host-{i}'] = time.time()
+                self.service.kdump_hosts_timestamp[f'host-{i}'] = time.monotonic()
 
         def reader():
             try:
@@ -71,7 +71,7 @@ class TestKdumpLock(unittest.TestCase):
             try:
                 for i in range(100):
                     with self.service.kdump_lock:
-                        self.service.kdump_hosts_timestamp[f'new-host-{i}'] = time.time()
+                        self.service.kdump_hosts_timestamp[f'new-host-{i}'] = time.monotonic()
             except Exception as e:
                 errors.append(f"writer: {e}")
 
@@ -111,10 +111,10 @@ class TestKdumpLock(unittest.TestCase):
         """Test that timestamp cleanup (dict reassignment) is safe under lock."""
         with self.service.kdump_lock:
             for i in range(200):
-                self.service.kdump_hosts_timestamp[f'host-{i}'] = time.time() - 500
+                self.service.kdump_hosts_timestamp[f'host-{i}'] = time.monotonic() - 500
 
         with self.service.kdump_lock:
-            cutoff = time.time() - 300
+            cutoff = time.monotonic() - 300
             self.service.kdump_hosts_timestamp = defaultdict(float,
                 {k: v for k, v in self.service.kdump_hosts_timestamp.items() if v >= cutoff})
 

--- a/test/instanceha/test_unit_core.py
+++ b/test/instanceha/test_unit_core.py
@@ -32,7 +32,7 @@ from unittest.mock import Mock, patch, MagicMock, call
 from datetime import datetime, timedelta
 from io import StringIO
 
-import conftest  # noqa: F401
+from conftest import make_mock_config  # noqa: F401
 
 # Suppress configuration warnings during testing
 logging.getLogger().setLevel(logging.CRITICAL)
@@ -275,19 +275,7 @@ class TestInstanceHAService(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        self.mock_config = Mock()
-        # Set up get_config_value to return appropriate values based on key
-        config_values = {
-            'EVACUABLE_TAG': 'evacuable',
-            'TAGGED_IMAGES': True,
-            'TAGGED_FLAVORS': True,
-            'TAGGED_AGGREGATES': False,
-            'SMART_EVACUATION': True,
-            'WORKERS': 4,
-            'DELAY': 0,
-        }
-        self.mock_config.get_config_value.side_effect = lambda key: config_values.get(key, False)
-
+        self.mock_config = make_mock_config(SMART_EVACUATION=True)
         self.mock_cloud_client = Mock()
         self.service = instanceha.InstanceHAService(self.mock_config, self.mock_cloud_client)
 
@@ -363,7 +351,7 @@ class TestInstanceHAService(unittest.TestCase):
         """Test cache refresh functionality."""
         # Set up initial cache
         self.service._evacuable_flavors_cache = ['cached-flavor']
-        self.service._cache_timestamp = time.time() - 400  # Make cache stale
+        self.service._cache_timestamp = time.monotonic() - 400  # Make cache stale
 
         mock_flavor = Mock()
         mock_flavor.id = 'new-flavor'
@@ -619,6 +607,51 @@ class TestEvacuationFunctions(unittest.TestCase):
         self.assertFalse(result.accepted)
         self.assertIn('not found', result.reason)
 
+    def test_extract_request_id_from_tuple_with_meta(self):
+        """Test extracting request ID from a TupleWithMeta-like object."""
+        obj = Mock(spec=['request_ids'])
+        obj.request_ids = ['req-abc-123']
+        self.assertEqual(instanceha._extract_request_id(obj), 'req-abc-123')
+
+    def test_extract_request_id_from_exception(self):
+        """Test extracting request ID from a novaclient exception."""
+        obj = Mock(spec=['request_id'])
+        obj.request_id = 'req-def-456'
+        self.assertEqual(instanceha._extract_request_id(obj), 'req-def-456')
+
+    def test_extract_request_id_returns_none_for_unknown(self):
+        """Test that unknown objects return None."""
+        self.assertIsNone(instanceha._extract_request_id(object()))
+
+    def test_server_evacuate_captures_request_id_on_success(self):
+        """Test that successful evacuation captures the Nova request ID."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.reason = 'OK'
+
+        mock_result = Mock()
+        mock_result.request_ids = ['req-evac-success']
+        mock_result.__iter__ = Mock(return_value=iter((mock_response, {})))
+        self.mock_connection.servers.evacuate.return_value = mock_result
+
+        result = instanceha._server_evacuate(self.mock_connection, 'server-123')
+
+        self.assertTrue(result.accepted)
+        self.assertEqual(result.request_id, 'req-evac-success')
+
+    def test_server_evacuate_captures_request_id_on_exception(self):
+        """Test that failed evacuation captures request ID from the exception."""
+        from novaclient.exceptions import Conflict
+        exc = Conflict('already evacuating')
+        exc.request_id = 'req-evac-conflict'
+        self.mock_connection.servers.evacuate.side_effect = exc
+
+        result = instanceha._server_evacuate(self.mock_connection, 'server-123')
+
+        self.assertFalse(result.accepted)
+        self.assertEqual(result.request_id, 'req-evac-conflict')
+        self.assertEqual(result.status_code, 409)
+
     def test_host_disable_success(self):
         """Test successful host disable operation."""
         result = instanceha._host_disable(self.mock_connection, self.mock_service)
@@ -653,7 +686,7 @@ class TestEvacuationFunctions(unittest.TestCase):
 
     def test_check_evacuable_tag_dict(self):
         """Test evacuable tag checking with dictionary data."""
-        service = instanceha.InstanceHAService(Mock(), Mock())
+        service = instanceha.InstanceHAService(make_mock_config(), Mock())
 
         # Test exact match
         data = {'evacuable': 'true'}
@@ -672,7 +705,7 @@ class TestEvacuationFunctions(unittest.TestCase):
 
     def test_check_evacuable_tag_list(self):
         """Test evacuable tag checking with list data."""
-        service = instanceha.InstanceHAService(Mock(), Mock())
+        service = instanceha.InstanceHAService(make_mock_config(), Mock())
 
         # Test exact match in list
         data = ['evacuable', 'other_tag']
@@ -1554,8 +1587,8 @@ class TestSecretExposure(unittest.TestCase):
         self._assert_no_secrets_in_logs()
 
     @patch.dict(os.environ, {'OS_CLOUD': 'testcloud'})
-    def test_get_nova_connection_exception_no_secret_exposure(self):
-        """Test that _get_nova_connection exceptions don't expose passwords."""
+    def test_establish_nova_connection_nonfatal_exception_no_secret_exposure(self):
+        """Test that _establish_nova_connection(fatal=False) exceptions don't expose passwords."""
         # Clear log capture
         self.log_capture.seek(0)
         self.log_capture.truncate(0)
@@ -1571,7 +1604,7 @@ class TestSecretExposure(unittest.TestCase):
         with patch('instanceha.nova_login') as mock_login:
             mock_login.side_effect = Exception("Connection error: password=wrong")
 
-            instanceha._get_nova_connection(service)
+            instanceha._establish_nova_connection(service, fatal=False)
 
             self._assert_no_secrets_in_logs()
 
@@ -2440,18 +2473,18 @@ class TestPerformanceAndMemory(unittest.TestCase):
     def test_kdump_timestamp_memory_management(self):
         """Test that kdump timestamps are cleaned up."""
         # Add many old timestamps
-        old_time = time.time() - 400
+        old_time = time.monotonic() - 400
         for i in range(200):
             self.service.kdump_hosts_timestamp[f'old-host-{i}'] = old_time
 
         # Add some recent ones
-        recent_time = time.time()
+        recent_time = time.monotonic()
         for i in range(10):
             self.service.kdump_hosts_timestamp[f'recent-host-{i}'] = recent_time
 
         # Simulate cleanup (threshold is 100 entries)
         if len(self.service.kdump_hosts_timestamp) > 100:
-            cutoff = time.time() - 300
+            cutoff = time.monotonic() - 300
             old_keys = [k for k, v in self.service.kdump_hosts_timestamp.items() if v < cutoff]
             for k in old_keys:
                 del self.service.kdump_hosts_timestamp[k]
@@ -2657,7 +2690,7 @@ class TestFunctionalIntegration(unittest.TestCase):
 
         # Mock fencing, connection retrieval, and filter to succeed
         with patch('instanceha._execute_fence_operation', return_value=True), \
-             patch('instanceha._get_nova_connection', return_value=mock_nova), \
+             patch('instanceha._establish_nova_connection', return_value=mock_nova), \
              patch.object(service, 'filter_hosts_with_servers', side_effect=lambda services, cache: services):
             # Process the service (simulate one host being processed)
             result = instanceha.process_service(failed_service, [], False, service)
@@ -2737,7 +2770,7 @@ class TestFunctionalIntegration(unittest.TestCase):
         # Mock fencing, kdump, connection retrieval, and filter
         with patch('instanceha._execute_fence_operation', return_value=True), \
              patch('instanceha._check_kdump', return_value=(nova_state['services'][:2], [])), \
-             patch('instanceha._get_nova_connection', return_value=mock_nova), \
+             patch('instanceha._establish_nova_connection', return_value=mock_nova), \
              patch.object(service, 'get_hosts_with_servers_cached', return_value=host_servers_cache), \
              patch.object(service, 'filter_hosts_with_servers', side_effect=lambda services, cache: services):
 
@@ -2858,7 +2891,7 @@ class TestFunctionalIntegration(unittest.TestCase):
 
         with patch('instanceha._execute_fence_operation', return_value=True), \
              patch('instanceha._check_kdump', return_value=(down_list, [])), \
-             patch('instanceha._get_nova_connection', return_value=mock_nova), \
+             patch('instanceha._establish_nova_connection', return_value=mock_nova), \
              patch.object(service, 'get_hosts_with_servers_cached', return_value=host_servers_cache), \
              patch.object(service, 'filter_hosts_with_servers', side_effect=lambda services, cache: services):
 
@@ -3032,7 +3065,7 @@ class TestFunctionalIntegration(unittest.TestCase):
                             if magic == 0x1B302A40:
                                 # Valid kdump message - extract hostname
                                 hostname = addr[0]
-                                service.kdump_hosts_timestamp[hostname] = time.time()
+                                service.kdump_hosts_timestamp[hostname] = time.monotonic()
                     except socket.timeout:
                         continue
                 sock.close()
@@ -3069,7 +3102,7 @@ class TestFunctionalIntegration(unittest.TestCase):
 
         # Verify timestamp is recent
         timestamp = service.kdump_hosts_timestamp['127.0.0.1']
-        self.assertGreater(timestamp, time.time() - 3)
+        self.assertGreater(timestamp, time.monotonic() - 3)
 
     def test_cache_lifecycle_integration(self):
         """Test cache lifecycle: initial load, staleness, refresh, usage."""
@@ -3104,7 +3137,7 @@ class TestFunctionalIntegration(unittest.TestCase):
         self.assertEqual(mock_nova.flavors.list.call_count, 1, "Should still be 1 (cached)")
 
         # Make cache stale
-        service._cache_timestamp = time.time() - 400  # Older than 300s
+        service._cache_timestamp = time.monotonic() - 400  # Older than 300s
 
         # Add new flavor to Nova
         new_flavor = Mock()
@@ -3123,7 +3156,7 @@ class TestFunctionalIntegration(unittest.TestCase):
         self.assertIn('flavor-new', evacuable_flavors_new)
 
         # Verify cache is fresh
-        cache_age = time.time() - service._cache_timestamp
+        cache_age = time.monotonic() - service._cache_timestamp
         self.assertLess(cache_age, 5, "Cache should be fresh (< 5 seconds old)")
 
 


### PR DESCRIPTION
Notable changes:
    - Add heartbeat cliff detection with configurable expiry (HEARTBEAT_CLIFF_MAX_CYCLES)
    - Cap fencing to MAX_HOSTS_PER_CYCLE per reconciliation cycle
    - Replace bare Mock() configs in tests with make_mock_config() helper

Rest is cleanups, improved logging (like adding the nova request id to easily grep in nova logs), documentation restructuring to remove duplicates and cross reference between docs instead:
    - Register signal handlers for clean shutdown (SIGTERM/SIGINT)
    - Extract Nova API request IDs from evacuate calls for cross-correlation
    - Add WARNING when MAX_HOSTS_PER_CYCLE cap is exceeded
    - Deduplicate documentation