### PR TITLE
Add Redis/Valkey compatibility to redis templates

### DIFF
--- a/internal/redis/volumes.go
+++ b/internal/redis/volumes.go
@@ -46,6 +46,12 @@ func getVolumes(r *redisv1.Redis) []corev1.Volume {
 			},
 		},
 		{
+			Name: "redis-data",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
 			Name: "config-data",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -140,6 +146,9 @@ func getRedisVolumeMounts(r *redisv1.Redis) []corev1.VolumeMount {
 		MountPath: "/var/lib/operator-scripts",
 		ReadOnly:  true,
 		Name:      "operator-scripts",
+	}, {
+		MountPath: "/var/lib/redis",
+		Name:      "redis-data",
 	}}
 	vm = append(vm, getTLSVolumeMounts(r)...)
 	return vm
@@ -157,6 +166,9 @@ func getSentinelVolumeMounts(r *redisv1.Redis) []corev1.VolumeMount {
 		MountPath: "/var/lib/operator-scripts",
 		ReadOnly:  true,
 		Name:      "operator-scripts",
+	}, {
+		MountPath: "/var/lib/redis",
+		Name:      "redis-data",
 	}}
 	vm = append(vm, getTLSVolumeMounts(r)...)
 	return vm

--- a/templates/redis/bin/common.sh
+++ b/templates/redis/bin/common.sh
@@ -13,15 +13,38 @@ POD_FQDN=$HOSTNAME.$SVC_FQDN
 # Extract pod IP from /etc/hosts
 POD_IP=$(grep "$HOSTNAME" /etc/hosts | awk '{print $1}' | head -1)
 
+# Detect complete Redis or Valkey binary set
+if command -v redis-cli >/dev/null 2>&1 && \
+   command -v redis-server >/dev/null 2>&1 && \
+   command -v redis-sentinel >/dev/null 2>&1; then
+    CLI_BIN="redis-cli"
+    SERVER_BIN="redis-server"
+    SENTINEL_BIN="redis-sentinel"
+elif command -v valkey-cli >/dev/null 2>&1 && \
+     command -v valkey-server >/dev/null 2>&1 && \
+     command -v valkey-sentinel >/dev/null 2>&1; then
+    CLI_BIN="valkey-cli"
+    SERVER_BIN="valkey-server"
+    SENTINEL_BIN="valkey-sentinel"
+else
+    echo "ERROR: Neither complete Redis nor Valkey binary set found in PATH"
+    exit 1
+fi
+
 if test -d /var/lib/config-data/tls; then
-    REDIS_CLI_CMD="redis-cli --tls"
+    echo "INFO: TLS mode enabled - using TLS configs"
+    REDIS_CLI_CMD="$CLI_BIN --tls"
     REDIS_CONFIG=/var/lib/config-data/generated/var/lib/redis/redis-tls.conf
     SENTINEL_CONFIG=/var/lib/config-data/generated/var/lib/redis/sentinel-tls.conf
 else
-    REDIS_CLI_CMD=redis-cli
+    echo "INFO: TLS mode disabled - using plain configs"
+    REDIS_CLI_CMD=$CLI_BIN
     REDIS_CONFIG=/var/lib/config-data/generated/var/lib/redis/redis.conf
     SENTINEL_CONFIG=/var/lib/config-data/generated/var/lib/redis/sentinel.conf
 fi
