### PR TITLE
Remove deprecated webhook.Defaulter/Validator interface assertions

### DIFF
--- a/apis/memcached/v1beta1/memcached_webhook.go
+++ b/apis/memcached/v1beta1/memcached_webhook.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	common_webhook "github.com/openstack-k8s-operators/lib-common/modules/common/webhook"
@@ -50,8 +49,6 @@ func SetupMemcachedDefaults(defaults MemcachedDefaults) {
 	memcachedlog.Info("Memcached defaults initialized", "defaults", defaults)
 }
 
-var _ webhook.Defaulter = &Memcached{}
-
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *Memcached) Default() {
 	memcachedlog.Info("default", "name", r.Name)
@@ -71,8 +68,6 @@ func (spec *MemcachedSpec) Default() {
 func (spec *MemcachedSpecCore) Default() {
 	// nothing here
 }
-
-var _ webhook.Validator = &Memcached{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Memcached) ValidateCreate() (admission.Warnings, error) {

--- a/apis/network/v1beta1/dnsmasq_webhook.go
+++ b/apis/network/v1beta1/dnsmasq_webhook.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -44,8 +43,6 @@ func SetupDNSMasqDefaults(defaults DNSMasqDefaults) {
 	dnsMasqDefaults = defaults
 	dnsmasqlog.Info("DNSMasq defaults initialized", "defaults", defaults)
 }
-
-var _ webhook.Defaulter = &DNSMasq{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *DNSMasq) Default() {
@@ -84,8 +81,6 @@ func (spec *DNSMasqSpecCore) Default(namespace string) {
 		})
 	}
 }
-
-var _ webhook.Validator = &DNSMasq{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *DNSMasq) ValidateCreate() (admission.Warnings, error) {

--- a/apis/network/v1beta1/ipset_webhook.go
+++ b/apis/network/v1beta1/ipset_webhook.go
@@ -29,14 +29,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	k8snet "k8s.io/utils/net"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // log is for logging in this package.
 var ipsetlog = logf.Log.WithName("ipset-resource")
-
-var _ webhook.Defaulter = &IPSet{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *IPSet) Default() {
@@ -44,8 +41,6 @@ func (r *IPSet) Default() {
 
 	// TODO(user): fill in your defaulting logic.
 }
-
-var _ webhook.Validator = &IPSet{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *IPSet) ValidateCreate() (admission.Warnings, error) {

--- a/apis/network/v1beta1/netconfig_webhook.go
+++ b/apis/network/v1beta1/netconfig_webhook.go
@@ -30,14 +30,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	k8snet "k8s.io/utils/net"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // log is for logging in this package.
 var netconfiglog = logf.Log.WithName("netconfig-resource")
-
-var _ webhook.Defaulter = &NetConfig{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *NetConfig) Default() {
@@ -47,8 +44,6 @@ func (r *NetConfig) Default() {
 		}
 	}
 }
-
-var _ webhook.Validator = &NetConfig{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *NetConfig) ValidateCreate() (admission.Warnings, error) {

--- a/apis/network/v1beta1/reservation_webhook.go
+++ b/apis/network/v1beta1/reservation_webhook.go
@@ -19,14 +19,11 @@ package v1beta1
 import (
 	"k8s.io/apimachinery/pkg/runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // log is for logging in this package.
 var reservationlog = logf.Log.WithName("reservation-resource")
-
-var _ webhook.Defaulter = &Reservation{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *Reservation) Default() {
@@ -34,8 +31,6 @@ func (r *Reservation) Default() {
 
 	// TODO(user): fill in your defaulting logic.
 }
-
-var _ webhook.Validator = &Reservation{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Reservation) ValidateCreate() (admission.Warnings, error) {

--- a/apis/rabbitmq/v1beta1/rabbitmq_webhook.go
+++ b/apis/rabbitmq/v1beta1/rabbitmq_webhook.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -161,8 +160,6 @@ func (spec *RabbitMqSpecCore) Default(isNew bool) {
 			"targetVersion", *spec.TargetVersion)
 	}
 }
-
-var _ webhook.Validator = &RabbitMq{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *RabbitMq) ValidateCreate() (admission.Warnings, error) {

--- a/apis/redis/v1beta1/redis_webhook.go
+++ b/apis/redis/v1beta1/redis_webhook.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	common_webhook "github.com/openstack-k8s-operators/lib-common/modules/common/webhook"
@@ -50,8 +49,6 @@ func SetupRedisDefaults(defaults RedisDefaults) {
 	redislog.Info("Redis defaults initialized", "defaults", defaults)
 }
 
-var _ webhook.Defaulter = &Redis{}
-
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *Redis) Default() {
 	redislog.Info("default", "name", r.Name)
@@ -71,8 +68,6 @@ func (spec *RedisSpec) Default() {
 func (spec *RedisSpecCore) Default() {
 	//nothing to validate yet
 }
-
-var _ webhook.Validator = &Redis{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Redis) ValidateCreate() (admission.Warnings, error) {


### PR DESCRIPTION
These compile-time assertions reference webhook.Defaulter and webhook.Validator interfaces that are removed in controller-runtime v0.21 (OCP 4.20). The assertions are dead code — webhook registration already uses CustomDefaulter/CustomValidator in internal/webhook/.

Removing them makes the API module forward-compatible with CR v0.21 so that consumers (like openstack-operator) can bump controller-runtime without needing replace directives for this operator.

Jira: [OSPRH-32989](https://redhat.atlassian.net/browse/OSPRH-32989)