### PR TITLE
Add Explicit Private Key Stanzas for Metrics and Webhook Services Configured with Cert Manager

### DIFF
--- a/config/certmanager/certificate-metrics.yaml
+++ b/config/certmanager/certificate-metrics.yaml
@@ -21,4 +21,3 @@ spec:
   privateKey:
     algorithm: ECDSA
     size: 384
-

--- a/config/certmanager/certificate-metrics.yaml
+++ b/config/certmanager/certificate-metrics.yaml
@@ -18,3 +18,7 @@ spec:
     kind: Issuer
     name: selfsigned-issuer
   secretName: metrics-server-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 384
+

--- a/config/certmanager/certificate-webhook.yaml
+++ b/config/certmanager/certificate-webhook.yaml
@@ -21,4 +21,3 @@ spec:
   privateKey:
     algorithm: ECDSA
     size: 384
-

--- a/config/certmanager/certificate-webhook.yaml
+++ b/config/certmanager/certificate-webhook.yaml
@@ -18,3 +18,7 @@ spec:
     kind: Issuer
     name: selfsigned-issuer
   secretName: webhook-server-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 384
+


### PR DESCRIPTION
Previously, we did not specify the parameters of the private keys that would generated for the Metrics and Webhook services in the Infra Operator, relying instead on whatever the defaults might be.

As we move towards enabling post-quantum safety in our operators, we are starting by explicitly stating what the private key algorithm and key size shall be. This is to ensure that the keys are exactly what we want them to be and to provide an easy-to-configure place to change the algorithm and key size should the need arise (such as when quantum safe algorithms become available to use for generating private keys.)