### PR TITLE
Skip NodeSet sync for controlplane-only credential rotation

### DIFF
--- a/apis/rabbitmq/v1beta1/conditions.go
+++ b/apis/rabbitmq/v1beta1/conditions.go
@@ -61,7 +61,28 @@ const (
 	// The TransportURL controller sets this label after verifying NodeSet deployment
 	// completion, so the user controller can safely auto-delete the CR on sight.
 	RabbitMQUserOrphanedLabel = "rabbitmq.openstack.org/orphaned"
+
+	// EDPMServiceAnnotation overrides the automatic owner-based EDPM detection
+	// for a TransportURL. When set to "true", the controller always uses the
+	// two-phase NodeSet sync check. When "false", it releases the old user
+	// immediately. When unset, the controller infers EDPM status from the
+	// ownerReference Kind (Nova and NeutronAPI are EDPM; everything else is not).
+	EDPMServiceAnnotation = "rabbitmq.openstack.org/edpm-service"
 )
+
+// edpmOwnerKinds lists the owner CR Kinds whose TransportURLs serve
+// EDPM-deployed agents and therefore require NodeSet hash-sync gating
+// during credential rotation.
+var edpmOwnerKinds = map[string]bool{
+	"Nova":       true,
+	"NeutronAPI": true,
+}
+
+// IsEDPMOwnerKind reports whether the given owner Kind serves
+// EDPM-deployed agents that require NodeSet hash-sync gating.
+func IsEDPMOwnerKind(kind string) bool {
+	return edpmOwnerKinds[kind]
+}
 
 // TransportURLFinalizerFor returns the per-consumer finalizer for a TransportURL.
 // If the name fits within Kubernetes' 63-char name segment limit, it is used directly

--- a/internal/controller/rabbitmq/rabbitmquser_controller.go
+++ b/internal/controller/rabbitmq/rabbitmquser_controller.go
@@ -55,10 +55,6 @@ const userFinalizer = "rabbitmquser.openstack.org/finalizer"
 // credentialSecretNameField is the field index for the credential secret
 const credentialSecretNameField = ".spec.secret"
 
