### PR TITLE
Resume-safe evacuation: check migration status before re-evacuating on pod restart

### DIFF
--- a/templates/instanceha/bin/instanceha.py
+++ b/templates/instanceha/bin/instanceha.py
@@ -64,6 +64,7 @@ KDUMP_MAGIC_NUMBER = 0x1B302A40
 MAX_PROCESSING_TIME_PADDING_SECONDS = 30
 MIGRATION_QUERY_MINUTES = 5
 MIGRATION_QUERY_LIMIT = 1000
+RESUME_MIGRATION_QUERY_MINUTES = 60
 USERNAME_MAX_LENGTH = 64
 FENCING_RETRY_DELAY_SECONDS = 1
 KDUMP_REENABLE_DELAY_SECONDS = 60
@@ -262,6 +263,7 @@ class EvacuationStatus:
     """Status of an ongoing server evacuation."""
     completed: bool
     error: bool
+    created_at: Optional[str] = None
 
 
 @dataclass
@@ -1635,13 +1637,16 @@ def _should_skip_server(server, skip_names) -> bool:
     return any(fnmatch.fnmatch(server.name, pattern) for pattern in skip_names)
 
 
-def _get_evacuable_servers(connection, host, service) -> List:
+def _get_evacuable_servers(connection, host, service, resume=False) -> List:
     """Get list of evacuable servers from a host."""
     images = service.get_evacuable_images(connection)
     flavors = service.get_evacuable_flavors(connection)
 
     servers = connection.servers.list(search_opts={'host': host, 'all_tenants': 1})
-    servers = [s for s in servers if s.status in {'ACTIVE', 'ERROR', 'SHUTOFF'}]
+    allowed_statuses = {'ACTIVE', 'ERROR', 'SHUTOFF'}
+    if resume:
+        allowed_statuses.add('REBUILD')
+    servers = [s for s in servers if s.status in allowed_statuses]
 
     skip_names = service.config.get_config_value('SKIP_SERVERS_WITH_NAME')
     if skip_names:
@@ -1760,7 +1765,7 @@ def _run_concurrent(func, items, max_workers, item_id_func, log_prefix="",
     return all_succeeded
 
 
-def _concurrent_evacuate(connection, evacuables, service, host, service_id, target_host=None) -> bool:
+def _concurrent_evacuate(connection, evacuables, service, host, service_id, target_host=None, resume=False) -> bool:
     """Evacuate concurrently, optionally with priority-ordered phases."""
     orchestrated = service.config.get_config_value('ORCHESTRATED_RESTART')
     phases = _build_evacuation_groups(evacuables) if orchestrated else [evacuables]
@@ -1787,7 +1792,8 @@ def _concurrent_evacuate(connection, evacuables, service, host, service_id, targ
             lambda s: _server_evacuate_future(connection, s, target_host,
                                               max_retries=max_retries,
                                               shutdown_event=service.shutdown_event,
-                                              evacuation_timeout=evacuation_timeout),
+                                              evacuation_timeout=evacuation_timeout,
+                                              resume=resume),
             phase_servers,
             inner_workers,
             lambda s: s.id,
@@ -1832,11 +1838,11 @@ def _traditional_evacuate(connection, evacuables, host, target_host=None) -> boo
 
     return all_succeeded
 
-def _host_evacuate(connection, failed_service, service, target_host=None) -> bool:
+def _host_evacuate(connection, failed_service, service, target_host=None, resume=False) -> bool:
     """Evacuate all instances from a failed host."""
     host = failed_service.host
 
-    evacuables = _get_evacuable_servers(connection, host, service)
+    evacuables = _get_evacuable_servers(connection, host, service, resume=resume)
     if not evacuables:
         logging.info("Nothing to evacuate")
         return True
@@ -1844,7 +1850,7 @@ def _host_evacuate(connection, failed_service, service, target_host=None) -> boo
     _interruptible_sleep(service.shutdown_event, service.config.get_config_value('DELAY'))
 
     if service.config.get_config_value('ORCHESTRATED_RESTART') or service.config.get_config_value('SMART_EVACUATION'):
-        return _concurrent_evacuate(connection, evacuables, service, host, failed_service.id, target_host=target_host)
+        return _concurrent_evacuate(connection, evacuables, service, host, failed_service.id, target_host=target_host, resume=resume)
     else:
         return _traditional_evacuate(connection, evacuables, host, target_host=target_host)
 
@@ -1952,10 +1958,12 @@ def _server_evacuation_status(connection, server, query_minutes=MIGRATION_QUERY_
         migrations = sorted(migrations, key=_migration_sort_key, reverse=True)
         migration = migrations[0]
         status = getattr(migration, 'status', None) or getattr(migration, '_info', {}).get('status')
+        created_at = getattr(migration, 'created_at', None)
 
         return EvacuationStatus(
             completed=status in MIGRATION_STATUS_COMPLETED if status else False,
-            error=status in MIGRATION_STATUS_ERROR if status else True
+            error=status in MIGRATION_STATUS_ERROR if status else True,
+            created_at=created_at,
         )
 
     except Exception as e:
@@ -2031,7 +2039,8 @@ def _monitor_evacuation(connection, server_id, response_uuid, start_time,
 def _server_evacuate_future(connection, server, target_host=None,
                             max_retries=DEFAULT_EVACUATION_RETRIES,
                             shutdown_event=None,
-                            evacuation_timeout=MAX_EVACUATION_TIMEOUT_SECONDS) -> bool:
+                            evacuation_timeout=MAX_EVACUATION_TIMEOUT_SECONDS,
+                            resume=False) -> bool:
     """Evacuate a server and monitor until completion."""
     if not hasattr(server, 'id'):
         logging.warning("Could not evacuate instance - missing server ID: %s",
@@ -2052,6 +2061,73 @@ def _server_evacuate_future(connection, server, target_host=None,
         logging.warning("Could not lock server %s (may already be locked)", server.id)
 
     try:
+        if resume:
+            mig_status = _server_evacuation_status(connection, server.id,
+                                                   query_minutes=RESUME_MIGRATION_QUERY_MINUTES)
+
+            if mig_status.completed:
+                logging.info("Server %s already evacuated (migration completed), skipping",
+                             server.id)
+                INSTANCE_EVACUATION_TOTAL.labels(host=source_host, result='succeeded').inc()
+                return True
+
+            if not mig_status.error:
+                # Compute elapsed time from when the migration actually started,
+                # not from when this pod started, so the timeout reflects real
+                # migration age and a crash-loop can't grant infinite extensions.
+                resume_start = start_time
+                if mig_status.created_at:
+                    try:
+                        created_dt = datetime.fromisoformat(
+                            str(mig_status.created_at).replace('Z', '+00:00'))
+                        elapsed = (datetime.now(timezone.utc) - created_dt).total_seconds()
+                        resume_start = time.monotonic() - elapsed
+                    except (ValueError, TypeError):
+                        pass
+
+                logging.info("Server %s has in-progress evacuation, monitoring existing migration",
+                             server.id)
+                _emit_k8s_event(source_host, 'InstanceEvacuationResumed',
+                                f'Resuming monitoring of in-progress evacuation for {server.id}')
+                INSTANCE_EVACUATION_TOTAL.labels(host=source_host, result='started').inc()
+
+                result = _monitor_evacuation(
+                    connection, server.id, server.id, resume_start,
+                    max_retries=max_retries,
+                    shutdown_event=shutdown_event,
+                    evacuation_timeout=evacuation_timeout)
+
+                if result:
+                    _emit_k8s_event(source_host, 'InstanceEvacuationSucceeded',
+                                    f'Instance {server.id} evacuated successfully (resumed)')
+                    INSTANCE_EVACUATION_TOTAL.labels(host=source_host, result='succeeded').inc()
+                    INSTANCE_EVACUATION_DURATION.labels(host=source_host).observe(
+                        time.monotonic() - start_time)
+                    if original_status in ('SHUTOFF', 'ERROR'):
+                        current = connection.servers.get(server.id)
+                        current_status = getattr(current, 'status', None)
+                        if current_status != original_status:
+                            try:
+                                if original_status == 'SHUTOFF':
+                                    connection.servers.stop(server.id)
+                                else:
+                                    connection.servers.reset_state(server.id, 'error')
+                                logging.info("Restored server %s to %s state",
+                                             server.id, original_status)
+                            except Exception as e:
+                                logging.warning("Failed to restore %s state for %s: %s",
+                                                original_status, server.id, e)
+                else:
+                    _emit_k8s_event(source_host, 'InstanceEvacuationFailed',
+                                    f'Instance {server.id} evacuation failed (resumed)',
+                                    event_type='Warning')
+                    INSTANCE_EVACUATION_TOTAL.labels(host=source_host, result='failed').inc()
+
+                return result
+
+            logging.info("Server %s has no recent successful migration, will re-evacuate",
+                         server.id)
+
         _emit_k8s_event(source_host, 'InstanceEvacuationStarted',
                         f'Evacuating instance {server.id}')
         INSTANCE_EVACUATION_TOTAL.labels(host=source_host, result='started').inc()
@@ -3003,7 +3079,8 @@ def process_service(failed_service, reserved_hosts, resume, service) -> bool:
             if evac_target:
                 logging.info("Forcing evacuation to reserved host: %s", evac_target)
             if not _execute_step("Evacuation", _host_evacuate, host_name,
-                                conn, failed_service, service, evac_target):
+                                conn, failed_service, service, evac_target,
+                                resume=resume):
                 _emit_k8s_event(host_name, 'EvacuationFailed',
                                 'VM evacuation failed', event_type='Warning')
                 EVACUATION_TOTAL.labels(host=host_name, result='failed').inc()

--- a/test/instanceha/test_orchestrated_evacuation.py
+++ b/test/instanceha/test_orchestrated_evacuation.py
@@ -333,7 +333,8 @@ class TestOrchestratedEvacuate(unittest.TestCase):
         mock_future.assert_called_once_with(conn, server, 'reserved-01',
                                                    max_retries=5,
                                                    shutdown_event=service.shutdown_event,
-                                                   evacuation_timeout=300)
+                                                   evacuation_timeout=300,
+                                                   resume=False)
 
     @patch('instanceha._update_service_disable_reason')
     @patch('instanceha._server_evacuate_future')

--- a/test/instanceha/test_unit_core.py
+++ b/test/instanceha/test_unit_core.py
@@ -3789,6 +3789,255 @@ class TestMainFunction(unittest.TestCase):
             mock_init.assert_called_once_with(mock_cm)
 
 
+class TestResumeSafeEvacuation(unittest.TestCase):
+    """Test resume-safe evacuation after pod restart."""
+
+    def setUp(self):
+        self.mock_connection = Mock()
+        self.mock_service = Mock()
+
+    def test_get_evacuable_servers_includes_rebuild_on_resume(self):
+        """REBUILD servers are included when resume=True, excluded otherwise."""
+        active = Mock(status='ACTIVE', name='vm-1', id='s-1')
+        rebuild = Mock(status='REBUILD', name='vm-2', id='s-2')
+        self.mock_connection.servers.list.return_value = [active, rebuild]
+        self.mock_service.get_evacuable_images.return_value = []
+        self.mock_service.get_evacuable_flavors.return_value = []
+        self.mock_service.config.get_config_value.side_effect = lambda k: {
+            'SKIP_SERVERS_WITH_NAME': [],
+        }.get(k, False)
+
+        without_resume = instanceha._get_evacuable_servers(
+            self.mock_connection, 'host', self.mock_service)
+        self.assertEqual(len(without_resume), 1)
+        self.assertEqual(without_resume[0].id, 's-1')
+
+        with_resume = instanceha._get_evacuable_servers(
+            self.mock_connection, 'host', self.mock_service, resume=True)
+        self.assertEqual(len(with_resume), 2)
+
+    @patch('instanceha._emit_k8s_event')
+    @patch('instanceha._server_evacuation_status')
+    def test_resume_skips_completed_migration(self, mock_status, mock_event):
+        """Server with completed migration returns True without calling evacuate."""
+        server = Mock(id='s-1', status='ACTIVE')
+        server.name = 'vm-1'
+        setattr(server, 'OS-EXT-SRV-ATTR:host', 'src-host')
+        mock_status.return_value = instanceha.EvacuationStatus(completed=True, error=False)
+
+        result = instanceha._server_evacuate_future(
+            self.mock_connection, server, resume=True)
+
+        self.assertTrue(result)
+        self.mock_connection.servers.evacuate.assert_not_called()
+
+    @patch('instanceha._emit_k8s_event')
+    @patch('instanceha._monitor_evacuation')
+    @patch('instanceha._server_evacuation_status')
+    def test_resume_monitors_in_progress_migration(self, mock_status, mock_monitor, mock_event):
+        """Server with in-progress migration calls monitor, not evacuate."""
+        server = Mock(id='s-1', status='ACTIVE')
+        server.name = 'vm-1'
+        setattr(server, 'OS-EXT-SRV-ATTR:host', 'src-host')
+        mock_status.return_value = instanceha.EvacuationStatus(completed=False, error=False)
+        mock_monitor.return_value = True
+
+        result = instanceha._server_evacuate_future(
+            self.mock_connection, server, resume=True)
+
+        self.assertTrue(result)
+        mock_monitor.assert_called_once()
+        self.mock_connection.servers.evacuate.assert_not_called()
+
+    @patch('instanceha._emit_k8s_event')
+    @patch('instanceha._monitor_evacuation')
+    @patch('instanceha._server_evacuate')
+    @patch('instanceha._server_evacuation_status')
+    def test_resume_re_evacuates_on_error(self, mock_status, mock_evacuate, mock_monitor, mock_event):
+        """Server with errored migration falls through to normal evacuate path."""
+        server = Mock(id='s-1', status='ACTIVE')
+        server.name = 'vm-1'
+        setattr(server, 'OS-EXT-SRV-ATTR:host', 'src-host')
+        setattr(server, 'OS-EXT-STS:task_state', None)
+        mock_status.return_value = instanceha.EvacuationStatus(completed=False, error=True)
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.reason = 'OK'
+        mock_response.accepted = True
+        mock_response.uuid = 's-1'
+        mock_response.request_id = 'req-1'
+        mock_evacuate.return_value = mock_response
+        mock_monitor.return_value = True
+
+        result = instanceha._server_evacuate_future(
+            self.mock_connection, server, resume=True)
+
+        self.assertTrue(result)
+        mock_evacuate.assert_called_once()
+
+    @patch('instanceha._emit_k8s_event')
+    @patch('instanceha._monitor_evacuation')
+    @patch('instanceha._server_evacuation_status')
+    def test_resume_restores_shutoff_state(self, mock_status, mock_monitor, mock_event):
+        """Resumed in-progress evacuation restores SHUTOFF state on success."""
+        server = Mock(id='s-1', status='SHUTOFF')
+        server.name = 'vm-1'
+        setattr(server, 'OS-EXT-SRV-ATTR:host', 'src-host')
+        mock_status.return_value = instanceha.EvacuationStatus(completed=False, error=False)
+        mock_monitor.return_value = True
+        current_server = Mock(status='ACTIVE')
+        self.mock_connection.servers.get.return_value = current_server
+
+        result = instanceha._server_evacuate_future(
+            self.mock_connection, server, resume=True)
+
+        self.assertTrue(result)
+        self.mock_connection.servers.stop.assert_called_once_with('s-1')
+
+    @patch('instanceha._emit_k8s_event')
+    @patch('instanceha._monitor_evacuation')
+    @patch('instanceha._server_evacuation_status')
+    def test_resume_restores_error_state(self, mock_status, mock_monitor, mock_event):
+        """Resumed in-progress evacuation restores ERROR state on success."""
+        server = Mock(id='s-1', status='ERROR')
+        server.name = 'vm-1'
+        setattr(server, 'OS-EXT-SRV-ATTR:host', 'src-host')
+        mock_status.return_value = instanceha.EvacuationStatus(completed=False, error=False)
+        mock_monitor.return_value = True
+        current_server = Mock(status='ACTIVE')
+        self.mock_connection.servers.get.return_value = current_server
+
+        result = instanceha._server_evacuate_future(
+            self.mock_connection, server, resume=True)
+
+        self.assertTrue(result)
+        self.mock_connection.servers.reset_state.assert_called_with('s-1', 'error')
+
+    @patch('instanceha._emit_k8s_event')
+    @patch('instanceha._monitor_evacuation')
+    @patch('instanceha._server_evacuation_status')
+    def test_resume_in_progress_monitor_fails(self, mock_status, mock_monitor, mock_event):
+        """Resumed in-progress evacuation returns False when monitor fails."""
+        server = Mock(id='s-1', status='ACTIVE')
+        server.name = 'vm-1'
+        setattr(server, 'OS-EXT-SRV-ATTR:host', 'src-host')
+        mock_status.return_value = instanceha.EvacuationStatus(completed=False, error=False)
+        mock_monitor.return_value = False
+
+        result = instanceha._server_evacuate_future(
+            self.mock_connection, server, resume=True)
+
+        self.assertFalse(result)
+        mock_monitor.assert_called_once()
+        self.mock_connection.servers.evacuate.assert_not_called()
+
+    @patch('instanceha._emit_k8s_event')
+    @patch('instanceha._server_evacuate')
+    @patch('instanceha._server_evacuation_status')
+    def test_non_resume_skips_migration_check(self, mock_status, mock_evacuate, mock_event):
+        """Without resume=True, migration status is never checked."""
+        server = Mock(id='s-1', status='ACTIVE')
+        server.name = 'vm-1'
+        setattr(server, 'OS-EXT-SRV-ATTR:host', 'src-host')
+        setattr(server, 'OS-EXT-STS:task_state', None)
+
+        mock_response = Mock(accepted=True, uuid='s-1', request_id='req-1',
+                             status_code=200, reason='OK')
+        mock_evacuate.return_value = mock_response
+
+        with patch('instanceha._monitor_evacuation', return_value=True):
+            instanceha._server_evacuate_future(
+                self.mock_connection, server, resume=False)
+
+        mock_status.assert_not_called()
+        mock_evacuate.assert_called_once()
+
+    @patch('instanceha._interruptible_sleep')
+    @patch('instanceha._concurrent_evacuate')
+    def test_host_evacuate_passes_resume_through(self, mock_concurrent, mock_sleep):
+        """_host_evacuate passes resume flag to _concurrent_evacuate."""
+        failed_service = Mock(host='test-host', id='svc-1')
+        service = Mock()
+        service.config.get_config_value.side_effect = lambda k: {
+            'SKIP_SERVERS_WITH_NAME': [], 'SMART_EVACUATION': True,
+            'DELAY': 0, 'ORCHESTRATED_RESTART': False,
+        }.get(k, False)
+        service.get_evacuable_images.return_value = []
+        service.get_evacuable_flavors.return_value = []
+        server = Mock(id='s-1', status='ACTIVE', name='vm-1')
+        self.mock_connection.servers.list.return_value = [server]
+        mock_concurrent.return_value = True
+
+        instanceha._host_evacuate(self.mock_connection, failed_service, service,
+                                  resume=True)
+
+        mock_concurrent.assert_called_once()
+        _, kwargs = mock_concurrent.call_args
+        self.assertTrue(kwargs.get('resume'))
+
+    @patch('instanceha._emit_k8s_event')
+    @patch('instanceha._monitor_evacuation')
+    @patch('instanceha._server_evacuation_status')
+    def test_resume_rebuild_server_with_in_progress_migration(self, mock_status, mock_monitor, mock_event):
+        """REBUILD server on resume with in-progress migration is monitored, not re-evacuated."""
+        server = Mock(id='s-1', status='REBUILD')
+        server.name = 'vm-1'
+        setattr(server, 'OS-EXT-SRV-ATTR:host', 'src-host')
+        mock_status.return_value = instanceha.EvacuationStatus(completed=False, error=False)
+        mock_monitor.return_value = True
+
+        result = instanceha._server_evacuate_future(
+            self.mock_connection, server, resume=True)
+
+        self.assertTrue(result)
+        mock_monitor.assert_called_once()
+        self.mock_connection.servers.evacuate.assert_not_called()
+
+    @patch('instanceha._emit_k8s_event')
+    @patch('instanceha._monitor_evacuation')
+    @patch('instanceha._server_evacuation_status')
+    def test_resume_uses_wide_query_window(self, mock_status, mock_monitor, mock_event):
+        """Resume path uses RESUME_MIGRATION_QUERY_MINUTES, not timeout-bounded window."""
+        server = Mock(id='s-1', status='ACTIVE')
+        server.name = 'vm-1'
+        setattr(server, 'OS-EXT-SRV-ATTR:host', 'src-host')
+        mock_status.return_value = instanceha.EvacuationStatus(completed=True, error=False)
+
+        instanceha._server_evacuate_future(
+            self.mock_connection, server, resume=True)
+
+        mock_status.assert_called_once_with(
+            self.mock_connection, 's-1',
+            query_minutes=instanceha.RESUME_MIGRATION_QUERY_MINUTES)
+
+    @patch('instanceha._emit_k8s_event')
+    @patch('instanceha._monitor_evacuation')
+    @patch('instanceha._server_evacuation_status')
+    def test_resume_uses_migration_created_at_for_timeout(self, mock_status, mock_monitor, mock_event):
+        """Resume computes elapsed time from migration created_at, not pod start time."""
+        server = Mock(id='s-1', status='ACTIVE')
+        server.name = 'vm-1'
+        setattr(server, 'OS-EXT-SRV-ATTR:host', 'src-host')
+        # Migration started 120 seconds ago
+        from datetime import datetime, timezone, timedelta
+        created = (datetime.now(timezone.utc) - timedelta(seconds=120)).isoformat()
+        mock_status.return_value = instanceha.EvacuationStatus(
+            completed=False, error=False, created_at=created)
+        mock_monitor.return_value = True
+
+        instanceha._server_evacuate_future(
+            self.mock_connection, server, resume=True, evacuation_timeout=300)
+
+        # _monitor_evacuation should have been called with a start_time
+        # that reflects ~120s elapsed, not 0s
+        call_args = mock_monitor.call_args
+        resume_start = call_args[0][3]  # 4th positional arg is start_time
+        elapsed = time.monotonic() - resume_start
+        self.assertGreater(elapsed, 100, "start_time should reflect migration age (~120s)")
+        self.assertLess(elapsed, 150, "start_time should not overshoot")
+
+
 if __name__ == '__main__':
     # Create test suite
     test_suite = unittest.TestSuite()
@@ -3809,6 +4058,7 @@ if __name__ == '__main__':
         TestFunctionalIntegration,
         TestAdvancedIntegration,
         TestMainFunction,
+        TestResumeSafeEvacuation,
     ]
 
     for test_class in test_classes:


### PR DESCRIPTION
When the InstanceHA pod is killed mid-evacuation (e.g. by a liveness probe failure), on restart the resume path blindly re-evacuated all servers, disrupting in-progress migrations by resetting task_state. This change makes the resume path migration-aware: it checks each server's migration status before acting, monitors in-progress migrations, skips completed ones, and only re-evacuates when the migration errored or doesn't exist. Also includes REBUILD status servers in the evacuable list on resume so mid-evacuation VMs are not silently dropped.