### PR TITLE
Decouple detection from evacuation and evaluate safety gates cumulatively across poll cycles

### DIFF
--- a/docs/instanceha_architecture.md
+++ b/docs/instanceha_architecture.md
@@ -205,6 +205,12 @@ def __init__(self, config_manager: ConfigManager, cloud_client: Optional[OpenSta
     # Host processing tracking
     self.hosts_processing = defaultdict(float)
     self.processing_lock = threading.Lock()
+    try:
+        workers = self.config.get_config_value('WORKERS')
+    except (TypeError, ValueError, AttributeError):
+        workers = 4
+    self.processing_executor = concurrent.futures.ThreadPoolExecutor(
+        max_workers=workers if isinstance(workers, int) and workers > 0 else 4)
     self.reserved_hosts_lock = threading.Lock()
 
     logging.info("InstanceHA service initialized successfully")
@@ -214,6 +220,7 @@ def __init__(self, config_manager: ConfigManager, cloud_client: Optional[OpenSta
 
 - `ready` flag starts `False` and is set to `True` after the first successful poll cycle. This drives the `/healthz` readiness probe endpoint -- Kubernetes won't route traffic until the service has completed its first poll.
 - `k8s_api_reachable` starts `True` (fail-open). The background health check thread flips it to `False` after 3 consecutive failures. See [Fencing Safety Model](#fencing-safety-model) for the startup trade-off rationale.
+- `processing_executor` is a persistent `ThreadPoolExecutor` for background host processing (fencing + evacuation). Safety gates run synchronously in the main loop, then accepted hosts are submitted to the executor non-blocking. The main loop polls every `POLL` seconds regardless of in-flight work.
 - `shutdown_event` is set by the SIGTERM handler to signal the main loop and all `wait()` calls to exit gracefully.
 - `kdump_lock` protects all kdump-related state since the UDP listener thread writes concurrently with the main poll loop.
 - `heartbeat_lock` similarly protects heartbeat state from concurrent UDP listener writes.
@@ -463,13 +470,14 @@ def validate_input(value: str, validation_type: str, context: str) -> bool:
                             │
                             ▼
     ┌──────────────────────────────────────────────────┐
-    │ 4. Process Stale Services                        │
+    │ 4. Admit Stale Services (async)                  │
     │    - Filter processing hosts (deduplication)     │
     │    - Filter by servers, tags, aggregates         │
     │    - Filter reachable hosts (heartbeat check)    │
-    │    - Check threshold (active services only)      │
+    │    - Check threshold (total cluster health)      │
     │    - Check critical services operational         │
-    │    - Execute evacuations (with cleanup)          │
+    │    - Submit accepted hosts to executor           │
+    │      (non-blocking -- main loop continues)       │
     └──────────────────────────────────────────────────┘
                             │
                             ▼
@@ -676,7 +684,7 @@ Poll cycle starts
   │   Rationale: if InstanceHA's worker node is network-isolated,
   │   Nova's service list may be stale -- fencing would hit healthy hosts
   │
-  │   ─── enters _process_stale_services ───
+  │   ─── enters _admit_stale_services ───
   │
   ├─ Pre-gate: _filter_processing_hosts
   │   Excludes hosts already being processed (in-flight fencing/evacuation)
@@ -685,6 +693,8 @@ Poll cycle starts
   │   Question: "Did we lose visibility, or did hosts actually fail?"
   │   If >=HEARTBEAT_CLIFF_THRESHOLD% of heartbeats vanish at once -> skip ALL fencing
   │   Requires >= 3 previously active heartbeat hosts to evaluate
+  │   Excludes hosts_processing from active heartbeat counts so expected heartbeat
+  │   absence (host is being fenced/evacuated) does not trigger false cliff detection
   │   Rationale: simultaneous mass heartbeat loss is more likely a listener-side
   │   network partition than N simultaneous host failures
   │   Expiry: after HEARTBEAT_CLIFF_MAX_CYCLES consecutive cliff cycles, accept as genuine
@@ -697,6 +707,7 @@ Poll cycle starts
   │
   ├─ Gate 4: All-services-stale circuit breaker
   │   Question: "Is the data source itself broken?"
+  │   Includes in-flight hosts when checking whether all active services appear stale
   │   If every active service (>=3) still appears stale after heartbeat filtering -> skip ALL fencing
   │   Rationale: all hosts down at once indicates a Nova API or
   │   infrastructure anomaly, not a genuine failure of every server.
@@ -709,17 +720,22 @@ Poll cycle starts
   │   Nova API query errors on no-VM/flavor filters fail-open (host is kept)
   │   Rationale: downstream gates operate on the actionable candidate set only
   │
-  ├─ Gate 6: Global threshold
-  │   Question: "Are too many evacuable hosts down to safely proceed?"
-  │   If failed percentage > THRESHOLD -> skip all fencing (strict `>`, not `>=`)
+  ├─ Gate 6: Global threshold (total cluster health)
+  │   Question: "What percentage of my cluster is down?"
+  │   Evaluates total cluster health: all down/forced_down hosts (including
+  │   in-flight hosts from previous cycles) divided by all services (or all
+  │   evacuable hosts when TAGGED_AGGREGATES is enabled)
+  │   Catches slow cascades where hosts fail one per cycle -- previously-evacuated
+  │   hosts that haven't recovered count as impacted
+  │   If percentage > THRESHOLD -> skip all fencing (strict `>`, not `>=`)
   │   Skipped when filtered compute_nodes is empty
-  │   Note: numerator is post-filter down hosts; denominator is all active evacuable hosts
   │   to_resume hosts are not counted in the calculation, but a threshold breach blocks
   │   all processing including to_resume
   │
-  ├─ Gate 7: Per-aggregate threshold
+  ├─ Gate 7: Per-aggregate threshold (total impact)
   │   Question: "Is this aggregate losing too many hosts?"
-  │   If failed count > instanceha:max_failures metadata -> skip hosts in that aggregate
+  │   Counts in-flight hosts toward their aggregate failure budget
+  │   If total impacted count (new + in-flight) > instanceha:max_failures metadata -> skip hosts in that aggregate
   │   to_resume hosts bypass this gate (only compute_nodes are filtered)
   │
   ├─ Gate 8: Per-cycle rate limit
@@ -1508,9 +1524,9 @@ Reserved Hosts: reserved-01 (aggregate-A), reserved-02 (aggregate-B)
 
 ### 7. Threshold Protection
 
-**Purpose**: Prevent mass evacuations during datacenter-level failures.
+**Purpose**: Prevent mass evacuations during datacenter-level failures and catch slow cascades where hosts fail one per poll cycle.
 
-**Evaluation order**: The threshold check runs **after** evacuability filtering (`_prepare_evacuation_resources`). The numerator is the count of down hosts that survived filtering (have VMs, match flavor/image/aggregate tags). Hosts Nova reported as down but excluded by tagging are not counted.
+**Evaluation order**: The threshold check runs **after** evacuability filtering (`_prepare_evacuation_resources`). It evaluates **total cluster health**: all down/forced_down hosts (including those evacuated in previous cycles that haven't recovered) divided by all services.
 
 **Implementation**:
 ```python
@@ -1518,30 +1534,37 @@ Reserved Hosts: reserved-01 (aggregate-A), reserved-02 (aggregate-B)
 compute_nodes, reserved_hosts, images, flavors = _prepare_evacuation_resources(
     conn, service, services, compute_nodes, aggregates=aggregates)
 
-# Threshold uses the filtered candidate list, not the original stale-service list
+# Threshold evaluates total cluster health using _count_down_hosts
 if service.config.get_config_value('TAGGED_AGGREGATES'):
+    evacuable_hosts = _get_evacuable_hosts_from_aggregates(conn, service, aggregates=aggregates)
     total_evacuable = _count_evacuable_hosts(conn, service, services, aggregates=aggregates)
-    threshold_percent = (len(compute_nodes) / total_evacuable * 100) if total_evacuable > 0 else 0
+    total_down = _count_down_hosts(services, compute_nodes=compute_nodes, evacuable_hosts=evacuable_hosts)
+    threshold_percent = (total_down / total_evacuable * 100) if total_evacuable > 0 else 0
 else:
-    active_services = [s for s in services if 'disabled' not in s.status and not s.forced_down]
-    threshold_percent = (len(compute_nodes) / len(active_services)) * 100 if active_services else 0
+    total_down = _count_down_hosts(services, compute_nodes=compute_nodes)
+    threshold_percent = (total_down / len(services)) * 100 if services else 0
 
 if threshold_percent > service.config.get_config_value('THRESHOLD'):
     logging.error('Impacted (%.1f%%) exceeds threshold', threshold_percent)
     return  # Do not evacuate
 ```
 
-Both paths exclude disabled and forced-down hosts from the denominator. The `TAGGED_AGGREGATES` path further restricts the denominator to hosts in evacuable aggregates. The numerator counts only post-filter down hosts (empty hosts excluded); the denominator counts all active evacuable hosts including healthy ones. The check is skipped when filtered `compute_nodes` is empty. `to_resume` candidates are not counted in the threshold calculation and individually bypass per-aggregate filtering, but a global threshold breach blocks all processing including `to_resume`.
+**Total cluster health model**: The numerator (`_count_down_hosts`) counts all services with `state='down'` or `forced_down=True`, plus compute_nodes detected as stale this cycle (whose Nova state may not have transitioned yet). The denominator is all services (or all evacuable hosts when `TAGGED_AGGREGATES` is enabled) -- **not** just active services. This means previously-evacuated hosts that remain `forced_down` count as impacted: a slow cascade where hosts fail one per cycle accumulates rather than staying flat.
+
+Previously, each evacuated host left both the numerator (no longer a new failure) and the denominator (excluded via forced_down filter), keeping the threshold percentage flat regardless of how many hosts were down. Now the percentage answers "what fraction of my cluster is down?" and a slow cascade triggers the threshold once enough hosts accumulate.
+
+The check is skipped when filtered `compute_nodes` is empty. `to_resume` candidates are not counted in the calculation, but a global threshold breach blocks all processing including `to_resume`.
 
 **Implication**: A partial infrastructure failure (for example, one Nova cell offline) that affects mostly non-evacuable hosts may not trip the global threshold. Use per-aggregate `instanceha:max_failures`, the all-services-stale gate (full-cluster anomalies only), and external monitoring for cell-level protection. See [Threshold Is Evaluated After Evacuability Filtering](instanceha_guide.md#threshold-is-evaluated-after-evacuability-filtering) in the operator guide.
 
 ### Per-Aggregate Threshold
 
-In addition to the global percentage-based threshold, operators can set an absolute failure limit per aggregate via the `instanceha:max_failures` metadata key on Nova aggregates. When `TAGGED_AGGREGATES` is enabled, the agent checks each evacuable aggregate's metadata after the global threshold passes. If the number of failed hosts in an aggregate exceeds its `instanceha:max_failures` value, evacuation is blocked for all failed hosts in that aggregate.
+In addition to the global percentage-based threshold, operators can set an absolute failure limit per aggregate via the `instanceha:max_failures` metadata key on Nova aggregates. When `TAGGED_AGGREGATES` is enabled, the agent checks each evacuable aggregate's metadata after the global threshold passes. The count includes both newly-failed hosts and in-flight hosts (from `hosts_processing`) that belong to the aggregate, so the per-aggregate budget accounts for total impact across cycles. If the total impacted count exceeds the aggregate's `instanceha:max_failures` value, evacuation is blocked for all failed hosts in that aggregate.
 
 - **Activation**: Automatic when the metadata key is present (no config option needed)
+- **Total impact**: The impacted count for each aggregate is `new failures + in-flight hosts in that aggregate`, catching slow per-aggregate cascades
 - **Multi-aggregate semantics**: Most-restrictive-wins -- if a host belongs to multiple aggregates and any one exceeds its limit, the host is blocked
-- **K8s event**: `AggregateThresholdExceeded` (Warning) emitted per blocked aggregate
+- **K8s event**: `AggregateThresholdExceeded` (Warning) emitted per blocked aggregate, including the breakdown of new vs in-flight hosts
 - **Metric**: `instanceha_aggregate_threshold_exceeded_total{aggregate}` counter
 
 ```
@@ -1836,8 +1859,9 @@ signal.signal(signal.SIGTERM, _sigterm_handler)
 **Behavior**:
 - `shutdown_event` is a `threading.Event` checked in the main loop condition (`while not service.shutdown_event.is_set()`)
 - All `time.sleep()` calls replaced with `service.shutdown_event.wait(seconds)` -- these return immediately when the event is set
-- In-flight evacuations complete before shutdown (no abrupt termination)
-- Logs `"Graceful shutdown complete"` on exit
+- SIGTERM stops new submissions to the processing executor, then the main loop exits
+- After the main loop exits, `processing_executor.shutdown(wait=True)` waits for all in-flight fencing and evacuation work to complete
+- Logs `"Waiting for in-flight evacuations to complete"` followed by `"Graceful shutdown complete"` on exit
 
 **Kubernetes Integration**:
 - The Deployment's `terminationGracePeriodSeconds` is set to 45 seconds
@@ -2406,20 +2430,23 @@ config:
 **Description**: Maximum percentage of failed compute services before evacuation is blocked.
 
 **Usage**:
-- Denominator always excludes disabled and force-downed hosts (active services only)
+- Evaluates total cluster health: all down/forced_down hosts divided by all services
 - Calculation depends on `TAGGED_AGGREGATES` setting:
-  - When `TAGGED_AGGREGATES=false`: `(failed_hosts / active_hosts) * 100`
-  - When `TAGGED_AGGREGATES=true`: `(failed_hosts / active_evacuable_hosts) * 100`
+  - When `TAGGED_AGGREGATES=false`: `(total_down_hosts / all_services) * 100`
+  - When `TAGGED_AGGREGATES=true`: `(total_down_hosts / all_evacuable_hosts) * 100`
+- `total_down_hosts` = all services with `state='down'` or `forced_down=True`, plus compute_nodes detected as stale this cycle
 - If percentage is strictly greater than threshold, evacuation is skipped and error logged
 
 **Behavior**:
 - **Without aggregate filtering** (`TAGGED_AGGREGATES=false`):
-  - Calculates percentage against active compute services (excludes disabled/force-downed)
-  - Example: 3 failed / 6 active = 50% (not 3/10 total = 30%)
+  - Calculates percentage against all compute services
+  - Example: 3 down + 2 forced_down / 10 total = 50%
 
 - **With aggregate filtering** (`TAGGED_AGGREGATES=true`):
-  - Calculates percentage against active hosts in evacuable aggregates
-  - Example: 3 failed / 5 active evacuable = 60%
+  - Calculates percentage against all hosts in evacuable aggregates
+  - Example: 3 down + 2 forced_down / 8 evacuable = 62.5%
+
+- **Slow cascade protection**: Previously-evacuated hosts that remain `forced_down` count toward the numerator. A slow cascade where hosts fail one per cycle accumulates until the threshold fires, rather than staying flat (as it did when only new failures were counted).
 
 **Testing**:
 - Unit tests verify percentage validation and clamping
@@ -2448,10 +2475,10 @@ config:
 **Default**: `4`
 **Range**: `1-100`
 
-**Description**: Thread pool size for concurrent processing. Controls parallelism at two levels: host-level processing and per-host server evacuation.
+**Description**: Thread pool size for the persistent `processing_executor` that handles background host processing (fencing + evacuation). Also controls per-host server evacuation concurrency.
 
 **Usage**:
-- **Host-level**: `_process_stale_services` uses `_run_concurrent` with `WORKERS` threads to process multiple failed hosts in parallel via `process_service`. This applies to all evacuation modes (traditional, smart, and orchestrated).
+- **Host-level**: `_admit_stale_services` runs safety gates synchronously, then submits accepted hosts to `processing_executor` (a persistent `ThreadPoolExecutor` with `max_workers=WORKERS`). Each host runs `process_service` in a background thread, non-blocking to the main poll loop.
 - **Per-host (smart/orchestrated only)**: Within each host's evacuation, `_smart_evacuate` and `_orchestrated_evacuate` use `_run_concurrent` to evacuate multiple VMs concurrently. The per-host thread count is calculated as `EVACUATION_MAX_THREADS // WORKERS` to cap the total system-wide thread count.
 
 **Testing**:
@@ -2918,7 +2945,7 @@ openstack flavor set --property ha-enabled=true m1.small
 - When `false`:
   - Ignore aggregate tags (all aggregates considered evacuable)
   - Reserved hosts matched by availability zone
-  - `THRESHOLD` percentage calculated against active compute services (excludes disabled/force-downed)
+  - `THRESHOLD` percentage calculated against all compute services (total cluster health)
 
 **Testing**:
 - Functional tests verify aggregate-based filtering
@@ -2941,7 +2968,7 @@ openstack aggregate set --property ha-enabled=true production-hosts
 
 **Notes**:
 - Affects reserved host matching behavior
-- Affects threshold calculation (percentage of active evacuable hosts vs active hosts)
+- Affects threshold calculation (percentage of total down/forced_down hosts in evacuable aggregates vs all evacuable hosts)
 
 ---
 
@@ -3238,7 +3265,7 @@ config:
 **Description**: Maximum number of hosts that can be fenced in a single poll cycle. If more hosts are detected as down, the first `MAX_HOSTS_PER_CYCLE` are fenced and the rest are deferred to the next cycle. This bounds the blast radius of a single poll cycle -- a Nova API anomaly (conductor crash, stale data, Keystone token issue) cannot trigger mass fencing beyond this cap.
 
 **Usage**:
-- Applied in `_process_stale_services()` after all other safety gates (threshold, per-aggregate, heartbeat) have run
+- Applied in `_admit_stale_services()` after all other safety gates (threshold, per-aggregate, heartbeat) have run
 - Deferred hosts are not lost -- they are re-evaluated on the next poll cycle
 - A `FencingRateLimited` K8s event (Warning) is emitted when the cap is hit
 
@@ -3413,7 +3440,7 @@ requests.post(url, timeout=20)  # Retry up to 3 times
 **Behavior**:
 - Health hash updated approximately every `HASH_INTERVAL` seconds
 - Hash exposed via HTTP health check server on port 8080:
-  - `GET /` -- **Liveness probe**: returns 200 with current hash if `hash_update_successful`, 500 otherwise
+  - `GET /` -- **Liveness probe**: returns 200 with current hash if `hash_update_successful`, 500 otherwise. Also returns 500 if any `hosts_processing` entry is older than `2 * max(FENCING_TIMEOUT, EVACUATION_TIMEOUT)`, indicating a stale processing entry (since the main loop no longer blocks on evacuation, hung processing cannot be detected via poll staleness)
   - `GET /healthz` -- **Readiness probe**: returns 200 if `ready` flag is set (after first successful poll), 503 otherwise
   - `GET /metrics` -- **Prometheus metrics**: returns all registered metrics in Prometheus text format
 - `hash_update_successful` flag indicates service liveness

--- a/docs/instanceha_guide.md
+++ b/docs/instanceha_guide.md
@@ -53,7 +53,7 @@ InstanceHA runs as a Kubernetes-managed workload alongside the OpenStack control
 
 1. **Detection**: The agent polls the Nova API every `POLL` seconds (default: 45). It queries all `nova-compute` services and checks each one's `updated_at` timestamp. A service is considered failed if it is reported as `down` or if its `updated_at` timestamp is older than `DELTA` seconds (default: 30). When heartbeat verification is enabled (`CHECK_HEARTBEAT`), both the Nova service-list poll and the UDP heartbeat channel must agree that a host is unreachable before it is marked as failed.
 
-2. **Safety checks**: Before acting, the agent verifies that the percentage of failed hosts does not exceed the `THRESHOLD` (default: 50%) -- calculated against only active services, excluding already-disabled and already-forced-down hosts -- and that at least one `nova-scheduler` is running. These checks prevent cascading evacuations during infrastructure-wide outages. A `ThresholdExceeded` K8s event is emitted when the limit is hit.
+2. **Safety checks**: Before acting, the agent verifies that the total percentage of down and forced_down hosts does not exceed the `THRESHOLD` (default: 50%) -- calculated against all services (or all evacuable hosts when `TAGGED_AGGREGATES` is enabled). Previously-evacuated hosts that remain forced_down count toward this total, catching slow cascades. The agent also verifies that at least one `nova-scheduler` is running. These checks prevent cascading evacuations during infrastructure-wide outages. A `ThresholdExceeded` K8s event is emitted when the limit is hit.
 
 3. **Fencing**: The failed host is powered off via its baseboard management controller (BMC) using IPMI, Redfish, or the Metal3 Kubernetes API. Fencing ensures the host is truly offline before evacuation begins, preventing split-brain scenarios where the old and new copies of an instance run simultaneously. The server is locked in Nova (API microversion 2.73, reason `instanceha-evacuation`) to prevent concurrent operations.
 
@@ -142,7 +142,7 @@ See [instanceha_prometheus.md](instanceha_prometheus.md) for the complete metric
 
 ### Graceful Shutdown
 
-When the pod receives SIGTERM (during scaling, rolling updates, or node drain), InstanceHA immediately marks itself as not-ready (`ready = False`), stops the heartbeat and kdump listeners, shuts down the health check HTTP server, and sets the shutdown flag. In-flight fencing and evacuation workers check this flag between operations and finish promptly. The Deployment is configured with a 45-second termination grace period.
+When the pod receives SIGTERM (during scaling, rolling updates, or node drain), InstanceHA immediately marks itself as not-ready (`ready = False`), stops the heartbeat and kdump listeners, shuts down the health check HTTP server, stops accepting new submissions to the processing executor, and sets the shutdown flag. After the main loop exits, the processing executor waits for all in-flight fencing and evacuation work to complete before the process terminates. The Deployment is configured with a 45-second termination grace period.
 
 > **Note:** The worst-case shutdown time depends on `FENCING_TIMEOUT` (default 30s) plus thread-pool drain time. If you increase `FENCING_TIMEOUT` beyond the default, consider increasing `terminationGracePeriodSeconds` in the Deployment spec accordingly to avoid SIGKILL during in-flight fencing or evacuation. If the pod is killed mid-operation, orphan recovery at the next startup handles any partially-processed hosts.
 
@@ -782,7 +782,7 @@ config:
   TAGGED_AGGREGATES: "true"
 ```
 
-The threshold is calculated against active services only (already-disabled and already-forced-down hosts are excluded from the denominator). When `TAGGED_AGGREGATES` is enabled, the percentage is calculated against only the hosts in evacuable aggregates.
+The threshold evaluates total cluster health: all down and forced_down hosts (including those evacuated in previous cycles that haven't recovered) divided by all services. When `TAGGED_AGGREGATES` is enabled, both the numerator and denominator are restricted to hosts in evacuable aggregates. This catches slow cascades where hosts fail one per poll cycle -- each previously-evacuated host that remains forced_down counts toward the impacted total.
 
 If the threshold is exceeded, InstanceHA logs an error, emits a `ThresholdExceeded` K8s event, and skips evacuation for that poll cycle, waiting for the situation to resolve or for an operator to intervene.
 
@@ -790,32 +790,43 @@ Setting `THRESHOLD` to `100` disables the check entirely (allows up to 100% of h
 
 ### Threshold Is Evaluated After Evacuability Filtering
 
-The global `THRESHOLD` check does **not** count every host Nova reports as down. It runs **after** `_prepare_evacuation_resources()` has narrowed the candidate list. Only hosts that would actually be fenced and evacuated are included in the numerator. The denominator counts **all** active evacuable compute services (including healthy hosts), while the numerator counts only post-filter down hosts -- empty compute nodes are excluded from the numerator but still counted in the denominator, so idle host pools lower the failure percentage.
+The global `THRESHOLD` check runs **after** `_prepare_evacuation_resources()` has narrowed the candidate list. The threshold evaluates total cluster health: the numerator (`_count_down_hosts`) includes all services with `state='down'` or `forced_down=True`, plus compute_nodes detected as stale this cycle. The denominator is all services (or all evacuable hosts when `TAGGED_AGGREGATES` is enabled). Previously-evacuated hosts that remain `forced_down` count toward the numerator, so a slow cascade where hosts fail one per cycle accumulates rather than staying flat.
 
 If evacuability filtering removes every stale host (for example, all down hosts had no VMs), the global threshold check is **skipped** entirely -- even when many hosts were stale upstream.
 
 Hosts in the `to_resume` list (interrupted evacuations) are not counted in the threshold calculation and individually bypass per-aggregate filtering. However, if the global `THRESHOLD` is breached by new fencing candidates, the function returns early -- blocking `to_resume` processing as well. When no new candidates survive filtering, the threshold check is skipped and `to_resume` proceeds unimpeded.
 
-**What is removed before the threshold check:**
+**What the threshold numerator includes:**
 
-| Filter | Effect on threshold numerator |
-|--------|------------------------------|
-| Hosts with no VMs | Excluded -- empty compute nodes are not counted |
-| `TAGGED_FLAVORS` / `TAGGED_IMAGES` | Hosts with no evacuable VMs on them are excluded |
-| `TAGGED_AGGREGATES` | Hosts outside evacuable aggregates are excluded |
-| Heartbeat gate (Gate 4, `CHECK_HEARTBEAT=true` only) | Hosts still sending heartbeats are excluded earlier in the cycle |
-| Nova API query failure (no-VM/flavor filters) | Host is kept -- query errors fail-open so hosts are not incorrectly skipped |
+The numerator is computed by `_count_down_hosts`, which counts all services with `state='down'` or `forced_down=True`, plus compute_nodes detected as stale this cycle (whose Nova state may not have transitioned yet). When `TAGGED_AGGREGATES` is enabled, only services in evacuable aggregates are counted.
+
+| Source | Included in numerator? |
+|--------|----------------------|
+| Services with `state='down'` | Yes |
+| Services with `forced_down=True` (including previously-evacuated hosts) | Yes |
+| Compute nodes detected as stale this cycle | Yes (Nova state may lag) |
+| When `TAGGED_AGGREGATES`: services outside evacuable aggregates | No |
+
+**What is filtered before fencing proceeds (after the threshold check passes):**
+
+| Filter | Effect |
+|--------|--------|
+| Hosts with no VMs | Excluded from fencing |
+| `TAGGED_FLAVORS` / `TAGGED_IMAGES` | Hosts with no evacuable VMs on them excluded from fencing |
+| `TAGGED_AGGREGATES` | Hosts outside evacuable aggregates excluded from fencing |
+| Heartbeat gate (`CHECK_HEARTBEAT=true` only) | Hosts still sending heartbeats excluded earlier in the cycle |
+| Nova API query failure (no-VM/flavor filters) | Host is kept -- query errors fail-open |
 
 **Denominator behavior:**
 
 | Setting | Denominator |
 |---------|-------------|
-| `TAGGED_AGGREGATES: false` | All active compute services (not disabled, not forced-down) |
-| `TAGGED_AGGREGATES: true` | Active compute services in evacuable aggregates only |
+| `TAGGED_AGGREGATES: false` | All compute services (all states) |
+| `TAGGED_AGGREGATES: true` | All compute services in evacuable aggregates (all states) |
 
-**Example:** Nova reports 40 hosts as down across the region. Only 8 are in evacuable aggregates and carry evacuable workloads. With `TAGGED_AGGREGATES: true` and `THRESHOLD: 50`, the agent calculates `8 / total_evacuable x 100` -- not `40 / total_active x 100`. A datacenter-wide outage that mostly affects non-evacuable or untagged hosts may **not** trip the global threshold, even though many physical hosts are unhealthy.
+**Example:** Nova reports 40 hosts as down across the region. Only 8 are in evacuable aggregates and carry evacuable workloads. With `TAGGED_AGGREGATES: true` and `THRESHOLD: 50`, the agent calculates `total_down_in_evacuable / total_evacuable x 100`. A datacenter-wide outage that mostly affects non-evacuable or untagged hosts may **not** trip the global threshold, even though many physical hosts are unhealthy.
 
-**Why this design:** The threshold is a guard against **runaway evacuation**, not a general infrastructure health monitor. Counting hosts InstanceHA would never evacuate would cause false threshold trips during partial outages (for example, a cell where most hosts are intentionally untagged).
+**Why this design:** The threshold evaluates total cluster health (all down/forced_down hosts vs all services) to catch slow cascades. The candidate list used for the numerator includes all services in a down or forced_down state, plus compute_nodes detected as stale this cycle. When `TAGGED_AGGREGATES` is enabled, both numerator and denominator are restricted to evacuable aggregates.
 
 **Earlier gates still protect against infrastructure-wide anomalies:**
 
@@ -846,9 +857,10 @@ For more granular control, you can set an absolute failure limit per aggregate u
 openstack aggregate set --property instanceha:max_failures=2 my-aggregate
 ```
 
-When `TAGGED_AGGREGATES` is enabled and an aggregate has this metadata key, the agent counts how many failed hosts belong to that aggregate. If the count exceeds the limit, evacuation is blocked for all failed hosts in that aggregate -- other aggregates are unaffected.
+When `TAGGED_AGGREGATES` is enabled and an aggregate has this metadata key, the agent counts both newly-failed hosts and in-flight hosts (from previous cycles) that belong to that aggregate. If the total impacted count exceeds the limit, evacuation is blocked for all failed hosts in that aggregate -- other aggregates are unaffected.
 
 - Both checks run after evacuability filtering; the global `THRESHOLD` check runs first, then the per-aggregate check is an additional filter
+- The impacted count for each aggregate includes in-flight hosts from `hosts_processing`, catching slow per-aggregate cascades
 - If a host belongs to multiple aggregates, the most restrictive limit applies
 - Setting `instanceha:max_failures=0` blocks evacuation on any failure in that aggregate
 - Aggregates without the metadata key have no per-aggregate limit
@@ -1297,7 +1309,7 @@ InstanceHA runs as a single pod and polls the Nova API for all compute services 
 - **Nova API latency**: `services.list(binary="nova-compute")` returns all 1000 services in a single call. Nova's `nova-manage cell_v2` maps cells transparently, so InstanceHA does not need per-cell configuration. However, cross-cell queries are slower -- expect 1-3 seconds per poll at this scale.
 - **Heartbeat processing**: The UDP listener processes heartbeat packets individually. At 1000 nodes with the default `HEARTBEAT_TIMEOUT: 120`, the listener handles ~8 packets/second (1000 nodes / 120 seconds). The [heartbeat performance benchmarks](instanceha_heartbeat_performance.md) show the listener handles 5000+ packets/second.
 - **Fencing concurrency**: With `WORKERS: 4`, up to 4 hosts are fenced in parallel. Each fencing operation (IPMI/Redfish) takes 5-30 seconds. At large scale, a correlated failure (e.g., a rack power event taking down 20 nodes) will be fenced across multiple poll cycles due to `MAX_HOSTS_PER_CYCLE`.
-- **Detection latency during long cycles**: The main loop is synchronous -- it blocks on `_process_stale_services` until all fencing and evacuation completes before polling again. Cycles cannot overlap. However, a long cycle delays detection of new failures. With `WORKERS: 8` and `MAX_HOSTS_PER_CYCLE: 5`, a worst-case cycle runs ~30 seconds (5 fencing ops at 30s each, parallelized across 8 workers), plus evacuation. Any host that fails during this window won't be detected until the next poll.
+- **Detection latency**: The main loop runs safety gates synchronously and submits accepted hosts to a background `ThreadPoolExecutor` for fencing and evacuation. The main loop does not block on in-flight work -- it polls every `POLL` seconds regardless of ongoing processing. New failures are detected on the next poll cycle even while previous evacuations are still in flight. Safety gates evaluate total cluster impact by including in-flight hosts from previous cycles in their calculations (global threshold, per-aggregate threshold, all-stale check, heartbeat cliff).
 
 #### Recommended Configuration
 
@@ -1337,7 +1349,7 @@ spec:
 
 #### Why These Values
 
-**`POLL: 120`** -- At 1000 nodes, a poll cycle that triggers fencing and evacuation can take 60+ seconds (cross-cell service list query + aggregate lookups + fencing with `WORKERS: 8`). A 120-second interval ensures the previous cycle completes before the next one starts. The detection latency trade-off (up to POLL + DELTA = 3 minutes) is offset by heartbeat verification, which provides near-real-time detection independent of the poll interval.
+**`POLL: 120`** -- At 1000 nodes, the safety gates evaluate 1000+ services, fetch aggregate memberships, and include in-flight hosts in threshold calculations. A 120-second interval reduces Nova API load. Since the main loop does not block on in-flight fencing and evacuation, the poll interval only affects detection latency (up to POLL + DELTA = 3 minutes), which heartbeat verification offsets with near-real-time detection independent of the poll interval.
 
 **`DELTA: 60`** -- Nova's `updated_at` timestamp for compute services can lag during cross-cell database queries, especially when cells are under load. A 60-second staleness window absorbs this variance. Combined with `POLL: 120`, worst-case detection time is ~3 minutes.
 
@@ -1345,11 +1357,11 @@ spec:
 
 **`HEARTBEAT_CLIFF_MAX_CYCLES: 5`** -- At `POLL: 120`, 5 cycles = 10 minutes before the cliff detector gives up and accepts the state as genuine. This is long enough for most transient network events (spanning tree convergence, switch firmware upgrades, brief routing flaps) to resolve, while still bounded -- a genuine spine switch failure will be acted on within 10 minutes. **Important**: when the cliff expires, `MAX_HOSTS_PER_CYCLE` is the primary defense against fencing too many hosts at once. These two settings are mutually dependent -- do not raise `MAX_HOSTS_PER_CYCLE` without also ensuring `HEARTBEAT_CLIFF_MAX_CYCLES * POLL` exceeds your longest expected network reconvergence time. Values below 10 for `HEARTBEAT_CLIFF_THRESHOLD` are silently clamped to 10 (the ConfigManager minimum).
 
-**`THRESHOLD: 10`** -- At 1000 nodes, 10% allows up to 100 simultaneous failures. A single rack (~40 nodes) failing is 4%, two racks (80 nodes) is 8% -- both pass the threshold. 100+ hosts reporting down simultaneously indicates a Nova API issue, a cell outage, or a network partition. The per-aggregate thresholds (see below) provide finer-grained control within failure domains.
+**`THRESHOLD: 10`** -- At 1000 nodes, 10% means fencing is blocked when 100+ hosts are down or forced_down across the cluster (total cluster health). Since the threshold now counts previously-evacuated hosts that remain forced_down, a slow cascade accumulates toward this limit. A single rack (~40 nodes) failing is 4%, two racks (80 nodes) is 8% -- both pass the threshold. The per-aggregate thresholds (see below) provide finer-grained control within failure domains.
 
 **`MAX_HOSTS_PER_CYCLE: 5`** -- Limits fencing throughput to 5 hosts per cycle. A 40-node rack failure takes 8 poll cycles (16 minutes at `POLL: 120`) to fully fence, during which operators can observe the `FencingRateLimited` events and confirm the failure is genuine. For faster recovery within specific failure domains, use per-aggregate thresholds rather than raising the global cap.
 
-**`WORKERS: 8`** -- With `MAX_HOSTS_PER_CYCLE: 5`, 8 workers process the entire batch in a single round of parallel fencing. The inner evacuation thread pool is `EVACUATION_MAX_THREADS / WORKERS` = 32/8 = 4 concurrent evacuations per host (configurable via `EVACUATION_MAX_THREADS`). Peak concurrent evacuation requests: 5 x 4 = 20.
+**`WORKERS: 8`** -- The persistent `processing_executor` has 8 worker threads. The inner per-host evacuation thread pool is `EVACUATION_MAX_THREADS / WORKERS` = 32/8 = 4 concurrent evacuations per host (configurable via `EVACUATION_MAX_THREADS`). Since hosts are submitted to the executor non-blocking, multiple cycles' worth of hosts can be in flight simultaneously (bounded by `max_workers`).
 
 **`EVACUATION_RETRIES: 3`** -- At large scale, 5 retries per VM across 10 hosts with dozens of VMs each can create a long tail of retry traffic against the Nova API. 3 retries catches transient errors without piling up.
 

--- a/templates/instanceha/bin/instanceha.py
+++ b/templates/instanceha/bin/instanceha.py
@@ -854,6 +854,12 @@ class InstanceHAService:
         # Host processing tracking
         self.hosts_processing = defaultdict(float)
         self.processing_lock = threading.Lock()
+        try:
+            workers = self.config.get_config_value('WORKERS')
+        except (TypeError, ValueError, AttributeError):
+            workers = 4
+        self.processing_executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=workers if isinstance(workers, int) and workers > 0 else 4)
         self.reserved_hosts_lock = threading.Lock()
 
         logging.debug("MAX_HOSTS_PER_CYCLE=%d", self.config.get_config_value('MAX_HOSTS_PER_CYCLE'))
@@ -1325,6 +1331,18 @@ class InstanceHAService:
                     self._respond(500, "text/plain",
                                   f"Main loop stale ({staleness:.0f}s since last poll)".encode())
                     return
+
+                if service_instance.hosts_processing:
+                    now = time.monotonic()
+                    oldest_entry = min(service_instance.hosts_processing.values())
+                    max_processing = max(
+                        service_instance.config.get_config_value('FENCING_TIMEOUT'),
+                        service_instance.config.get_config_value('EVACUATION_TIMEOUT')) * 2
+                    if now - oldest_entry > max_processing:
+                        self._respond(500, "text/plain",
+                                      f"Processing stale ({len(service_instance.hosts_processing)} hosts, "
+                                      f"oldest {now - oldest_entry:.0f}s)".encode())
+                        return
 
                 self._respond(200, "text/plain", service_instance.current_hash)
 
@@ -3145,6 +3163,10 @@ def _filter_processing_hosts(service, compute_nodes, to_resume):
     current_time = time.monotonic()
     stagger = service.config.get_config_value('EVACUATION_STAGGER')
     max_threads = service.config.get_config_value('EVACUATION_MAX_THREADS')
+    # Use max_threads (not actual VM count) as the stagger multiplier: we don't
+    # know the per-host VM count at expiry-check time, so this is a deliberate
+    # safe upper bound that prevents premature expiry at the cost of holding the
+    # "in processing" slot longer than strictly necessary.
     max_processing_time = max(service.config.get_config_value('FENCING_TIMEOUT'),
                               service.config.get_config_value('EVACUATION_TIMEOUT')
                               + (max_threads - 1) * stagger)
@@ -3253,11 +3275,13 @@ def _filter_reachable_hosts(service, compute_nodes):
 
         timestamps_snapshot = dict(service.heartbeat_hosts_timestamp)
 
+    processing_hostnames = set(service.hosts_processing.keys())
     current_active = sum(
-        1 for ts in timestamps_snapshot.values()
-        if ts > 0 and (current_time - ts) <= heartbeat_timeout
+        1 for host, ts in timestamps_snapshot.items()
+        if host not in processing_hostnames
+        and ts > 0 and (current_time - ts) <= heartbeat_timeout
     )
-    previous_active = service.heartbeat_previous_active_count
+    previous_active = max(1, service.heartbeat_previous_active_count - len(processing_hostnames))
 
     cliff_detected = False
     if previous_active >= 3:
@@ -3311,14 +3335,15 @@ def _filter_reachable_hosts(service, compute_nodes):
     return unreachable, skipped, False
 
 
-def _process_stale_services(conn, service, services, compute_nodes, to_resume):
-    """Process stale compute services for evacuation."""
+def _admit_stale_services(conn, service, services, compute_nodes, to_resume):
+    """Evaluate safety gates and submit accepted hosts for background processing."""
     # Convert generators to lists - needed for multiple iterations and length checks
     compute_nodes = list(compute_nodes)
     to_resume = list(to_resume)
 
     if not (compute_nodes or to_resume):
         return
+
 
     # Filter out hosts already being processed
     compute_nodes, to_resume, marked_hostnames, current_time = _filter_processing_hosts(service, compute_nodes, to_resume)
@@ -3386,14 +3411,18 @@ def _process_stale_services(conn, service, services, compute_nodes, to_resume):
         compute_nodes, reserved_hosts, images, flavors = _prepare_evacuation_resources(
             conn, service, services, compute_nodes, aggregates=aggregates)
 
-        # Check evacuation threshold
+        # Check evacuation threshold: total cluster health (all down/forced_down
+        # hosts vs total hosts). Catches slow cascades where hosts fail one at a
+        # time -- previously-evacuated hosts that haven't recovered count as impacted.
         if services and compute_nodes:
-            # When TAGGED_AGGREGATES is enabled, calculate threshold against evacuable hosts only
             if service.config.get_config_value('TAGGED_AGGREGATES'):
+                evacuable_hosts = _get_evacuable_hosts_from_aggregates(conn, service, aggregates=aggregates)
                 total_evacuable = _count_evacuable_hosts(conn, service, services, aggregates=aggregates)
-                threshold_percent = (len(compute_nodes) / total_evacuable * 100) if total_evacuable > 0 else 0
+                total_down = _count_down_hosts(services, compute_nodes=compute_nodes, evacuable_hosts=evacuable_hosts)
+                threshold_percent = (total_down / total_evacuable * 100) if total_evacuable > 0 else 0
             else:
-                threshold_percent = (len(compute_nodes) / len(active_services)) * 100 if active_services else 0
+                total_down = _count_down_hosts(services, compute_nodes=compute_nodes)
+                threshold_percent = (total_down / len(services)) * 100 if services else 0
 
             threshold = service.config.get_config_value('THRESHOLD')
             if threshold_percent > threshold:
@@ -3446,13 +3475,6 @@ def _process_stale_services(conn, service, services, compute_nodes, to_resume):
                 to_evacuate = compute_nodes
                 kdump_fenced = []
 
-            workers = service.config.get_config_value('WORKERS')
-            poll_interval = service.config.get_config_value('POLL')
-            stagger = service.config.get_config_value('EVACUATION_STAGGER')
-            max_threads = service.config.get_config_value('EVACUATION_MAX_THREADS')
-            outer_timeout = (service.config.get_config_value('FENCING_TIMEOUT')
-                             + service.config.get_config_value('EVACUATION_TIMEOUT')
-                             + (max_threads - 1) * stagger + 60)
             for batch_name, batch, resume in [
                 ('new evacuations', to_evacuate, False),
                 ('kdump-fenced', kdump_fenced, True),
@@ -3460,13 +3482,19 @@ def _process_stale_services(conn, service, services, compute_nodes, to_resume):
             ]:
                 if not batch:
                     continue
-                _run_concurrent(
-                    lambda svc, _resume=resume: process_service(svc, reserved_hosts, _resume, service),
-                    batch,
-                    workers,
-                    lambda svc: f"{svc.host} ({batch_name})",
-                    timeout=outer_timeout,
-                )
+                logging.info("Submitting %d host(s) for %s", len(batch), batch_name)
+                for svc in batch:
+                    future = service.processing_executor.submit(
+                        process_service, svc, reserved_hosts, resume, service)
+                    _host = svc.host
+                    _batch = batch_name
+                    future.add_done_callback(
+                        lambda f, h=_host, b=_batch: logging.warning(
+                            "%s (%s) failed", h, b
+                        ) if f.exception() or not f.result() else logging.info(
+                            "%s (%s) succeeded", h, b
+                        )
+                    )
 
             final_hostnames = {_extract_hostname(svc.host) for svc in to_evacuate + kdump_fenced + to_resume}
         else:
@@ -3490,12 +3518,28 @@ def _get_evacuable_hosts_from_aggregates(conn, service, aggregates=None):
 
 
 def _count_evacuable_hosts(conn, service, services, aggregates=None):
-    """Count total number of compute services in evacuable aggregates."""
+    """Count total number of compute services in evacuable aggregates (all states)."""
     evacuable_hosts = _get_evacuable_hosts_from_aggregates(conn, service, aggregates)
-    active_services = [s for s in services if 'disabled' not in s.status and not getattr(s, 'forced_down', False)]
     if evacuable_hosts is None:
-        return len(active_services)
-    return sum(1 for svc in active_services if svc.host in evacuable_hosts)
+        return len(services)
+    return sum(1 for svc in services if svc.host in evacuable_hosts)
+
+
+def _count_down_hosts(services, compute_nodes=None, evacuable_hosts=None):
+    """Count compute services that are down, forced_down, or detected as stale.
+
+    Includes compute_nodes (hosts detected as stale by instanceha this cycle)
+    because Nova's state field may not have transitioned to 'down' yet --
+    instanceha detects staleness via timestamp before Nova does.
+    """
+    candidates = services
+    if evacuable_hosts is not None:
+        candidates = [s for s in services if s.host in evacuable_hosts]
+    down_hosts = {s.host for s in candidates
+                  if s.state == 'down' or getattr(s, 'forced_down', False)}
+    if compute_nodes:
+        down_hosts.update(s.host for s in compute_nodes)
+    return len(down_hosts)
 
 
 def _filter_by_aggregates(conn, service, compute_nodes, services, aggregates=None):
@@ -3515,6 +3559,7 @@ def _filter_by_aggregates(conn, service, compute_nodes, services, aggregates=Non
 def _filter_by_aggregate_threshold(compute_nodes, aggregates, service):
     """Filter out compute nodes whose aggregates exceeded their per-aggregate failure threshold."""
     failed_hosts = {svc.host for svc in compute_nodes}
+    processing_hostnames = set(service.hosts_processing.keys())
     blocked_hosts = set()
 
     for agg in aggregates:
@@ -3537,16 +3582,21 @@ def _filter_by_aggregate_threshold(compute_nodes, aggregates, service):
                            agg.name, AGGREGATE_MAX_FAILURES_KEY, max_failures_str)
             continue
 
+        agg_host_shortnames = {_extract_hostname(h) for h in agg.hosts}
         agg_failed = failed_hosts.intersection(agg.hosts)
-        if len(agg_failed) > max_failures:
+        agg_processing = len(processing_hostnames.intersection(agg_host_shortnames))
+        total_agg_impacted = len(agg_failed) + agg_processing
+        if total_agg_impacted > max_failures:
             logging.error(
-                "Aggregate '%s' has %d failed hosts (limit: %d). "
+                "Aggregate '%s' has %d impacted hosts (%d new + %d in-flight, limit: %d). "
                 "Blocking evacuation for hosts in this aggregate: %s",
-                agg.name, len(agg_failed), max_failures, sorted(agg_failed))
+                agg.name, total_agg_impacted, len(agg_failed), agg_processing,
+                max_failures, sorted(agg_failed))
             _emit_k8s_event(
                 agg.name, 'AggregateThresholdExceeded',
-                f'Aggregate has {len(agg_failed)} failed hosts '
-                f'(limit: {max_failures}), evacuation blocked',
+                f'Aggregate has {total_agg_impacted} impacted hosts '
+                f'({len(agg_failed)} new + {agg_processing} in-flight, '
+                f'limit: {max_failures}), evacuation blocked',
                 event_type='Warning')
             AGGREGATE_THRESHOLD_EXCEEDED_TOTAL.labels(aggregate=agg.name).inc()
             blocked_hosts.update(agg_failed)
@@ -3718,6 +3768,7 @@ def main():
         service.shutdown_event.set()
         service.kdump_listener_stop_event.set()
         service.heartbeat_listener_stop_event.set()
+        service.processing_executor.shutdown(wait=False)
         if service._http_server:
             threading.Thread(target=service._http_server.shutdown, daemon=True).start()
 
@@ -3747,7 +3798,7 @@ def main():
 
             compute_nodes_list = list(compute_nodes)
 
-            _process_stale_services(conn, service, services, compute_nodes_list, to_resume)
+            _admit_stale_services(conn, service, services, compute_nodes_list, to_resume)
             _process_reenabling(conn, service, to_reenable)
 
             stale_count = len(compute_nodes_list)
@@ -3783,6 +3834,8 @@ def main():
 
         service.shutdown_event.wait(poll_interval)
 
+    logging.info("Waiting for in-flight evacuations to complete")
+    service.processing_executor.shutdown(wait=True)
     logging.info("Graceful shutdown complete")
 
 

--- a/test/instanceha/functional_test.py
+++ b/test/instanceha/functional_test.py
@@ -2418,10 +2418,10 @@ class TestFencingRaceCondition(BaseTestCase):
         # Capture the filtered hosts that would be processed
         filtered_hosts_before = [svc.host for svc in compute_nodes]
 
-        # Call _process_stale_services (this should filter out the host being processed)
+        # Call _admit_stale_services (this should filter out the host being processed)
         with patch('instanceha._establish_nova_connection', return_value=mock_conn), \
              patch('instanceha.process_service', return_value=True) as mock_process:
-            instanceha._process_stale_services(mock_conn, self.env.service,
+            instanceha._admit_stale_services(mock_conn, self.env.service,
                                              self.env.mock_nova.services.list(),
                                              compute_nodes, to_resume)
 
@@ -2484,10 +2484,10 @@ class TestFencingRaceCondition(BaseTestCase):
         from unittest.mock import Mock, patch
         mock_conn = Mock()
 
-        # Call _process_stale_services which should trigger cleanup
+        # Call _admit_stale_services which should trigger cleanup
         with patch('instanceha._establish_nova_connection', return_value=mock_conn), \
              patch('instanceha.process_service', return_value=True):
-            instanceha._process_stale_services(mock_conn, self.env.service,
+            instanceha._admit_stale_services(mock_conn, self.env.service,
                                              self.env.mock_nova.services.list(),
                                              stale_services, [])
 
@@ -2522,10 +2522,10 @@ class TestFencingRaceCondition(BaseTestCase):
         mock_conn = Mock()
         mock_conn.services.list.return_value = []
 
-        # Call _process_stale_services
+        # Call _admit_stale_services
         with patch('instanceha._establish_nova_connection', return_value=mock_conn), \
              patch('instanceha.process_service', return_value=True) as mock_process:
-            instanceha._process_stale_services(mock_conn, self.env.service,
+            instanceha._admit_stale_services(mock_conn, self.env.service,
                                              self.env.mock_nova.services.list(),
                                              stale_services, [])
 

--- a/test/instanceha/integration_test.py
+++ b/test/instanceha/integration_test.py
@@ -448,7 +448,7 @@ class TestEvacuationWorkflow(unittest.TestCase):
         with patch('instanceha.process_service') as mock_process_service:
             mock_process_service.return_value = True
 
-            instanceha._process_stale_services(
+            instanceha._admit_stale_services(
                 nova_client, service, self.mock_env.services, compute_nodes, to_resume
             )
 
@@ -475,7 +475,7 @@ class TestEvacuationWorkflow(unittest.TestCase):
         )
 
         with patch('instanceha.process_service') as mock_process_service:
-            instanceha._process_stale_services(
+            instanceha._admit_stale_services(
                 nova_client, service, self.mock_env.services, compute_nodes, to_resume
             )
 
@@ -807,7 +807,7 @@ class TestPerformanceAndScaling(unittest.TestCase):
 
             # Test concurrent processing
             start_time = time.time()
-            instanceha._process_stale_services(
+            instanceha._admit_stale_services(
                 nova_client, service, self.mock_env.services, compute_nodes, to_resume
             )
             processing_time = time.time() - start_time
@@ -913,8 +913,8 @@ class TestIncompleteServiceHandling(unittest.TestCase):
             count = instanceha._count_evacuable_hosts(nova_client, service, self.mock_env.services)
         self.assertEqual(count, 3)
 
-    def test_process_stale_services_with_incomplete_services(self):
-        """_process_stale_services should not crash when incomplete services are in the list."""
+    def test_admit_stale_services_with_incomplete_services(self):
+        """_admit_stale_services should not crash when incomplete services are in the list."""
         self.mock_env.add_incomplete_compute_service('compute-unknown')
         self.mock_env.add_compute_service('compute-ok', state='up', status='enabled')
 
@@ -927,7 +927,7 @@ class TestIncompleteServiceHandling(unittest.TestCase):
         )
 
         with patch('instanceha.process_service') as mock_process:
-            instanceha._process_stale_services(
+            instanceha._admit_stale_services(
                 nova_client, service, self.mock_env.services,
                 compute_nodes, to_resume
             )
@@ -978,7 +978,7 @@ class TestErrorHandlingAndRecovery(unittest.TestCase):
                 self.mock_env.services, target_date
             )
 
-            instanceha._process_stale_services(
+            instanceha._admit_stale_services(
                 nova_client, service, self.mock_env.services, compute_nodes, to_resume
             )
 

--- a/test/instanceha/test_aggregate_threshold.py
+++ b/test/instanceha/test_aggregate_threshold.py
@@ -29,6 +29,7 @@ def _make_service_obj(host):
 def _make_instanceha_service(evacuable_tag='evacuable'):
     service = Mock()
     service.evacuable_tag = evacuable_tag
+    service.hosts_processing = {}
     service._is_resource_evacuable = instanceha.InstanceHAService._is_resource_evacuable.__get__(service)
     service._check_evacuable_tag = instanceha.InstanceHAService._check_evacuable_tag.__get__(service)
     return service

--- a/test/instanceha/test_config_features.py
+++ b/test/instanceha/test_config_features.py
@@ -84,7 +84,7 @@ class TestDisabledConfig(unittest.TestCase):
             with patch('instanceha._prepare_evacuation_resources', return_value=(compute_nodes, [], [], [])):
                 with patch('instanceha._cleanup_filtered_hosts'):
                     with patch('instanceha.process_service') as mock_process:
-                        instanceha._process_stale_services(
+                        instanceha._admit_stale_services(
                             mock_conn,
                             mock_service,
                             services,
@@ -123,17 +123,16 @@ class TestDisabledConfig(unittest.TestCase):
         with patch('instanceha._filter_processing_hosts', return_value=(compute_nodes, [], set(['test-host']), 0)):
             with patch('instanceha._prepare_evacuation_resources', return_value=(compute_nodes, [], [], [])):
                 with patch('instanceha._cleanup_filtered_hosts'):
-                    with patch('instanceha.process_service', return_value=True) as mock_process:
-                        instanceha._process_stale_services(
-                            mock_conn,
-                            mock_service,
-                            services,
-                            compute_nodes,
-                            []
-                        )
+                    instanceha._admit_stale_services(
+                        mock_conn,
+                        mock_service,
+                        services,
+                        compute_nodes,
+                        []
+                    )
 
-        # Should process services when not disabled
-        mock_process.assert_called()
+        # Should submit services for processing when not disabled
+        mock_service.processing_executor.submit.assert_called()
 
 
 class TestForceEnableConfig(unittest.TestCase):
@@ -421,19 +420,19 @@ class TestTaggedAggregatesConfig(unittest.TestCase):
         mock_service.processing_lock = Mock()
         mock_service.hosts_processing = {}
 
-        svc1 = Mock(host='host1', status='enabled', forced_down=False)
-        svc2 = Mock(host='host2', status='enabled', forced_down=False)
+        svc1 = Mock(host='host1', status='enabled', forced_down=False, state='down')
+        svc2 = Mock(host='host2', status='enabled', forced_down=False, state='down')
+        healthy = [Mock(host=f'host{i}', status='enabled', forced_down=False, state='up') for i in range(3, 8)]
 
-        services = [svc1, svc2]
+        services = [svc1, svc2] + healthy
         compute_nodes = [svc1, svc2]
 
         with patch('instanceha._filter_processing_hosts', return_value=(compute_nodes, [], set(['host1', 'host2']), 0)):
             with patch('instanceha._prepare_evacuation_resources', return_value=(compute_nodes, [], [], [])):
                 with patch('instanceha._cleanup_filtered_hosts'):
-                    with patch('instanceha.process_service', return_value=True):
-                        # Should not call _filter_by_aggregates when disabled
+                    with patch('instanceha._check_critical_services', return_value=(True, '')):
                         with patch('instanceha._filter_by_aggregates') as mock_filter:
-                            instanceha._process_stale_services(
+                            instanceha._admit_stale_services(
                                 mock_conn,
                                 mock_service,
                                 services,

--- a/test/instanceha/test_coverage_gaps.py
+++ b/test/instanceha/test_coverage_gaps.py
@@ -15,7 +15,7 @@ Covers:
 - _is_service_stale: datetime.fromisoformat error handling
 - _monitor_evacuation: poll/retry/timeout behavior
 - main() backoff: exponential backoff on Unauthorized/DiscoveryFailure/generic errors
-- _process_stale_services: safety branches for empty/threshold/disabled paths
+- _admit_stale_services: safety branches for empty/threshold/disabled paths
 """
 
 import threading
@@ -863,7 +863,7 @@ class TestMainLoopBackoff(unittest.TestCase):
 
     @patch('instanceha.signal.signal')
     @patch('instanceha._process_reenabling')
-    @patch('instanceha._process_stale_services')
+    @patch('instanceha._admit_stale_services')
     @patch('instanceha._categorize_services')
     @patch('instanceha._establish_nova_connection')
     @patch('instanceha._initialize_service')
@@ -924,11 +924,11 @@ class TestMainLoopBackoff(unittest.TestCase):
 
 
 # ============================================================================
-# _process_stale_services safety branches tests
+# _admit_stale_services safety branches tests
 # ============================================================================
 
 class TestProcessStaleServicesSafety(unittest.TestCase):
-    """Tests for _process_stale_services safety branches."""
+    """Tests for _admit_stale_services safety branches."""
 
     def _make_service(self):
         import threading
@@ -952,7 +952,7 @@ class TestProcessStaleServicesSafety(unittest.TestCase):
 
     def test_empty_compute_nodes_and_resume(self):
         service = self._make_service()
-        instanceha._process_stale_services(Mock(), service, [], [], [])
+        instanceha._admit_stale_services(Mock(), service, [], [], [])
 
     def test_all_hosts_already_processing(self):
         import time as time_mod
@@ -961,7 +961,7 @@ class TestProcessStaleServicesSafety(unittest.TestCase):
         svc1.host = 'host-1'
         with service.processing_lock:
             service.hosts_processing['host-1'] = time_mod.monotonic()
-        instanceha._process_stale_services(Mock(), service, [svc1], [svc1], [])
+        instanceha._admit_stale_services(Mock(), service, [svc1], [svc1], [])
 
     def test_threshold_exceeded_skips_evacuation(self):
         service = self._make_service()
@@ -975,7 +975,7 @@ class TestProcessStaleServicesSafety(unittest.TestCase):
         service.filter_hosts_with_servers.return_value = [svc1]
         with patch('instanceha._emit_k8s_event'):
             with patch('instanceha._check_critical_services', return_value=(True, "")):
-                instanceha._process_stale_services(conn, service, [svc1], [svc1], [])
+                instanceha._admit_stale_services(conn, service, [svc1], [svc1], [])
 
     def test_disabled_mode_skips_evacuation(self):
         service = self._make_service()
@@ -992,7 +992,7 @@ class TestProcessStaleServicesSafety(unittest.TestCase):
         service.get_hosts_with_servers_cached.return_value = {'host-1': ['server-1']}
         service.filter_hosts_with_servers.return_value = [svc1]
         with patch('instanceha._emit_k8s_event'):
-            instanceha._process_stale_services(conn, service, [svc1], [svc1], [])
+            instanceha._admit_stale_services(conn, service, [svc1], [svc1], [])
 
     def test_no_evacuable_servers_after_filtering(self):
         service = self._make_service()
@@ -1002,7 +1002,7 @@ class TestProcessStaleServicesSafety(unittest.TestCase):
         service.get_hosts_with_servers_cached.return_value = {}
         service.filter_hosts_with_servers.return_value = []
         with patch('instanceha._emit_k8s_event'):
-            instanceha._process_stale_services(conn, service, [svc1], [svc1], [])
+            instanceha._admit_stale_services(conn, service, [svc1], [svc1], [])
 
 
 class TestReconcileOrphanedHosts(unittest.TestCase):
@@ -1779,7 +1779,7 @@ class TestNovaLoginAC(unittest.TestCase):
 # ============================================================================
 
 class TestFencingRateLimiter(unittest.TestCase):
-    """Tests for MAX_HOSTS_PER_CYCLE rate limiting in _process_stale_services."""
+    """Tests for MAX_HOSTS_PER_CYCLE rate limiting in _admit_stale_services."""
 
     def _make_service(self):
         import threading
@@ -1827,7 +1827,7 @@ class TestFencingRateLimiter(unittest.TestCase):
             f'host-{i}': [f'server-{i}'] for i in range(5)
         }
 
-        instanceha._process_stale_services(conn, service, all_services, stale_hosts, [])
+        instanceha._admit_stale_services(conn, service, all_services, stale_hosts, [])
 
         fenced_hosts = [c[0][0] for c in mock_fence.call_args_list]
         self.assertLessEqual(len(fenced_hosts), 3)
@@ -1848,7 +1848,7 @@ class TestFencingRateLimiter(unittest.TestCase):
             f'host-{i}': [f'server-{i}'] for i in range(2)
         }
 
-        instanceha._process_stale_services(conn, service, all_services, stale_hosts, [])
+        instanceha._admit_stale_services(conn, service, all_services, stale_hosts, [])
 
         rate_events = [c for c in mock_event.call_args_list
                        if len(c[0]) >= 2 and c[0][1] == 'FencingRateLimited']
@@ -1870,7 +1870,7 @@ class TestFencingRateLimiter(unittest.TestCase):
             f'host-{i}': [f'server-{i}'] for i in range(5)
         }
 
-        instanceha._process_stale_services(conn, service, all_services, stale_hosts, [])
+        instanceha._admit_stale_services(conn, service, all_services, stale_hosts, [])
 
         rate_events = [c for c in mock_event.call_args_list
                        if len(c[0]) >= 2 and c[0][1] == 'FencingRateLimited']
@@ -1893,7 +1893,7 @@ class TestFencingRateLimiter(unittest.TestCase):
         }
 
         before = instanceha.FENCING_RATE_LIMITED_TOTAL._value.get()
-        instanceha._process_stale_services(conn, service, all_services, stale_hosts, [])
+        instanceha._admit_stale_services(conn, service, all_services, stale_hosts, [])
         after = instanceha.FENCING_RATE_LIMITED_TOTAL._value.get()
         self.assertEqual(after - before, 1)
 
@@ -1903,7 +1903,7 @@ class TestFencingRateLimiter(unittest.TestCase):
 # ============================================================================
 
 class TestAllServicesStaleCircuitBreaker(unittest.TestCase):
-    """Tests for the all-services-stale safety check in _process_stale_services."""
+    """Tests for the all-services-stale safety check in _admit_stale_services."""
 
     def _make_service(self):
         import threading
@@ -1943,7 +1943,7 @@ class TestAllServicesStaleCircuitBreaker(unittest.TestCase):
         all_services = list(hosts)
 
         with patch('instanceha._execute_fence_operation') as mock_fence:
-            instanceha._process_stale_services(conn, service, all_services, hosts, [])
+            instanceha._admit_stale_services(conn, service, all_services, hosts, [])
             mock_fence.assert_not_called()
 
         stale_events = [c for c in mock_event.call_args_list
@@ -1959,7 +1959,7 @@ class TestAllServicesStaleCircuitBreaker(unittest.TestCase):
         all_services = list(hosts)
 
         before = instanceha.ALL_SERVICES_STALE_TOTAL._value.get()
-        instanceha._process_stale_services(conn, service, all_services, hosts, [])
+        instanceha._admit_stale_services(conn, service, all_services, hosts, [])
         after = instanceha.ALL_SERVICES_STALE_TOTAL._value.get()
         self.assertEqual(after - before, 1)
 
@@ -1978,7 +1978,7 @@ class TestAllServicesStaleCircuitBreaker(unittest.TestCase):
             f'host-{i}': [f'server-{i}'] for i in range(3)
         }
 
-        instanceha._process_stale_services(conn, service, all_services, stale_hosts, [])
+        instanceha._admit_stale_services(conn, service, all_services, stale_hosts, [])
 
         stale_events = [c for c in mock_event.call_args_list
                         if len(c[0]) >= 2 and c[0][1] == 'AllServicesStale']
@@ -1996,7 +1996,7 @@ class TestAllServicesStaleCircuitBreaker(unittest.TestCase):
             f'host-{i}': [f'server-{i}'] for i in range(2)
         }
 
-        instanceha._process_stale_services(conn, service, all_services, hosts, [])
+        instanceha._admit_stale_services(conn, service, all_services, hosts, [])
 
         stale_events = [c for c in mock_event.call_args_list
                         if len(c[0]) >= 2 and c[0][1] == 'AllServicesStale']
@@ -2012,7 +2012,7 @@ class TestAllServicesStaleCircuitBreaker(unittest.TestCase):
         all_services = stale_hosts + disabled_hosts
 
         with patch('instanceha._execute_fence_operation') as mock_fence:
-            instanceha._process_stale_services(conn, service, all_services, stale_hosts, [])
+            instanceha._admit_stale_services(conn, service, all_services, stale_hosts, [])
             mock_fence.assert_not_called()
 
         stale_events = [c for c in mock_event.call_args_list
@@ -2029,7 +2029,7 @@ class TestAllServicesStaleCircuitBreaker(unittest.TestCase):
         all_services = stale_hosts + forced_hosts
 
         with patch('instanceha._execute_fence_operation') as mock_fence:
-            instanceha._process_stale_services(conn, service, all_services, stale_hosts, [])
+            instanceha._admit_stale_services(conn, service, all_services, stale_hosts, [])
             mock_fence.assert_not_called()
 
         stale_events = [c for c in mock_event.call_args_list

--- a/test/instanceha/test_fencing_agents.py
+++ b/test/instanceha/test_fencing_agents.py
@@ -1129,14 +1129,17 @@ class TestFencingRaceCondition(unittest.TestCase):
         mock_services = [Mock(status='enabled', forced_down=False) for _ in range(10)]
 
         # Simulate filtering: hosts get filtered out (no servers)
-        # The cleanup should happen in _process_stale_services after filtering
+        # The cleanup should happen in _admit_stale_services after filtering
         with unittest.mock.patch.object(self.service, 'get_hosts_with_servers_cached', return_value={}), \
              unittest.mock.patch.object(self.service, 'get_evacuable_images', return_value=[]), \
              unittest.mock.patch.object(self.service, 'get_evacuable_flavors', return_value=[]), \
              unittest.mock.patch.object(self.service, 'refresh_evacuable_cache'):
-            instanceha._process_stale_services(mock_conn, self.service, mock_services, [mock_svc1, mock_svc2], [])
+            instanceha._admit_stale_services(mock_conn, self.service, mock_services, [mock_svc1, mock_svc2], [])
 
-        # Verify filtered hosts are cleaned up (were marked but filtered out)
+        # Wait for async processing to complete
+        self.service.processing_executor.shutdown(wait=True)
+
+        # Verify hosts are cleaned up after processing
         with self.service.processing_lock:
             self.assertNotIn('host-1', self.service.hosts_processing)
             self.assertNotIn('host-2', self.service.hosts_processing)
@@ -1161,7 +1164,7 @@ class TestFencingRaceCondition(unittest.TestCase):
              unittest.mock.patch.object(self.service, 'get_evacuable_images', return_value=[]), \
              unittest.mock.patch.object(self.service, 'get_evacuable_flavors', return_value=[]), \
              unittest.mock.patch.object(self.service, 'refresh_evacuable_cache'):
-            instanceha._process_stale_services(mock_conn, self.service, mock_services, [mock_svc], [])
+            instanceha._admit_stale_services(mock_conn, self.service, mock_services, [mock_svc], [])
 
         # Verify host is cleaned up (threshold exceeded, no evacuation)
         with self.service.processing_lock:
@@ -1184,7 +1187,7 @@ class TestFencingRaceCondition(unittest.TestCase):
              unittest.mock.patch.object(self.service, 'get_evacuable_flavors', return_value=[]), \
              unittest.mock.patch.object(self.service, 'refresh_evacuable_cache'):
             # Pass host that will be filtered out
-            instanceha._process_stale_services(mock_conn, self.service, mock_services, [mock_svc], [])
+            instanceha._admit_stale_services(mock_conn, self.service, mock_services, [mock_svc], [])
 
         # Verify host is cleaned up (was marked but filtered out)
         with self.service.processing_lock:

--- a/test/instanceha/test_helper_functions.py
+++ b/test/instanceha/test_helper_functions.py
@@ -209,7 +209,7 @@ class TestFilterProcessingHosts(unittest.TestCase):
             EVACUATION_TIMEOUT=300, FENCING_TIMEOUT=30))
 
         # Add an entry that would be expired without stagger (350s ago > 300+30),
-        # but should survive with stagger (300 + 31*10 = 610 + 30 padding = 640)
+        # but should survive with stagger (300 + (32-1)*10 = 610 + 30 padding = 640)
         old_time = time.monotonic() - 350
         service.hosts_processing['active-host'] = old_time
 

--- a/test/instanceha/test_k8s_partition.py
+++ b/test/instanceha/test_k8s_partition.py
@@ -169,12 +169,12 @@ class TestFencingGate(unittest.TestCase):
         self.service = instanceha.InstanceHAService(self.config)
 
     def test_k8s_unreachable_blocks_fencing(self):
-        """When k8s_api_reachable is False, _process_stale_services should not be called."""
+        """When k8s_api_reachable is False, _admit_stale_services should not be called."""
         self.service.k8s_api_reachable = False
         self.service.ready = False
 
-        # _process_stale_services should not be called
-        with patch('instanceha._process_stale_services') as mock_process:
+        # _admit_stale_services should not be called
+        with patch('instanceha._admit_stale_services') as mock_process:
             with patch('instanceha._process_reenabling') as mock_reenable:
                 # Simulate what the main loop does
                 if not self.service.k8s_api_reachable:

--- a/test/instanceha/test_unit_core.py
+++ b/test/instanceha/test_unit_core.py
@@ -2830,7 +2830,7 @@ class TestFunctionalIntegration(unittest.TestCase):
              patch.object(service, 'get_hosts_with_servers_cached', return_value=host_servers_cache), \
              patch.object(service, 'filter_hosts_with_servers', side_effect=lambda services, cache: services):
 
-            # Simulate one poll cycle - call _process_stale_services
+            # Simulate one poll cycle - call _admit_stale_services
             target_date = datetime.now() - timedelta(seconds=30)
             compute_nodes, to_resume, to_reenable = instanceha._categorize_services(
                 nova_state['services'], target_date
@@ -2840,9 +2840,12 @@ class TestFunctionalIntegration(unittest.TestCase):
             down_hosts = [s for s in list(compute_nodes) if s.state == 'down']
 
             # Process stale services
-            instanceha._process_stale_services(
+            instanceha._admit_stale_services(
                 mock_nova, service, nova_state['services'], down_hosts, []
             )
+
+            # Wait for async processing to complete
+            service.processing_executor.shutdown(wait=True)
 
         # Verify cache was used (flavors/images list called for cache)
         self.assertGreaterEqual(mock_nova.flavors.list.call_count, 1)
@@ -2952,12 +2955,102 @@ class TestFunctionalIntegration(unittest.TestCase):
              patch.object(service, 'filter_hosts_with_servers', side_effect=lambda services, cache: services):
 
             # Process should now work
-            instanceha._process_stale_services(
+            instanceha._admit_stale_services(
                 mock_nova, service, nova_state['services'], down_list, []
             )
 
-        # Verify at least some hosts were processed
-        self.assertGreaterEqual(mock_nova.services.force_down.call_count, 1)
+            # Wait for async processing to complete
+            service.processing_executor.shutdown(wait=True)
+
+            # Verify at least some hosts were processed
+            self.assertGreaterEqual(mock_nova.services.force_down.call_count, 1)
+
+    def test_cascading_failure_threshold_with_inflight_evacuation(self):
+        """Test that hosts already being evacuated count toward the cluster threshold.
+
+        Scenario: 10 hosts total, threshold 40%.
+        - 3 hosts are already forced_down from a previous cycle (30%)
+        - 2 new hosts fail, bringing total impact to 5/10 = 50% > 40%
+        - The new failures should be blocked by the threshold gate.
+        """
+        mock_nova, nova_state = self._create_mock_nova_stateful()
+
+        for i in range(10):
+            svc = Mock()
+            svc.id = f'service-{i}'
+            svc.host = f'compute-{i}.example.com'
+            svc.binary = 'nova-compute'
+            svc.status = 'enabled'
+            svc.disabled_reason = None
+            if i < 3:
+                # Previously evacuated: forced_down but state='up' means Nova
+                # sees them as recovered enough to report, yet still impacted
+                svc.forced_down = True
+                svc.state = 'down'
+                svc.updated_at = (datetime.now() - timedelta(minutes=30)).isoformat()
+            elif i < 5:
+                # Newly failed this cycle
+                svc.forced_down = False
+                svc.state = 'down'
+                svc.updated_at = (datetime.now() - timedelta(minutes=5)).isoformat()
+            else:
+                svc.forced_down = False
+                svc.state = 'up'
+                svc.updated_at = datetime.now().isoformat()
+            nova_state['services'].append(svc)
+
+        # Add servers on the two newly-failed hosts so they pass filter
+        for i in range(3, 5):
+            server = Mock()
+            server.id = f'server-{i}'
+            server.host = f'compute-{i}.example.com'
+            server.status = 'ACTIVE'
+            server.name = f'test-server-{i}'
+            setattr(server, 'OS-EXT-STS:task_state', None)
+            server.image = {'id': 'image-1'}
+            server.flavor = {'id': 'flavor-1', 'extra_specs': {}}
+            nova_state['servers'].append(server)
+
+        config = instanceha.ConfigManager()
+        service = instanceha.InstanceHAService(config, mock_nova)
+
+        config_values = {
+            'TAGGED_FLAVORS': False,
+            'TAGGED_IMAGES': False,
+            'TAGGED_AGGREGATES': False,
+            'THRESHOLD': 40,
+            'WORKERS': 4,
+        }
+        service.config.get_config_value = Mock(side_effect=lambda key: config_values.get(key, False))
+
+        service.config.fencing = {
+            f'compute-{i}': {'agent': 'ipmi', 'ipaddr': f'192.168.1.{i}', 'login': 'admin', 'passwd': 'test'}
+            for i in range(3, 5)
+        }
+
+        host_servers_cache = {f'compute-{i}.example.com': [nova_state['servers'][i - 3]]
+                              for i in range(3, 5)}
+
+        # Only the 2 newly-failed hosts are passed as compute_nodes
+        target_date = datetime.now() - timedelta(seconds=30)
+        compute_nodes, _, _ = instanceha._categorize_services(nova_state['services'], target_date)
+        new_down = [s for s in list(compute_nodes) if s.state == 'down' and not s.forced_down]
+
+        with patch('instanceha._execute_fence_operation', return_value=True), \
+             patch('instanceha._check_kdump', return_value=(new_down, [])), \
+             patch('instanceha._establish_nova_connection', return_value=mock_nova), \
+             patch.object(service, 'get_hosts_with_servers_cached', return_value=host_servers_cache), \
+             patch.object(service, 'filter_hosts_with_servers', side_effect=lambda services, cache: services):
+
+            instanceha._admit_stale_services(
+                mock_nova, service, nova_state['services'], new_down, []
+            )
+
+            service.processing_executor.shutdown(wait=True)
+
+        # Threshold is 40%, total impact is 5/10 = 50% — evacuation must be blocked
+        self.assertEqual(mock_nova.services.force_down.call_count, 0,
+                         "Evacuation should be blocked: 3 already forced_down + 2 new = 50% > 40% threshold")
 
     def test_host_recovery_workflow(self):
         """Test host recovery: re-enable after forced_down."""


### PR DESCRIPTION
The main poll loop previously blocked during evacuation, preventing detection of new host failures until in-flight evacuations completed. This change decouples detection (admission) from processing (evacuation) and makes every cumulative safety gate evaluate total cluster impact.

Async processing:
- Add persistent ThreadPoolExecutor to InstanceHAService for background host processing (fence + evacuate)
- Rename _process_stale_services to _admit_stale_services: safety gates run synchronously, then accepted hosts are submitted to the executor non-blocking
- Main loop no longer blocks on evacuation -- polls every POLL seconds regardless of in-flight work

Total-impact safety gates:
- Global threshold: evaluates total cluster health (all down/forced_down hosts vs all services) using _count_down_hosts. Catches slow cascades where hosts fail one per cycle -- previously-evacuated hosts that haven't recovered count as impacted
- All-stale check: includes in-flight count when checking whether all active services appear stale
- Per-aggregate threshold: counts in-flight hosts toward their aggregate failure budget
- Heartbeat cliff: excludes hosts_processing from active heartbeat counts so expected heartbeat absence does not trigger false cliff detection

Processing health:
- Liveness probe detects stale processing entries (oldest entry > 2x max(FENCING_TIMEOUT, EVACUATION_TIMEOUT)) since the main loop no longer blocks and cannot detect hung processing via poll staleness
- Graceful shutdown: SIGTERM stops new submissions, then waits for in-flight evacuations to complete