-// ConnectionCheckInterval is the polling interval for pending user release checks
-// in the TransportURL controller, used as a fallback alongside the NodeSet watch.
-const ConnectionCheckInterval = 5 * time.Minute
-
 // generatePassword generates a random password
 func generatePassword(length int) (string, error) {
 	bytes := make([]byte, length)

--- a/internal/controller/rabbitmq/transporturl_controller.go
+++ b/internal/controller/rabbitmq/transporturl_controller.go
@@ -49,6 +49,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+// PendingReleaseCheckInterval is the requeue interval while waiting for a
+// pending user release.
+const PendingReleaseCheckInterval = 1 * time.Minute
+
 // GetClient -
 func (r *TransportURLReconciler) GetClient() client.Client {
 	return r.Client
@@ -560,7 +564,7 @@ func (r *TransportURLReconciler) reconcileNormal(ctx context.Context, instance *
 		if !released {
 			Log.Info("Pending user release waiting for deployment",
 				"pendingUser", instance.Status.PreviousRabbitmqUserRef)
-			return ctrl.Result{RequeueAfter: ConnectionCheckInterval}, nil
+			return ctrl.Result{RequeueAfter: PendingReleaseCheckInterval}, nil
 		}
 	}
 
@@ -887,6 +891,25 @@ func (r *TransportURLReconciler) deleteOrphanedCR(ctx context.Context, obj clien
 func (r *TransportURLReconciler) tryReleasePendingUser(ctx context.Context, instance *rabbitmqv1.TransportURL) (bool, error) {
 	Log := r.GetLogger(ctx)
 	pendingRef := instance.Status.PreviousRabbitmqUserRef
+
+	// Determine whether this TransportURL serves an EDPM-deployed service.
+	// Explicit annotation wins; otherwise infer from the ownerReference Kind.
+	edpmService := false
+	if v, ok := instance.Annotations[rabbitmqv1.EDPMServiceAnnotation]; ok {
+		edpmService = v == "true"
+	} else {
+		for _, ref := range instance.OwnerReferences {
+			if rabbitmqv1.IsEDPMOwnerKind(ref.Kind) {
+				edpmService = true
+				break
+			}
+		}
+	}
+	if !edpmService {
+		Log.Info("Non-EDPM service, releasing old user immediately",
+			"pendingUser", pendingRef)
+		return r.releasePendingUser(ctx, instance)
+	}
 
 	// No NodeSets with secretHashes -> no computes affected, release immediately
 	haveNS, err := edpm.HaveNodeSets(ctx, r.Client, instance.Namespace)

--- a/test/functional/transporturl_controller_test.go
+++ b/test/functional/transporturl_controller_test.go
@@ -1208,11 +1208,27 @@ var _ = Describe("TransportURL controller", func() {
 			rabbitmq := CreateRabbitMQ(rabbitmqName, spec)
 			DeferCleanup(th.DeleteInstance, rabbitmq)
 
-			tuSpec := map[string]any{
-				"rabbitmqClusterName": rabbitmqName.Name,
-				"username":            "phase-user-a",
+			// Create TransportURL with a Nova ownerReference (EDPM service)
+			tu := &rabbitmqv1.TransportURL{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      turlName.Name,
+					Namespace: turlName.Namespace,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "nova.openstack.org/v1beta1",
+							Kind:       "Nova",
+							Name:       "nova",
+							UID:        "fake-nova-uid",
+						},
+					},
+				},
+				Spec: rabbitmqv1.TransportURLSpec{
+					RabbitmqClusterName: rabbitmqName.Name,
+					Username:            "phase-user-a",
+				},
 			}
-			DeferCleanup(th.DeleteInstance, CreateTransportURL(turlName, tuSpec))
+			Expect(k8sClient.Create(ctx, tu)).Should(Succeed())
+			DeferCleanup(th.DeleteInstance, tu)
 
 			CreateNodeSet(nodesetName)
 			DeferCleanup(DeleteNodeSet, nodesetName)
@@ -1330,6 +1346,248 @@ var _ = Describe("TransportURL controller", func() {
 				rabbitmqv1.TransportURLReadyCondition,
 				corev1.ConditionTrue,
 			)
+		})
+	})
+
+	When("credential rotation for controlplane-only owner (non-EDPM)", func() {
+		var rabbitmqName types.NamespacedName
+		var turlName types.NamespacedName
+		var nodesetName types.NamespacedName
+
+		BeforeEach(func() {
+			rabbitmqName = types.NamespacedName{
+				Name:      "rabbitmq-cp-only",
+				Namespace: namespace,
+			}
+			turlName = types.NamespacedName{
+				Name:      "turl-cp-only",
+				Namespace: namespace,
+			}
+			nodesetName = types.NamespacedName{
+				Name:      "compute-cp-only",
+				Namespace: namespace,
+			}
+
+			SetupMockRabbitMQAPI()
+			DeferCleanup(StopMockRabbitMQAPI)
+
+			CreateRabbitMQCluster(rabbitmqName, GetDefaultRabbitMQClusterSpec(false))
+			DeferCleanup(DeleteRabbitMQCluster, rabbitmqName)
+
+			spec := GetDefaultRabbitMQSpec()
+			rabbitmq := CreateRabbitMQ(rabbitmqName, spec)
+			DeferCleanup(th.DeleteInstance, rabbitmq)
+
+			// Create TransportURL with a non-EDPM ownerReference (simulating Cinder)
+			tu := &rabbitmqv1.TransportURL{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      turlName.Name,
+					Namespace: turlName.Namespace,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "cinder.openstack.org/v1beta1",
+							Kind:       "Cinder",
+							Name:       "cinder",
+							UID:        "fake-cinder-uid",
+						},
+					},
+				},
+				Spec: rabbitmqv1.TransportURLSpec{
+					RabbitmqClusterName: rabbitmqName.Name,
+					Username:            "cp-only-user-a",
+				},
+			}
+			Expect(k8sClient.Create(ctx, tu)).Should(Succeed())
+			DeferCleanup(th.DeleteInstance, tu)
+
+			CreateNodeSet(nodesetName)
+			DeferCleanup(DeleteNodeSet, nodesetName)
+		})
+
+		It("should release old user immediately without waiting for NodeSet sync", func() {
+			SimulateRabbitMQClusterReady(rabbitmqName)
+
+			userACRName := types.NamespacedName{
+				Name:      rabbitmqv1.CanonicalUserName(rabbitmqName.Name, "/", "cp-only-user-a"),
+				Namespace: namespace,
+			}
+			Eventually(func(g Gomega) {
+				user := &rabbitmqv1.RabbitMQUser{}
+				g.Expect(k8sClient.Get(ctx, userACRName, user)).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			SimulateRabbitMQUserReady(userACRName, "/")
+
+			transportURLSecretName := types.NamespacedName{
+				Name:      "rabbitmq-transport-url-" + turlName.Name,
+				Namespace: namespace,
+			}
+			Eventually(func(g Gomega) {
+				tr := th.GetTransportURL(turlName)
+				g.Expect(tr.Status.RabbitmqUsername).To(Equal("cp-only-user-a"))
+				s := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, transportURLSecretName, s)).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			initialHash := GetSecretHash(transportURLSecretName)
+			SetNodeSetSecretHashes(nodesetName, map[string]string{
+				transportURLSecretName.Name: initialHash,
+			})
+
+			// --- Trigger credential rotation ---
+			Eventually(func(g Gomega) {
+				tr := th.GetTransportURL(turlName)
+				tr.Spec.Username = "cp-only-user-b"
+				g.Expect(k8sClient.Update(ctx, tr)).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			userBCRName := types.NamespacedName{
+				Name:      rabbitmqv1.CanonicalUserName(rabbitmqName.Name, "/", "cp-only-user-b"),
+				Namespace: namespace,
+			}
+			Eventually(func(g Gomega) {
+				user := &rabbitmqv1.RabbitMQUser{}
+				g.Expect(k8sClient.Get(ctx, userBCRName, user)).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			SimulateRabbitMQUserReady(userBCRName, "/")
+
+			// Old user should be released immediately — owner is Cinder
+			// (not in EDPMOwnerKinds), so no NodeSet sync needed
+			Eventually(func(g Gomega) {
+				user := &rabbitmqv1.RabbitMQUser{}
+				err := k8sClient.Get(ctx, userACRName, user)
+				g.Expect(k8s_errors.IsNotFound(err)).To(BeTrue(),
+					"Old user should be deleted immediately for non-EDPM owner")
+			}, timeout, interval).Should(Succeed())
+
+			// Verify cleanup
+			Eventually(func(g Gomega) {
+				tr := th.GetTransportURL(turlName)
+				g.Expect(tr.Status.PreviousRabbitmqUserRef).To(BeEmpty())
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	When("annotation overrides owner-based EDPM detection", func() {
+		var rabbitmqName types.NamespacedName
+		var turlName types.NamespacedName
+		var nodesetName types.NamespacedName
+
+		BeforeEach(func() {
+			rabbitmqName = types.NamespacedName{
+				Name:      "rabbitmq-anno-override",
+				Namespace: namespace,
+			}
+			turlName = types.NamespacedName{
+				Name:      "turl-anno-override",
+				Namespace: namespace,
+			}
+			nodesetName = types.NamespacedName{
+				Name:      "compute-anno-override",
+				Namespace: namespace,
+			}
+
+			SetupMockRabbitMQAPI()
+			DeferCleanup(StopMockRabbitMQAPI)
+
+			CreateRabbitMQCluster(rabbitmqName, GetDefaultRabbitMQClusterSpec(false))
+			DeferCleanup(DeleteRabbitMQCluster, rabbitmqName)
+
+			spec := GetDefaultRabbitMQSpec()
+			rabbitmq := CreateRabbitMQ(rabbitmqName, spec)
+			DeferCleanup(th.DeleteInstance, rabbitmq)
+
+			// Nova-owned TransportURL with edpm-service=false annotation override
+			tu := &rabbitmqv1.TransportURL{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      turlName.Name,
+					Namespace: turlName.Namespace,
+					Annotations: map[string]string{
+						rabbitmqv1.EDPMServiceAnnotation: "false",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "nova.openstack.org/v1beta1",
+							Kind:       "Nova",
+							Name:       "nova",
+							UID:        "fake-nova-uid-2",
+						},
+					},
+				},
+				Spec: rabbitmqv1.TransportURLSpec{
+					RabbitmqClusterName: rabbitmqName.Name,
+					Username:            "anno-user-a",
+				},
+			}
+			Expect(k8sClient.Create(ctx, tu)).Should(Succeed())
+			DeferCleanup(th.DeleteInstance, tu)
+
+			CreateNodeSet(nodesetName)
+			DeferCleanup(DeleteNodeSet, nodesetName)
+		})
+
+		It("should release immediately when annotation says false despite Nova owner", func() {
+			SimulateRabbitMQClusterReady(rabbitmqName)
+
+			userACRName := types.NamespacedName{
+				Name:      rabbitmqv1.CanonicalUserName(rabbitmqName.Name, "/", "anno-user-a"),
+				Namespace: namespace,
+			}
+			Eventually(func(g Gomega) {
+				user := &rabbitmqv1.RabbitMQUser{}
+				g.Expect(k8sClient.Get(ctx, userACRName, user)).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			SimulateRabbitMQUserReady(userACRName, "/")
+
+			transportURLSecretName := types.NamespacedName{
+				Name:      "rabbitmq-transport-url-" + turlName.Name,
+				Namespace: namespace,
+			}
+			Eventually(func(g Gomega) {
+				tr := th.GetTransportURL(turlName)
+				g.Expect(tr.Status.RabbitmqUsername).To(Equal("anno-user-a"))
+				s := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, transportURLSecretName, s)).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			initialHash := GetSecretHash(transportURLSecretName)
+			SetNodeSetSecretHashes(nodesetName, map[string]string{
+				transportURLSecretName.Name: initialHash,
+			})
+
+			// Trigger credential rotation
+			Eventually(func(g Gomega) {
+				tr := th.GetTransportURL(turlName)
+				tr.Spec.Username = "anno-user-b"
+				g.Expect(k8sClient.Update(ctx, tr)).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			userBCRName := types.NamespacedName{
+				Name:      rabbitmqv1.CanonicalUserName(rabbitmqName.Name, "/", "anno-user-b"),
+				Namespace: namespace,
+			}
+			Eventually(func(g Gomega) {
+				user := &rabbitmqv1.RabbitMQUser{}
+				g.Expect(k8sClient.Get(ctx, userBCRName, user)).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			SimulateRabbitMQUserReady(userBCRName, "/")
+
+			// Annotation override: despite Nova owner, edpm-service=false
+			// should cause immediate release
+			Eventually(func(g Gomega) {
+				user := &rabbitmqv1.RabbitMQUser{}
+				err := k8sClient.Get(ctx, userACRName, user)
+				g.Expect(k8s_errors.IsNotFound(err)).To(BeTrue(),
+					"Annotation override should bypass owner-based EDPM detection")
+			}, timeout, interval).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				tr := th.GetTransportURL(turlName)
+				g.Expect(tr.Status.PreviousRabbitmqUserRef).To(BeEmpty())
+			}, timeout, interval).Should(Succeed())
 		})
 	})
 


### PR DESCRIPTION
During RabbitMQ credential rotation, the TransportURL controller uses a two-phase NodeSet hash-sync check to ensure EDPM nodes pick up new credentials before releasing the old user. This is only needed for services that run agents on EDPM nodes (Nova, Neutron).

Determine EDPM status from the TransportURL's ownerReference Kind: if the owner is Nova or NeutronAPI, wait for NodeSet deployment; otherwise release the old user immediately. The edpm-service annotation is available as an explicit override for edge cases.