+
+echo "INFO: Using binary: $SERVER_BIN"
+echo "INFO: Config path: $REDIS_CONFIG"
 
 function log() {
     echo "$(date +%F_%H_%M_%S) $*"
@@ -32,14 +55,76 @@ function log_error() {
 }
 
 function generate_configs() {
-    # Copying config files except template files
-    tar -C /var/lib/config-data --exclude '..*' --exclude '*.in' -h -c default | tar -C /var/lib/config-data/generated -x --strip=1
-    # Generating config files from templates
-    cd /var/lib/config-data/default
-    for cfg in $(find -L * -name '*.conf.in'); do
-        log "Generating config file from template $PWD/${cfg}"
-        sed -e "s/{ POD_FQDN }/${POD_FQDN}/g" -e "s/{ POD_IP }/${POD_IP}/g" "${cfg}" > "/var/lib/config-data/generated/${cfg%.in}"
-    done
+    local tmplist
+    local ret=0
+
+    # Create the target directory structure upfront
+    mkdir -p /var/lib/config-data/generated/var/lib/redis || {
+        log_error "Failed to create /var/lib/config-data/generated/var/lib/redis"
+        return 1
+    }
+
+    # Change to source directory
+    cd /var/lib/config-data/default || {
+        log_error "Failed to change directory to /var/lib/config-data/default"
+        return 1
+    }
+
+    # Create temporary file for file lists
+    tmplist=$(mktemp) || {
+        log_error "Failed to create temporary file"
+        return 1
+    }
+
+    # Find all files to copy (except hidden files and templates)
+    # Exclude Kubernetes ConfigMap internal directories (..data, ..YYYY_MM_DD_*)
+    if ! find . \( -type f -o -type l \) ! -path './\.\.*' ! -name '.*' ! -name '*.in' -print0 > "$tmplist"; then
+        log_error "Failed to find configuration files"
+        rm -f "$tmplist"
+        return 1
+    fi
+
+    # Copy each file with error checking
+    while IFS= read -r -d '' file; do
+        dest_dir="/var/lib/config-data/generated/$(dirname "$file")"
+        if ! mkdir -p "$dest_dir"; then
+            log_error "Failed to create directory $dest_dir"
+            ret=1
+            break
+        fi
+        if ! cp -rfL "$file" "/var/lib/config-data/generated/$file"; then
+            log_error "Failed to copy $file"
+            ret=1
+            break
+        fi
+    done < "$tmplist"
+
+    if [ $ret -ne 0 ]; then
+        rm -f "$tmplist"
+        return 1
+    fi
+
+    # Find template files
+    # Exclude Kubernetes ConfigMap internal directories (..data, ..YYYY_MM_DD_*)
+    if ! find -L . ! -path './\.\.*' -name '*.conf.in' -print0 > "$tmplist"; then
+        log_error "Failed to find template files"
+        rm -f "$tmplist"
+        return 1
+    fi
+
+    # Process each template with error checking
+    while IFS= read -r -d '' cfg; do
+        log "Generating config file from template ${cfg}"
+        output_file="/var/lib/config-data/generated/${cfg%.in}"
+        if ! sed -e "s/{ POD_FQDN }/${POD_FQDN}/g" -e "s/{ POD_IP }/${POD_IP}/g" "${cfg}" > "$output_file"; then
+            log_error "Failed to generate config from template ${cfg}"
+            ret=1
+            break
+        fi
+    done < "$tmplist"
+
+    rm -f "$tmplist"
+    return $ret
 }
 
 function is_bootstrap_pod() {

--- a/templates/redis/bin/start_redis_replication.sh
+++ b/templates/redis/bin/start_redis_replication.sh
@@ -2,7 +2,10 @@
 
 . /var/lib/operator-scripts/common.sh
 
-generate_configs
+if ! generate_configs; then
+    echo "ERROR: Configuration generation failed"
+    exit 1
+fi
 
 # 1. check if a redis cluster is already running by contacting sentinel
 output=$(timeout ${TIMEOUT} $REDIS_CLI_CMD -h ${SVC_FQDN} -p 26379 sentinel master redis)
@@ -10,14 +13,14 @@ if [ $? -eq 0 ]; then
     master=$(echo "$output" | awk '/^ip$/ {getline; print $0; exit}')
     # TODO skip if no master was found
     log "Connecting to the existing Redis cluster (master: ${master})"
-    exec redis-server $REDIS_CONFIG --protected-mode no --replicaof "$master" 6379
+    exec $SERVER_BIN $REDIS_CONFIG --protected-mode no --replicaof "$master" 6379
 fi
 
 # 2. else bootstrap a new cluster (assume we should be the first redis pod)
 if is_bootstrap_pod $POD_NAME; then
     log "Bootstrapping a new Redis cluster from ${POD_NAME}"
     set_pod_label $POD_NAME redis~1master
-    exec redis-server $REDIS_CONFIG --protected-mode no
+    exec $SERVER_BIN $REDIS_CONFIG --protected-mode no
 fi
 
 # 3. else this is an error, exit and let the pod restart and try again

--- a/templates/redis/bin/start_sentinel.sh
+++ b/templates/redis/bin/start_sentinel.sh
@@ -2,7 +2,10 @@
 
 . /var/lib/operator-scripts/common.sh
 
-generate_configs
+if ! generate_configs; then
+    echo "ERROR: Configuration generation failed"
+    exit 1
+fi
 
 # 1. check if a redis cluster is already running by contacting sentinel
 output=$(timeout ${TIMEOUT} $REDIS_CLI_CMD -h ${SVC_FQDN} -p 26379 sentinel master redis)
@@ -11,7 +14,7 @@ if [ $? -eq 0 ]; then
     # TODO skip if no master was found
     log "Connecting to the existing sentinel cluster (master: $master)"
     echo "sentinel monitor redis ${master} 6379 ${SENTINEL_QUORUM}" >> $SENTINEL_CONFIG
-    exec redis-sentinel $SENTINEL_CONFIG
+    exec $SENTINEL_BIN $SENTINEL_CONFIG
 fi
 
 # 2. else let the pod's redis server bootstrap a new cluster and monitor it
@@ -19,7 +22,7 @@ fi
 if is_bootstrap_pod $POD_NAME; then
     log "Bootstrapping a new sentinel cluster"
     echo "sentinel monitor redis ${POD_FQDN} 6379 ${SENTINEL_QUORUM}" >> $SENTINEL_CONFIG
-    exec redis-sentinel $SENTINEL_CONFIG
+    exec $SENTINEL_BIN $SENTINEL_CONFIG
 fi
 
 # 3. else this is an error, exit and let the pod restart and try again


### PR DESCRIPTION
This change makes the redis operator templates compatible with both Redis and Valkey container images without requiring operator code changes.

Changes:
- Remove tar dependency from config generation, replacing it with find + cp for better portability
- Auto-detect redis-cli/redis-server or valkey-cli/valkey-server binaries at runtime and use the appropriate commands
- Update startup scripts to use detected binary variables instead of hardcoded redis-server/redis-sentinel commands
- Change data directory from /var/lib/redis to /var/lib/config-data/generated to use the writable EmptyDir volume (valkey user lacks permissions for /var/lib/redis)

The operator continues to work with existing Redis images while also supporting Valkey as a drop-in replacement.